### PR TITLE
Fix #42: RoqObjectMapperBuildItem

### DIFF
--- a/common/deployment/pom.xml
+++ b/common/deployment/pom.xml
@@ -15,6 +15,10 @@
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-deployment</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.roq</groupId>
             <artifactId>quarkus-roq-common</artifactId>
             <version>${project.version}</version>

--- a/common/deployment/src/main/java/io/quarkiverse/roq/deployment/RoqProjectProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/roq/deployment/RoqProjectProcessor.java
@@ -7,7 +7,14 @@ import java.nio.file.Paths;
 
 import org.jboss.logging.Logger;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
 import io.quarkiverse.roq.deployment.config.RoqConfig;
+import io.quarkiverse.roq.deployment.config.RoqJacksonConfig;
+import io.quarkiverse.roq.deployment.items.RoqObjectMapperBuildItem;
 import io.quarkiverse.roq.deployment.items.RoqProjectBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
@@ -35,6 +42,23 @@ public class RoqProjectProcessor {
             LOG.warn("Not Roq site directory found. It is recommended to remove the quarkus-roq extension if not used.");
         }
         return roqProject;
+    }
+
+    @BuildStep
+    RoqObjectMapperBuildItem findProject(RoqJacksonConfig jacksonConfig) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        if (!jacksonConfig.failOnUnknownProperties()) {
+            // this feature is enabled by default, so we disable it
+            objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        }
+        if (!jacksonConfig.failOnEmptyBeans()) {
+            // this feature is enabled by default, so we disable it
+            objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        }
+        if (jacksonConfig.acceptCaseInsensitiveEnums()) {
+            objectMapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+        }
+        return new RoqObjectMapperBuildItem(objectMapper);
     }
 
     /**

--- a/common/deployment/src/main/java/io/quarkiverse/roq/deployment/config/RoqJacksonConfig.java
+++ b/common/deployment/src/main/java/io/quarkiverse/roq/deployment/config/RoqJacksonConfig.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.roq.deployment.config;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.roq.jackson")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface RoqJacksonConfig {
+
+    /**
+     * If enabled, Jackson will fail when encountering unknown properties.
+     * <p>
+     * You can still override it locally with {@code @JsonIgnoreProperties(ignoreUnknown = false)}.
+     */
+    @WithDefault("false")
+    boolean failOnUnknownProperties();
+
+    /**
+     * If enabled, Jackson will fail when no accessors are found for a type.
+     * This is enabled by default to match the default Jackson behavior.
+     */
+    @WithDefault("true")
+    boolean failOnEmptyBeans();
+
+    /**
+     * If enabled, Jackson will ignore case during Enum deserialization.
+     */
+    @WithDefault("false")
+    boolean acceptCaseInsensitiveEnums();
+
+}

--- a/common/deployment/src/main/java/io/quarkiverse/roq/deployment/items/RoqObjectMapperBuildItem.java
+++ b/common/deployment/src/main/java/io/quarkiverse/roq/deployment/items/RoqObjectMapperBuildItem.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.roq.deployment.items;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class RoqObjectMapperBuildItem extends SimpleBuildItem {
+
+    private final ObjectMapper objectMapper;
+
+    public RoqObjectMapperBuildItem(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+}

--- a/roq-data/deployment/pom.xml
+++ b/roq-data/deployment/pom.xml
@@ -20,6 +20,10 @@
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-deployment</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.roq</groupId>
             <artifactId>quarkus-roq-common-deployment</artifactId>
             <version>${project.version}</version>

--- a/roq-data/runtime/pom.xml
+++ b/roq-data/runtime/pom.xml
@@ -19,6 +19,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.vertx</groupId>

--- a/roq-generator/deployment/pom.xml
+++ b/roq-generator/deployment/pom.xml
@@ -16,6 +16,10 @@
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-deployment</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.roq</groupId>
             <artifactId>quarkus-roq-generator</artifactId>
             <version>${project.version}</version>

--- a/roq-generator/runtime/pom.xml
+++ b/roq-generator/runtime/pom.xml
@@ -17,6 +17,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fix #42: RoqObjectMapperBuildItem

I am not sure I got this right and its definitely not as full featured as the Jackson module.

Should I just use the quarkus jackson config item instead of creating my own?