### PR TITLE
Fix #99: Link defensive null check

### DIFF
--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/Link.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/Link.java
@@ -54,6 +54,9 @@ public class Link {
 
     // Slugify logic to make the title URL-friendly
     private static String slugify(String input) {
+        if (input == null) {
+            throw new IllegalArgumentException("Link input cannot be null");
+        }
         return input.toLowerCase()
                 .replaceAll("[^a-z0-9\\-]", "-") // Replace non-alphanumeric characters with hyphens
                 .replaceAll("-+", "-") // Replace multiple hyphens with a single one

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterScanProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterScanProcessor.java
@@ -35,7 +35,7 @@ import io.vertx.core.json.JsonObject;
 public class RoqFrontMatterScanProcessor {
     private static final Logger LOGGER = org.jboss.logging.Logger.getLogger(RoqFrontMatterScanProcessor.class);
     private static final Set<String> SUPPORTED_EXTENSIONS = Set.of(".md", "markdown", ".html", ".asciidoc", ".adoc");
-    public static final Pattern FRONTMATTER_PATTERN = Pattern.compile("^---\\n.*\\n---\\n", Pattern.DOTALL);
+    public static final Pattern FRONTMATTER_PATTERN = Pattern.compile("^---\\v.*\\v---\\v", Pattern.DOTALL);
 
     private record QuteMarkupSection(String open, String close) {
         public static final QuteMarkupSection MARKDOWN = new QuteMarkupSection("{#markdown}", "{/markdown}");


### PR DESCRIPTION
Fix #99: Link defensive null check

This gets past the NPE but now I get this..

```
ERROR] Failed to execute goal io.quarkus.platform:quarkus-maven-plugin:3.14.4:build (default) on project roq-blog: Failed to build quarkus application: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
[ERROR]         [error]: Build step io.quarkus.arc.deployment.SyntheticBeansProcessor#initStatic threw an exception: java.lang.IllegalStateException: A synthetic bean with identifier I8e6VDWFfp-mJuk3LsVFwebeYF0 is already registered: SYNTHETIC bean [types=[io.quarkiverse.roq.frontmatter.runtime.Page, java.lang.Object], qualifiers=[@Default, @Any, @Named("/")], target=n/a]
[ERROR]         at io.quarkus.arc.processor.BeanDeployment.addSyntheticBean(BeanDeployment.java:1511)
[ERROR]         at io.quarkus.arc.processor.BeanDeployment$BeanRegistrationContextImpl.accept(BeanDeployment.java:1866)
[ERROR]         at io.quarkus.arc.processor.BeanDeployment$BeanRegistrationContextImpl.accept(BeanDeployment.java:1835)
[ERROR]         at io.quarkus.arc.processor.BeanConfigurator.done(BeanConfigurator.java:114)
[ERROR]         at io.quarkus.arc.deployment.SyntheticBeansProcessor.configureSyntheticBean(SyntheticBeansProcessor.java:92)
[ERROR]         at io.quarkus.arc.deployment.SyntheticBeansProcessor.initStatic(SyntheticBeansProcessor.java:39)
[ERROR]         at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
[ERROR]         at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:856)
[ERROR]         at io.quarkus.builder.BuildContext.run(BuildContext.java:256)
[ERROR]         at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2516)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2495)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1521)
[ERROR]         at java.base/java.lang.Thread.run(Thread.java:1583)
[ERROR]         at org.jboss.threads.JBossThread.run(JBossThread.java:483)
```