### PR TITLE
Fix #80: SEO tag for Qute

### DIFF
--- a/blog/site/_includes/head.html
+++ b/blog/site/_includes/head.html
@@ -1,40 +1,12 @@
 <head>
   <meta charset="utf-8">
-  <title>
-    {#if page.title ne site.title}{page.title} - {site.title}{#else}{site.title}{/if}
-  </title>
+
+  {#seo page site /}
 
   <!-- Edit site and author settings in `_config.yml` to make the social details your own -->
   <base href="{site.rootUrl.relative}">
-  <meta content="{site.title}" property="og:site_name">
-
-
-  <meta name="twitter:card" content="summary">
-  {#if page.title}
-  <meta name="twitter:title" content="{page.title}">
-  {#else}
-  <meta name="twitter:title" content="{site.title}">
-  {/if}
-  {#if page.url}
-  <meta name="twitter:url" content="{site.url.absolute}">
-  {/if}
-  {#if page.description}
-  <meta name="twitter:description" content="{page.description}">
-  {#else}
-  <meta name="twitter:description" content="{site.description}">
-  {/if}
-  {#if page.img}
-  <meta name="twitter:image:src" content="{site.rootUrl.absolute.resolve('assets/img/').resolve(page.img)}">
-  {/if}
-
-  {#if page.description}
-  <meta name="description" content="{page.description}">
-  {#else}
-  <meta name="description" content="{site.description}">
-  {/if}
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <meta property="og:image" content="">
   <link rel="shortcut icon" href="{site.rootUrl.absolute.resolve('/static/assets/img/favicon/favicon.ico')}" type="image/x-icon">
   <link rel="apple-touch-icon" href="{site.rootUrl.absolute.resolve('assets/img/favicon/apple-touch-icon.png')}">
   <link rel="apple-touch-icon" sizes="72x72" href="{site.rootUrl.absolute.resolve('assets/img/favicon/apple-touch-icon-72x72.png')}">

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/Page.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/Page.java
@@ -47,7 +47,8 @@ public record Page(RootUrl rootUrl, String id, JsonObject data, Paginator pagina
     public ZonedDateTime date() {
         final String d = data.getString(DATE_KEY);
         if (d == null) {
-            return ZonedDateTime.now();
+            // must be NULL if no date found to distinguish website (null) from blog posts (date)
+            return null;
         }
         return ZonedDateTime.parse(d, DateTimeFormatter.ISO_DATE_TIME);
     }

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqCollection.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqCollection.java
@@ -7,7 +7,9 @@ import java.util.List;
 public class RoqCollection extends ArrayList<Page> {
 
     public RoqCollection(List<Page> pages) {
-        super(pages.stream().sorted(Comparator.comparing(Page::date).reversed()).toList());
+        super(pages.stream()
+                .sorted(Comparator.comparing(Page::date, Comparator.nullsLast(Comparator.naturalOrder())).reversed())
+                .toList());
     }
 
     public Page findNext(Page page) {

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplateGlobal.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplateGlobal.java
@@ -1,10 +1,14 @@
 package io.quarkiverse.roq.frontmatter.runtime;
 
 import java.time.LocalDateTime;
+import java.util.Locale;
+import java.util.Objects;
 
 import io.quarkus.qute.TemplateGlobal;
 
 @TemplateGlobal
 public class RoqTemplateGlobal {
-    public static LocalDateTime now = LocalDateTime.now();
+    static LocalDateTime now = LocalDateTime.now();
+    static String roqVersion = Objects.toString(RoqTemplateGlobal.class.getPackage().getImplementationVersion(), "???");
+    static String locale = Locale.getDefault().toString();
 }

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seo.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seo.html
@@ -5,7 +5,7 @@
 {#seoType page /}
 {#seoImage page site /}
 {#seoVerifications webmasterVerifications=site.webmasterVerifications /}
-{#seoPaginator previousPage=page.previous nextPage=page.next/}
+{#seoPaginator paginator=page.paginator /}
 {#seoFacebook facebook=site.facebook /}
 {#seoTwitter twitter=site.twitter /}
 {#seoLocale pageLocale=page.lang siteLocale=site.lang defaultLocale=global:locale /}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seo.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seo.html
@@ -1,0 +1,12 @@
+{#seoTitle pageTitle=page.title siteTitle=site.title /}
+{#seoDescription pageDescription=page.description siteDescription=site.description /}
+{#seoAuthor pageAuthor=page.author siteAuthor=site.author /}
+{#seoUrl pageUrl=page.url siteUrl=site.url /}
+{#seoType page /}
+{#seoImage page site /}
+{#seoVerifications webmasterVerifications=site.webmasterVerifications /}
+{#seoPaginator previousPage=page.previous nextPage=page.next/}
+{#seoFacebook facebook=site.facebook /}
+{#seoTwitter twitter=site.twitter /}
+{#seoLocale pageLocale=page.lang siteLocale=site.lang defaultLocale=global:locale /}
+{#seoGenerator name="Quarkus Roq" version=global:roqVersion /}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoAuthor.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoAuthor.html
@@ -1,0 +1,5 @@
+{#if pageAuthor || siteAuthor}
+  <!-- SEO AUTHOR -->
+  <meta property="article:author" content="{pageAuthor ?: siteAuthor}" />
+  <meta name="author" content="{pageAuthor ?: siteAuthor}" />
+{/if}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoDescription.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoDescription.html
@@ -1,0 +1,6 @@
+{#if pageDescription || siteDescription}
+  <!-- SEO DESCRIPTION -->
+  <meta name="description" content="{pageDescription ?: siteDescription}">
+  <meta property="og:description" content="{pageDescription ?: siteDescription}" />
+  <meta name="twitter:description" content="{pageDescription ?: siteDescription}">
+{/if}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoFacebook.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoFacebook.html
@@ -1,0 +1,14 @@
+{#if facebook}
+  <!-- SEO FACEBOOK -->
+  {#if facebook.admins}
+    <meta property="fb:admins" content="{facebook.admins}" />
+  {/if}
+
+  {#if facebook.publisher}
+    <meta property="article:publisher" content="{facebook.publisher}" />
+  {/if}
+
+  {#if facebook.app_id}
+    <meta property="fb:app_id" content="{facebook.app_id}" />
+  {/if}
+{/if}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoGenerator.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoGenerator.html
@@ -1,0 +1,4 @@
+{#if name}
+  <!-- SEO GENERATOR -->
+  <meta name="generator" content="{name} v{version}" />
+{/if}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoImage.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoImage.html
@@ -1,0 +1,9 @@
+{#if page.img and site.rootUrl}
+  <!-- SEO IMAGE -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image:src" content="{page.img.toUrl.absoluteOrElseFrom(site.rootUrl.relative.resolve('static/images/'))}" />
+  <meta property="og:image" content="{page.img.toUrl.absoluteOrElseFrom(site.rootUrl.relative.resolve('static/images/'))}" />
+{#else}
+  <!-- SEO IMAGE -->
+  <meta name="twitter:card" content="summary">
+{/if}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoLocale.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoLocale.html
@@ -1,0 +1,7 @@
+{#if pageLocale || siteLocale}
+  <!-- SEO LOCALE -->
+  <meta property="og:locale" content="{pageLocale ?: siteLocale}" />
+{#else}
+  <!-- SEO LOCALE -->
+  <meta property="og:locale" content="{defaultLocale}" />
+{/if}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoPaginator.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoPaginator.html
@@ -1,9 +1,9 @@
-{#if previousPage || nextPage}
+{#if paginator}
     <!-- SEO PAGINATOR -->
-    {#if previousPage}
-        <link rel="prev" href="{previousPage}" />
+    {#if paginator.previous}
+    <link rel="prev" href="{paginator.previous.relative}" />
     {/if}
-    {#if nextPage}
-        <link rel="next" href="{nextPage}" />
+    {#if paginator.next}
+    <link rel="next" href="{paginator.next.relative}" />
     {/if}
 {/if}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoPaginator.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoPaginator.html
@@ -1,0 +1,9 @@
+{#if previousPage || nextPage}
+    <!-- SEO PAGINATOR -->
+    {#if previousPage}
+        <link rel="prev" href="{previousPage}" />
+    {/if}
+    {#if nextPage}
+        <link rel="next" href="{nextPage}" />
+    {/if}
+{/if}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoTitle.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoTitle.html
@@ -1,0 +1,10 @@
+{#if pageTitle || siteTitle}
+  <!-- SEO TITLE -->
+  <title>
+    {#if pageTitle ne siteTitle}{pageTitle} - {siteTitle}{#else}{siteTitle}{/if}
+  </title>
+  <meta name="twitter:title" content="{#if pageTitle ne siteTitle}{pageTitle} - {siteTitle}{#else}{siteTitle}{/if}">
+{/if}
+{#if siteTitle}
+  <meta property="og:site_name" content="{siteTitle}">
+{/if}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoTwitter.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoTwitter.html
@@ -1,0 +1,5 @@
+{#if twitter}
+  <!-- SEO TWITTER -->
+  <meta name="twitter:site" content="@{twitter}" />
+  <meta name="twitter:creator" content="@{twitter}" />
+{/if}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoType.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoType.html
@@ -1,0 +1,8 @@
+{#if it.date}
+  <!-- SEO TYPE -->
+  <meta property="og:type" content="article" />
+  <meta property="article:published_time" content="{it.date}" />
+{#else}
+  <!-- SEO TYPE -->
+  <meta property="og:type" content="website" />
+{/if}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoUrl.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoUrl.html
@@ -1,0 +1,6 @@
+{#if pageUrl || siteUrl}
+  <!-- SEO URL -->
+  <link rel="canonical" href="{pageUrl ?: siteUrl.absolute}" />
+  <meta property="og:url" content="{pageUrl ?: siteUrl.absolute}" />
+  <meta name="twitter:url" content="{pageUrl ?: siteUrl.absolute}">
+{/if}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoVerifications.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoVerifications.html
@@ -1,0 +1,21 @@
+{#if webmasterVerifications}
+  <!-- SEO VERIFICATION -->
+  {#if webmasterVerifications.google}
+    <meta name="google-site-verification" content="{webmasterVerifications.google}">
+  {/if}
+  {#if webmasterVerifications.bing}
+    <meta name="msvalidate.01" content="{webmasterVerifications.bing}">
+  {/if}
+  {#if webmasterVerifications.alexa}
+    <meta name="alexaVerifyID" content="{webmasterVerifications.alexa}">
+  {/if}
+  {#if webmasterVerifications.yandex}
+    <meta name="yandex-verification" content="{webmasterVerifications.yandex}">
+  {/if}
+  {#if webmasterVerifications.baidu}
+    <meta name="baidu-site-verification" content="{webmasterVerifications.baidu}">
+  {/if}
+  {#if webmasterVerifications.facebook}
+    <meta name="facebook-domain-verification" content="{webmasterVerifications.facebook}">
+  {/if}
+{/if}


### PR DESCRIPTION
Fix #80 

Just getting this started this has a lot of what Jekyll has so far but some open questions.

- [x] ~~Date tag we need to figure out what is the correct format as Jekyll does this `{{ page.date | date_to_xmlschema }}`~~
- [x] ~~Where to get `author` data?~~
- [x] ~~For `generator` tag they use a version but didn't know if that was available. `content="Jekyll v{{ jekyll.version }}"`~~
- [x] ~~Where to get `page.locale` data?~~
- [x] ~~How to generate `previous`  and `next` pages.  Right now it prints out "1".~~
- [x] ~~Image URL generating issue see below...~~


generating wrong Image URLs
```xml
<!-- SEO IMAGE -->
  <meta name="twitter:card" content="summary_large_image" />
  <meta name="twitter:image:src" content="/assets/img/https://images.unsplash.com/photo-1563206767-5b18f218e8de?q=80&amp;w=3538&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D">
  <meta property="og:image" content="/assets/img/https://images.unsplash.com/photo-1563206767-5b18f218e8de?q=80&amp;w=3538&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
```