### PR TITLE
Move collections to site

### DIFF
--- a/blog/site/_includes/head.html
+++ b/blog/site/_includes/head.html
@@ -1,7 +1,7 @@
 <head>
   <meta charset="utf-8">
 
-  {#seo page site collections /}
+  {#seo page site /}
 
   <!-- Edit site and author settings in `_config.yml` to make the social details your own -->
   <base href="{site.rootUrl.relative}">

--- a/blog/site/_posts/2024-09-20-pagination.md
+++ b/blog/site/_posts/2024-09-20-pagination.md
@@ -21,7 +21,7 @@ paginate: posts
 Next, in your template, loop through the paginated posts using:
 
 ```html
-\{#for post in collections.posts.paginated(page.paginator)}
+\{#for post in site.collections.posts.paginated(page.paginator)}
 <article class="post">
   ...
 </article>

--- a/blog/site/_posts/2024-09-23-seo.md
+++ b/blog/site/_posts/2024-09-23-seo.md
@@ -10,7 +10,7 @@ date: 2024-09-23 14:00:00 +0200
 Adding SEO is as easy as adding this tag to your `<head>` section:
 
 ```html
-  \{#seo page site collections /}
+  \{#seo page site /}
 ```
 
 It will automatically use the Frontmatter data to fill the tags. Read the Roq documentation for more.. 
@@ -18,5 +18,5 @@ It will automatically use the Frontmatter data to fill the tags. Read the Roq do
 
 Like this:
 ```html
-{#seo page site collections /}
+{#seo page site /}
 ```

--- a/blog/site/index.html
+++ b/blog/site/index.html
@@ -14,7 +14,7 @@ paginate:
   size: 4
 ---
 
-{#for post in collections.posts.paginated(page.paginator)}
+{#for post in site.collections.posts.paginated(page.paginator)}
 <article class="post">
   {#if post.img}
   <a class="post-thumbnail" style="background-image: url({post.img.toUrl.absoluteOrElseFrom(site.rootUrl.relative.resolve('static/images/'))}" href="{post.url.relative}"></a>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <quarkus.version>3.15.0</quarkus.version>
         <assertj.version>3.26.3</assertj.version>
         <quarkus-qute-web.version>3.1.0</quarkus-qute-web.version>
+        <quarkus-web-bundler.version>1.7.1</quarkus-web-bundler.version>
     </properties>
 
     <dependencyManagement>

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/Link.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/Link.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import io.quarkiverse.roq.frontmatter.runtime.Page;
+import io.quarkiverse.roq.frontmatter.runtime.NormalPage;
 import io.quarkiverse.roq.util.PathUtils;
 import io.vertx.core.json.JsonObject;
 
@@ -27,13 +27,13 @@ public class Link {
         LocalDateTime now = LocalDateTime.now();
         PLACEHOLDER_HANDLERS.put(":page", (data) -> data.getString("page"));
         PLACEHOLDER_HANDLERS.put(":collection",
-                (data) -> data.getString(Page.COLLECTION_KEY));
+                (data) -> data.getString(NormalPage.COLLECTION_KEY));
         PLACEHOLDER_HANDLERS.put(":year", (data) -> data.getString("year", YEAR_FORMAT.format(now)));
         PLACEHOLDER_HANDLERS.put(":month", (data) -> data.getString("month", MONTH_FORMAT.format(now)));
         PLACEHOLDER_HANDLERS.put(":day", (data) -> data.getString("day", DAY_FORMAT.format(now)));
-        PLACEHOLDER_HANDLERS.put(":name", (data) -> slugify(data.getString(Page.BASE_FILE_NAME_KEY)));
+        PLACEHOLDER_HANDLERS.put(":name", (data) -> slugify(data.getString(NormalPage.BASE_FILE_NAME_KEY)));
         PLACEHOLDER_HANDLERS.put(":title",
-                (data) -> data.getString("slug", slugify(data.getString(Page.BASE_FILE_NAME_KEY))));
+                (data) -> data.getString("slug", slugify(data.getString(NormalPage.BASE_FILE_NAME_KEY))));
     }
 
     public static String link(String rootPath, String template, JsonObject data) {

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterScanProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterScanProcessor.java
@@ -1,6 +1,6 @@
 package io.quarkiverse.roq.frontmatter.deployment;
 
-import static io.quarkiverse.roq.frontmatter.runtime.Page.*;
+import static io.quarkiverse.roq.frontmatter.runtime.NormalPage.*;
 import static io.quarkiverse.roq.util.PathUtils.removeExtension;
 import static io.quarkiverse.roq.util.PathUtils.toUnixPath;
 import static java.util.function.Predicate.not;

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/items/RoqFrontMatterOutputBuildItem.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/items/RoqFrontMatterOutputBuildItem.java
@@ -9,16 +9,17 @@ import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class RoqFrontMatterOutputBuildItem extends SimpleBuildItem {
 
-    private final Map<String, Supplier<Page>> pages;
+    private final Map<String, Supplier<? extends Page>> all;
     private final Supplier<RoqCollections> roqCollectionsSupplier;
 
-    public RoqFrontMatterOutputBuildItem(Map<String, Supplier<Page>> pages, Supplier<RoqCollections> roqCollectionsSupplier) {
-        this.pages = pages;
+    public RoqFrontMatterOutputBuildItem(Map<String, Supplier<? extends Page>> all,
+            Supplier<RoqCollections> roqCollectionsSupplier) {
+        this.all = all;
         this.roqCollectionsSupplier = roqCollectionsSupplier;
     }
 
-    public Map<String, Supplier<Page>> pages() {
-        return pages;
+    public Map<String, Supplier<? extends Page>> all() {
+        return all;
     }
 
     public Supplier<RoqCollections> roqCollectionsSupplier() {

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterTest.java
@@ -2,14 +2,9 @@ package io.quarkiverse.roq.frontmatter.deployment;
 
 import static org.hamcrest.Matchers.*;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-import jakarta.inject.Named;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkiverse.roq.frontmatter.runtime.Page;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
@@ -19,7 +14,6 @@ public class RoqFrontMatterTest {
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addClass(MyResource.class)
                     .addAsResource("application.properties")
                     .addAsResource("site/_data/foo.yml")
                     .addAsResource("site/_includes/foo/bar.html")
@@ -75,20 +69,4 @@ public class RoqFrontMatterTest {
                 .body("html.body.div.p", equalTo("bar bar bar"));
     }
 
-    @ApplicationScoped
-    public static class MyResource {
-
-        @Inject
-        @Named("/bar/posts/awesome-post")
-        Page awesomePostFm;
-
-        @Inject
-        @Named("/bar/posts/markdown-post")
-        Page markdownPostFm;
-
-        @Inject
-        @Named("/bar/my-cool-page")
-        Page coolPageFm;
-
-    }
 }

--- a/roq-frontmatter/deployment/src/test/resources/site/index.html
+++ b/roq-frontmatter/deployment/src/test/resources/site/index.html
@@ -9,7 +9,7 @@ paginate: posts
 ---
 
 <div>
-  {#for post in collections.posts.paginated(page.paginator)}
+  {#for post in site.collections.posts.paginated(page.paginator)}
     <h1>{post.id}</h1>
   {/for}
 </div>

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/DocumentPage.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/DocumentPage.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.roq.frontmatter.runtime;
+
+import static io.quarkiverse.roq.frontmatter.runtime.NormalPage.*;
+
+import io.vertx.core.json.JsonObject;
+
+public record DocumentPage(RootUrl rootUrl, String id, JsonObject data) implements Page {
+
+    public static final String COLLECTION_KEY = "collection";
+    public static final String PREVIOUS_INDEX_KEY = "nextIndex";
+    public static final String NEXT_INDEX_KEY = "previousIndex";
+
+    public String rawContent() {
+        return data.getString(RAW_CONTENT_KEY);
+    }
+
+    public String collection() {
+        return data.getString(COLLECTION_KEY);
+    }
+
+    public Integer previous() {
+        return data.getInteger(PREVIOUS_INDEX_KEY);
+    }
+
+    public Integer prev() {
+        return previous();
+    }
+
+    public Integer next() {
+        return data.getInteger(NEXT_INDEX_KEY);
+    }
+
+}

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/NormalPage.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/NormalPage.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.roq.frontmatter.runtime;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import io.quarkiverse.roq.frontmatter.runtime.RoqCollection.Paginator;
+import io.vertx.core.json.JsonObject;
+
+public record NormalPage(RootUrl rootUrl, String id, JsonObject data, Paginator paginator) implements Page {
+
+    public static final String PAGINATE_KEY = "paginate";
+    public static final String DRAFT_KEY = "draft";
+    public static final String COLLECTION_KEY = "collection";
+    public static final String DATE_KEY = "date";
+    public static final String RAW_CONTENT_KEY = "rawContent";
+    public static final String BASE_FILE_NAME_KEY = "baseFileName";
+    public static final String FILE_NAME_KEY = "fileName";
+    public static final String FILE_PATH_KEY = "filePath";
+    public static final String LINK_KEY = "link";
+    public static final String PREVIOUS_INDEX_KEY = "nextIndex";
+    public static final String NEXT_INDEX_KEY = "previousIndex";
+
+    public String rawContent() {
+        return data.getString(RAW_CONTENT_KEY);
+    }
+
+    public PageUrl url() {
+        return new PageUrl(rootUrl, data.getString(LINK_KEY));
+    }
+
+    public ZonedDateTime date() {
+        final String d = data.getString(DATE_KEY);
+        if (d == null) {
+            // must be NULL if no date found to distinguish website (null) from blog posts (date)
+            return null;
+        }
+        return ZonedDateTime.parse(d, DateTimeFormatter.ISO_DATE_TIME);
+    }
+
+}

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/Page.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/Page.java
@@ -1,51 +1,30 @@
 package io.quarkiverse.roq.frontmatter.runtime;
 
+import static io.quarkiverse.roq.frontmatter.runtime.NormalPage.*;
+
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
-import io.quarkiverse.roq.frontmatter.runtime.RoqCollection.Paginator;
 import io.vertx.core.json.JsonObject;
 
-public record Page(RootUrl rootUrl, String id, JsonObject data, Paginator paginator) {
+public interface Page {
 
-    public static final String PAGINATE_KEY = "paginate";
-    public static final String DRAFT_KEY = "draft";
-    public static final String COLLECTION_KEY = "collection";
-    public static final String DATE_KEY = "date";
-    public static final String RAW_CONTENT_KEY = "rawContent";
-    public static final String BASE_FILE_NAME_KEY = "baseFileName";
-    public static final String FILE_NAME_KEY = "fileName";
-    public static final String FILE_PATH_KEY = "filePath";
-    public static final String LINK_KEY = "link";
-    public static final String PREVIOUS_INDEX_KEY = "nextIndex";
-    public static final String NEXT_INDEX_KEY = "previousIndex";
+    String id();
 
-    public String rawContent() {
-        return data.getString(RAW_CONTENT_KEY);
+    JsonObject data();
+
+    RootUrl rootUrl();
+
+    default PageUrl url() {
+        return new PageUrl(rootUrl(), data().getString(LINK_KEY));
     }
 
-    public String collection() {
-        return data.getString(COLLECTION_KEY);
+    default String rawContent() {
+        return data().getString(RAW_CONTENT_KEY);
     }
 
-    public Integer previous() {
-        return data.getInteger(PREVIOUS_INDEX_KEY);
-    }
-
-    public Integer prev() {
-        return previous();
-    }
-
-    public Integer next() {
-        return data.getInteger(NEXT_INDEX_KEY);
-    }
-
-    public PageUrl url() {
-        return new PageUrl(rootUrl, data.getString(LINK_KEY));
-    }
-
-    public ZonedDateTime date() {
-        final String d = data.getString(DATE_KEY);
+    default ZonedDateTime date() {
+        final String d = data().getString(DATE_KEY);
         if (d == null) {
             // must be NULL if no date found to distinguish website (null) from blog posts (date)
             return null;
@@ -53,11 +32,10 @@ public record Page(RootUrl rootUrl, String id, JsonObject data, Paginator pagina
         return ZonedDateTime.parse(d, DateTimeFormatter.ISO_DATE_TIME);
     }
 
-    public Object data(String name) {
+    default Object data(String name) {
         if (data().containsKey(name)) {
-            return data.getValue(name);
+            return data().getValue(name);
         }
         return null;
     }
-
 }

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqCollection.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqCollection.java
@@ -4,33 +4,33 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
-public class RoqCollection extends ArrayList<Page> {
+public class RoqCollection extends ArrayList<DocumentPage> {
 
-    public RoqCollection(List<Page> pages) {
-        super(pages.stream()
-                .sorted(Comparator.comparing(Page::date, Comparator.nullsLast(Comparator.naturalOrder())).reversed())
+    public RoqCollection(List<DocumentPage> documents) {
+        super(documents.stream()
+                .sorted(Comparator.comparing(DocumentPage::date, Comparator.nullsLast(Comparator.naturalOrder())).reversed())
                 .toList());
     }
 
-    public Page resolveNextPage(Page page) {
+    public DocumentPage resolveNextPage(DocumentPage page) {
         if (page.next() == null) {
             return null;
         }
         return this.get(page.next());
     }
 
-    public Page resolvePreviousPage(Page page) {
+    public DocumentPage resolvePreviousPage(DocumentPage page) {
         if (page.previous() == null) {
             return null;
         }
         return this.get(page.previous());
     }
 
-    public Page resolvePrevPage(Page page) {
+    public DocumentPage resolvePrevPage(DocumentPage page) {
         return this.resolvePreviousPage(page);
     }
 
-    public List<Page> paginated(Paginator paginator) {
+    public List<DocumentPage> paginated(Paginator paginator) {
         var zeroBasedCurrent = paginator.currentIndex - 1;
         return this.subList(zeroBasedCurrent * paginator.limit, Math.min(this.size(), zeroBasedCurrent + paginator.limit));
     }

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqCollections.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqCollections.java
@@ -7,28 +7,28 @@ public record RoqCollections(Map<String, RoqCollection> collections) {
         return collections.get(name);
     }
 
-    public Page resolveNextPage(Page page) {
+    public DocumentPage resolveNextPage(DocumentPage page) {
         final RoqCollection collection = resolveCollection(page);
         if (collection == null)
             return null;
         return collection.resolveNextPage(page);
     }
 
-    public Page resolvePreviousPage(Page page) {
+    public DocumentPage resolvePreviousPage(DocumentPage page) {
         final RoqCollection collection = resolveCollection(page);
         if (collection == null)
             return null;
         return collection.resolvePreviousPage(page);
     }
 
-    public RoqCollection resolveCollection(Page page) {
+    public RoqCollection resolveCollection(DocumentPage page) {
         if (page.collection() == null) {
             return null;
         }
         return this.get(page.collection());
     }
 
-    public Page resolvePrevPage(Page page) {
+    public DocumentPage resolvePrevPage(DocumentPage page) {
         return this.resolvePreviousPage(page);
     }
 

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplateExtension.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplateExtension.java
@@ -1,40 +1,31 @@
 package io.quarkiverse.roq.frontmatter.runtime;
 
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
-import io.quarkus.qute.Results;
 import io.quarkus.qute.TemplateExtension;
 
 @TemplateExtension
 public class RoqTemplateExtension {
-    private static final Set<String> PAGE_METHOD_NAMES = Arrays.stream(Page.class.getMethods()).sequential()
-            .map(Method::getName)
-            .collect(Collectors.toSet());
+
+    private static final int QUTE_FALLBACK_PRIORITY = -2;
+
     private static final Pattern COUNT_WORDS = Pattern.compile("\\b\\w+\\b");
-    public static final Results.NotFound NOT_PAGE_DATA = Results.NotFound.from("Not Page Data");
 
     public static long numberOfWords(String text) {
         return COUNT_WORDS.matcher(text).results().count();
     }
 
-    @TemplateExtension(matchName = "*")
+    @TemplateExtension(matchName = "*", priority = QUTE_FALLBACK_PRIORITY)
     public static Object data(Page page, String key) {
-        if (PAGE_METHOD_NAMES.contains(key)) {
-            return NOT_PAGE_DATA;
-        }
         return page.data(key);
     }
 
-    @TemplateExtension(matchName = "*")
+    @TemplateExtension(matchName = "*", priority = QUTE_FALLBACK_PRIORITY)
     public static RoqCollection collection(RoqCollections collections, String key) {
         return collections.get(key);
     }
 
-    public static Object readTime(Page page) {
+    public static Object readTime(NormalPage page) {
         final long count = numberOfWords(page.rawContent());
         return Math.round((float) count / 200);
     }

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/Site.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/Site.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.roq.frontmatter.runtime;
+
+import io.vertx.core.json.JsonObject;
+
+public record Site(NormalPage page, java.util.List<NormalPage> pages, RoqCollections collections) implements Page {
+
+    @Override
+    public String id() {
+        return page.id();
+    }
+
+    @Override
+    public JsonObject data() {
+        return page().data();
+    }
+
+    public RoqCollection.Paginator paginator() {
+        return page().paginator();
+    }
+
+    @Override
+    public RootUrl rootUrl() {
+        return page.rootUrl();
+    }
+}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seo.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seo.html
@@ -5,7 +5,7 @@
 {#seoType page /}
 {#seoImage page site /}
 {#seoVerifications webmasterVerifications=site.webmasterVerifications /}
-{#seoPaginator page collections /}
+{#seoPaginator page site /}
 {#seoFacebook facebook=site.facebook /}
 {#seoTwitter twitter=site.twitter /}
 {#seoLocale pageLocale=page.lang siteLocale=site.lang defaultLocale=global:locale /}

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoPaginator.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoPaginator.html
@@ -6,14 +6,14 @@
     {#if page.paginator.next}
     <link rel="next" href="{page.paginator.next.absolute}" />
     {/if}
-{#else}
+{#else if page.collection}
   <!-- SEO COLLECTION PAGES -->
-  {#let prevPage = collections.resolvePreviousPage(page)}
+  {#let prevPage = site.collections.resolvePreviousPage(page)}
   {#if prevPage}
   <link rel="prev" href="{prevPage.url.absolute}" />
   {/if}
   {/let}
-  {#let nextPage = collections.resolveNextPage(page) }
+  {#let nextPage = site.collections.resolveNextPage(page) }
   {#if nextPage}
   <link rel="next" href="{nextPage.url.absolute}" />
   {/if}

--- a/roq/deployment/pom.xml
+++ b/roq/deployment/pom.xml
@@ -28,6 +28,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.web-bundler</groupId>
+            <artifactId>quarkus-web-bundler-deployment</artifactId>
+            <version>${quarkus-web-bundler.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.roq</groupId>
             <artifactId>quarkus-roq</artifactId>
             <version>${project.version}</version>

--- a/roq/runtime/pom.xml
+++ b/roq/runtime/pom.xml
@@ -22,6 +22,11 @@
             <artifactId>quarkus-roq-frontmatter</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.web-bundler</groupId>
+            <artifactId>quarkus-web-bundler</artifactId>
+            <version>${quarkus-web-bundler.version}</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
- `collections` is now in `site.collections`
- we now only have `page` and `site` as data for pages
- Site, NormalPage and DocumentPage are differentiated and implement Page
- `site` is the index page plus some extra fields (collections, pages, ...), it is available from any page
