### PR TITLE
Apply asciidoc attributes to show project-version

### DIFF
--- a/docs/modules/ROOT/pages/quarkus-roq-data.adoc
+++ b/docs/modules/ROOT/pages/quarkus-roq-data.adoc
@@ -1,3 +1,5 @@
+include::./includes/attributes.adoc[]
+
 = Quarkus Roq Data
 
 Quarkus Roq Data is a Quarkus extension that register JSON/YAML files as CDI beans, and available from Qute templates, in a type-safe way in your project.

--- a/docs/modules/ROOT/pages/quarkus-roq-frontmatter.adoc
+++ b/docs/modules/ROOT/pages/quarkus-roq-frontmatter.adoc
@@ -1,3 +1,5 @@
+include::./includes/attributes.adoc[]
+
 = Quarkus Roq FrontMatter
 
 Quarkus Roq FrontMatter is a Quarkus extension that create a website from your Markdown/Asciidoc/Html pages using FrontMatter headers (url, layout, seo, data).

--- a/docs/modules/ROOT/pages/quarkus-roq-generator.adoc
+++ b/docs/modules/ROOT/pages/quarkus-roq-generator.adoc
@@ -1,3 +1,5 @@
+include::./includes/attributes.adoc[]
+
 = Quarkus Roq Generator
 
 It provides a command to run any Quarkus web application and extract it in a directory as purely static files (html and assets).


### PR DESCRIPTION
Reading the documentation was possible to see the `{project-version}` is not parsed correctly.

<img width="569" alt="image" src="https://github.com/user-attachments/assets/8c6557a1-8283-4a2f-b992-dfa8a26d00aa">

This pull request applies attributes to the documentation.

Now:

<img width="494" alt="image" src="https://github.com/user-attachments/assets/2f41e035-4c73-4af1-9766-593e789e8de0">
