### PR TITLE
Better pagination and introduce data modif api

### DIFF
--- a/blog/site/_includes/pagination.html
+++ b/blog/site/_includes/pagination.html
@@ -1,23 +1,6 @@
-{@io.quarkiverse.roq.frontmatter.runtime.model.Site site}
-
 <div class="container">
-  <nav class="pagination" role="pagination">
-    <ul>
-      {#if page.paginator.previous}
-      {#if page.paginator.isSecond}
-      <p><a class="newer-posts" href="{site.url}"><i class="fa fa-long-arrow-left" aria-hidden="true"></i></a></p>
-      {#else}
-      <p><a class="newer-posts" href="{page.paginator.previous}/"><i class="fa fa-long-arrow-left" aria-hidden="true"></i></a></p>
-      {/if}
-      {/if}
-
-      {#if page.paginator.total > 1}
-      <p><span class="page-number">Page {page.paginator.currentIndex} of {page.paginator.total}</span></p>
-      {/if}
-
-      {#if page.paginator.next}
-      <p><a class="older-posts" href="{page.paginator.next}"><i class="fa fa-long-arrow-right" aria-hidden="true"></i></a></p>
-      {/if}
-    </ul>
-  </nav>
+  {#include fm/pagination.html}
+    {#newer}<i class="fa fa-long-arrow-left" aria-hidden="true"></i>{/newer}
+    {#older}<i class="fa fa-long-arrow-right" aria-hidden="true"></i>{/older}
+  {/include}
 </div>

--- a/blog/site/_posts/2024-09-20-pagination.md
+++ b/blog/site/_posts/2024-09-20-pagination.md
@@ -34,27 +34,10 @@ Next, in your template, loop through the paginated posts using:
 To add pagination controls, add something like this to `_includes/pagination.html` and include it in your page `\{#include pagination.html/}`:
 
 ```html
-<div class="container">
-  <nav class="pagination" role="pagination">
-    <ul>
-      \{#if page.paginator.previous}
-      \{#if page.paginator.isSecond}
-      <p><a class="newer-posts" href="\{site.url}"><i class="fa fa-long-arrow-left" aria-hidden="true"></i></a></p>
-      \{#else}
-      <p><a class="newer-posts" href="\{page.paginator.previous)}/"><i class="fa fa-long-arrow-left" aria-hidden="true"></i></a></p>
-      \{/if}
-      \{/if}
-
-      \{#if page.paginator.total > 1}
-      <p><span class="page-number">Page \{page.paginator.currentIndex} of \{page.paginator.total}</span></p>
-      \{/if}
-
-      \{#if page.paginator.next}
-      <p><a class="older-posts" href="\{page.paginator.next)}"><i class="fa fa-long-arrow-right" aria-hidden="true"></i></a></p>
-      \{/if}
-    </ul>
-  </nav>
-</div>
+\{#include fm/pagination.html}
+\{#newer}<i class="fa fa-long-arrow-left" aria-hidden="true"></i>\{/newer}
+\{#older}<i class="fa fa-long-arrow-right" aria-hidden="true"></i>\{/older}
+\{/include}
 ```
 
 You can further customize your pagination by setting the page size and link format:

--- a/docs/modules/ROOT/pages/quarkus-roq-frontmatter.adoc
+++ b/docs/modules/ROOT/pages/quarkus-roq-frontmatter.adoc
@@ -39,32 +39,17 @@ Next, in your template, loop through the paginated posts using:
 
 === Step 2: Including Pagination Controls
 
-To add pagination controls, create something like this in `_includes/pagination.html`:
+To add pagination controls, use the provided `fm/pagination.html` in your own `_includes/pagination.html`:
 
 [source,html]
 ----
-<div class="container">
-  <nav class="pagination" role="pagination">
-    <ul>
-      {#if page.paginator.previous}
-      {#if page.paginator.isSecond}
-      <p><a class="newer-posts" href="{site.url}"><i class="fa fa-long-arrow-left" aria-hidden="true"></i></a></p>
-      {#else}
-      <p><a class="newer-posts" href="{page.paginator.previous)}/"><i class="fa fa-long-arrow-left" aria-hidden="true"></i></a></p>
-      {/if}
-      {/if}
-
-      {#if page.paginator.total > 1}
-      <p><span class="page-number">Page {page.paginator.currentIndex} of {page.paginator.total}</span></p>
-      {/if}
-
-      {#if page.paginator.next}
-      <p><a class="older-posts" href="{page.paginator.next)}"><i class="fa fa-long-arrow-right" aria-hidden="true"></i></a></p>
-      {/if}
-    </ul>
-  </nav>
-</div>
+{#include fm/pagination.html}
+{#newer}<i class="fa fa-long-arrow-left" aria-hidden="true"></i>{/newer}
+{#older}<i class="fa fa-long-arrow-right" aria-hidden="true"></i>{/older}
+{/include}
 ----
+
+NOTE: If you want to write your own controls, find inspiration in the FM sources https://github.com/quarkiverse/quarkus-roq/tree/main/roq-frontmatter/runtime/src/main/resources/templates/fm/pagination.html[fm/pagination.html].
 
 Just by doing so, Roq will generate a bunch of pages based on the pagination setting. For example with a pagination size of 4 and with 9 posts, you would get:
 

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterProcessor.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.quarkiverse.roq.frontmatter.deployment.scan.RoqFrontMatterRawTemplateBuildItem;
+import io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterMessages;
 import io.quarkiverse.roq.frontmatter.runtime.RoqTemplateExtension;
 import io.quarkiverse.roq.frontmatter.runtime.RoqTemplateGlobal;
 import io.quarkiverse.roq.frontmatter.runtime.model.*;
@@ -75,6 +76,7 @@ class RoqFrontMatterProcessor {
         }
         additionalBeans.produce(AdditionalBeanBuildItem.builder()
                 .addBeanClasses(
+                        RoqFrontMatterMessages.class,
                         RoqTemplateExtension.class,
                         RoqTemplateGlobal.class,
                         Page.class,

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/data/RoqFrontMatterDataModificationBuildItem.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/data/RoqFrontMatterDataModificationBuildItem.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.roq.frontmatter.deployment.data;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Allow to modify the FrontMatter data just before it is produced (and before it is merged with parents).
+ */
+public final class RoqFrontMatterDataModificationBuildItem extends MultiBuildItem {
+    private final DataModifier modifier;
+
+    /**
+     * Modifiers with the highest priority will run last.
+     */
+    private final int order;
+
+    public RoqFrontMatterDataModificationBuildItem(DataModifier modifier, int order) {
+        this.modifier = modifier;
+        this.order = order;
+    }
+
+    public RoqFrontMatterDataModificationBuildItem(DataModifier modifier) {
+        this.modifier = modifier;
+        this.order = 0;
+    }
+
+    public DataModifier modifier() {
+        return modifier;
+    }
+
+    public int order() {
+        return order;
+    }
+
+    public interface DataModifier {
+
+        JsonObject modify(String id, String templatePath, JsonObject fm);
+    }
+}

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/data/RoqFrontMatterDataProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/data/RoqFrontMatterDataProcessor.java
@@ -33,16 +33,19 @@ public class RoqFrontMatterDataProcessor {
         if (roqFrontMatterTemplates.isEmpty()) {
             return;
         }
+
         final var byKey = roqFrontMatterTemplates.stream()
                 .collect(Collectors.toMap(RoqFrontMatterRawTemplateBuildItem::id, Function.identity()));
         final RootUrl rootUrl = new RootUrl(config.urlOptional().orElse(""), httpConfig.rootPath);
         rootUrlProducer.produce(new RoqFrontMatterRootUrlBuildItem(rootUrl));
 
         for (RoqFrontMatterRawTemplateBuildItem item : roqFrontMatterTemplates) {
-            final JsonObject data = mergeParents(item, byKey);
+            JsonObject data = mergeParents(item, byKey);
             final String link = Link.pageLink(config.rootPath(), data.getString(LINK_KEY, DEFAULT_PAGE_LINK_TEMPLATE),
                     new Link.PageLinkData(item.info().baseFileName(), item.info().date(), item.collection(), data));
-            templatesProducer.produce(new RoqFrontMatterTemplateBuildItem(item, rootUrl.resolve(link), data));
+            RoqFrontMatterTemplateBuildItem templateItem = new RoqFrontMatterTemplateBuildItem(item, rootUrl.resolve(link),
+                    data);
+            templatesProducer.produce(templateItem);
         }
     }
 

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterApiModificationTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterApiModificationTest.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.roq.frontmatter.deployment;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.roq.frontmatter.deployment.data.RoqFrontMatterDataModificationBuildItem;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.json.JsonObject;
+
+public class RoqFrontMatterApiModificationTest {
+
+    // Start unit test with your extension loaded
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.roq.resource-dir", "simple-site")
+            .addBuildChainCustomizer(buildChainBuilder -> {
+                buildChainBuilder.addBuildStep(new BuildStep() {
+
+                    @Override
+                    public void execute(BuildContext context) {
+                        context.produce(new RoqFrontMatterDataModificationBuildItem((id, path, data) -> {
+                            if (id.equals("pages/some-page")) {
+                                final JsonObject newData = data.copy();
+                                newData.put("some-text", "modified text");
+                                newData.put("link", "/somewhere-else");
+                                return newData;
+                            }
+                            return data;
+                        }));
+                    }
+                }).produces(RoqFrontMatterDataModificationBuildItem.class).build();
+
+            })
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("simple-site"));
+
+    @Test
+    public void testPage() {
+        RestAssured.when().get("/somewhere-else").then().statusCode(200).log().ifValidationFails()
+                .body("html.body.article.p", equalTo("modified text"));
+    }
+
+}

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterSimpleTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterSimpleTest.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.roq.frontmatter.deployment;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class RoqFrontMatterSimpleTest {
+
+    // Start unit test with your extension loaded
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.roq.resource-dir", "simple-site")
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("simple-site"));
+
+    @Test
+    public void testPage() {
+        RestAssured.when().get("/page/some-page").then().statusCode(200).log().ifValidationFails()
+                .body("html.head.title", equalTo("Some page - Simple Site"))
+                .body("html.body.article.h1", equalTo("Some page"))
+                .body("html.body.article.p", equalTo("We can also use data"));
+    }
+
+    @Test
+    public void testIndex() {
+        RestAssured.when().get("/").then().statusCode(200).log().ifValidationFails()
+                .body("html.head.title", equalTo("Simple Site"))
+                .body("html.body.div.h1[0]", containsString("New Post"))
+                .body("html.body.div.h1[1]", containsString("Some Post"));
+    }
+
+}

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterTest.java
@@ -15,18 +15,7 @@ public class RoqFrontMatterTest {
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addAsResource("application.properties")
-                    .addAsResource("site/_data/foo.yml")
-                    .addAsResource("site/_includes/foo/bar.html")
-                    .addAsResource("site/_includes/view.html")
-                    .addAsResource("site/_includes/header.html")
-                    .addAsResource("site/_layouts/default.html")
-                    .addAsResource("site/_layouts/page.html")
-                    .addAsResource("site/_layouts/post.html")
-                    .addAsResource("site/index.html")
-                    .addAsResource("site/_posts/awesome-post.html")
-                    .addAsResource("site/_posts/2020-10-24-old-post.md")
-                    .addAsResource("site/_posts/markdown-post.md")
-                    .addAsResource("site/pages/cool-page.html"));
+                    .addAsResource("site"));
 
     @Test
     public void testHtmlPost() {

--- a/roq-frontmatter/deployment/src/test/resources/simple-site/_includes/header.html
+++ b/roq-frontmatter/deployment/src/test/resources/simple-site/_includes/header.html
@@ -1,0 +1,1 @@
+{#seo page site/}

--- a/roq-frontmatter/deployment/src/test/resources/simple-site/_layouts/default.html
+++ b/roq-frontmatter/deployment/src/test/resources/simple-site/_layouts/default.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+{#include header.html /}
+</head>
+<body>
+{#insert /}
+</body>
+</html>

--- a/roq-frontmatter/deployment/src/test/resources/simple-site/_layouts/page.html
+++ b/roq-frontmatter/deployment/src/test/resources/simple-site/_layouts/page.html
@@ -1,0 +1,7 @@
+---
+layout: default
+---
+
+<article class="page">
+  {#insert /}
+</article>

--- a/roq-frontmatter/deployment/src/test/resources/simple-site/_layouts/post.html
+++ b/roq-frontmatter/deployment/src/test/resources/simple-site/_layouts/post.html
@@ -1,0 +1,8 @@
+---
+layout: default
+link: /posts/:title
+---
+<article class="post">
+  {#insert /}
+  <span>{page.date}</span>
+</article>

--- a/roq-frontmatter/deployment/src/test/resources/simple-site/_posts/2020-10-24-old-post.md
+++ b/roq-frontmatter/deployment/src/test/resources/simple-site/_posts/2020-10-24-old-post.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: Old Post
+---
+
+# Old post with markdown
+
+This is a very old post

--- a/roq-frontmatter/deployment/src/test/resources/simple-site/_posts/2023-10-10-some-post.md
+++ b/roq-frontmatter/deployment/src/test/resources/simple-site/_posts/2023-10-10-some-post.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: Some Post
+---
+
+# Some post
+
+some content

--- a/roq-frontmatter/deployment/src/test/resources/simple-site/_posts/2024-10-9-new-post.html
+++ b/roq-frontmatter/deployment/src/test/resources/simple-site/_posts/2024-10-9-new-post.html
@@ -1,0 +1,8 @@
+---
+layout: post
+title: New Post
+---
+
+<h1>New post with html</h1>
+
+<p>This is a new post.</p>

--- a/roq-frontmatter/deployment/src/test/resources/simple-site/index.html
+++ b/roq-frontmatter/deployment/src/test/resources/simple-site/index.html
@@ -1,0 +1,15 @@
+---
+title: Simple Site
+layout:  default
+paginate:
+  collection: posts
+  size: 2
+---
+
+<div>
+  {#for post in site.collections.posts.paginated(page.paginator)}
+    <h1>{post.title}</h1>
+  {/for}
+</div>
+
+{#include fm/pagination.html /}

--- a/roq-frontmatter/deployment/src/test/resources/simple-site/pages/some-page.html
+++ b/roq-frontmatter/deployment/src/test/resources/simple-site/pages/some-page.html
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Some page
+link: /page/some-page
+description: This is a simple page
+some-text: We can also use data
+---
+
+<h1>{page.title}</h1>
+<p>{page.data.some-text}</p>

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqFrontMatterMessages.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqFrontMatterMessages.java
@@ -1,0 +1,11 @@
+package io.quarkiverse.roq.frontmatter.runtime;
+
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+
+@MessageBundle(value = "fm", locale = "en")
+public interface RoqFrontMatterMessages {
+
+    @Message("Page {index} of {total}")
+    public String pageNumber(int index, int total);
+}

--- a/roq-frontmatter/runtime/src/main/resources/templates/fm/pagination.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/fm/pagination.html
@@ -1,0 +1,17 @@
+{@io.quarkiverse.roq.frontmatter.runtime.model.NormalPage page}
+
+<nav class="pagination" role="navigation">
+  <ul>
+    {#if page.paginator.previous}
+    <p><a class="newer-posts" href="{page.paginator.previous}">{#insert newer}‹{/insert}</a></p>
+    {/if}
+
+    {#if page.paginator.total > 1}
+    <p><span class="page-number">{fm:pageNumber(page.paginator.currentIndex, page.paginator.total)}</span></p>
+    {/if}
+
+    {#if page.paginator.next}
+    <p><a class="older-posts" href="{page.paginator.next}">{#insert older}›{/insert}</a></p>
+    {/if}
+  </ul>
+</nav>

--- a/roq-frontmatter/runtime/src/main/resources/templates/tags/seoTitle.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/tags/seoTitle.html
@@ -3,9 +3,7 @@
 
 {#if pageTitle || siteTitle}
   <!-- SEO TITLE -->
-  {#fragment title rendered=false}
-  {#if pageTitle && pageTitle ne siteTitle}{pageTitle} - {siteTitle}{#else}{siteTitle}{/if}
-  {/fragment}
+  {#fragment title rendered=false}{#if pageTitle && pageTitle ne siteTitle}{pageTitle} - {siteTitle}{#else}{siteTitle}{/if}{/fragment}
   <title>{#include $title /}</title>
   <meta name="twitter:title" content="{#include $title /}">
 {/if}


### PR DESCRIPTION
Now we have:
- `fm/pagination.html` template provided by FM
- a `fm` namespace message bundle (this can be overridden by apps right @mkouba?)
- an api to modify the data before it is consumed from a plugin (part of #152)
- add `simple-site` to deployment test to make it easier to create new tests
