### PR TITLE
Fix aliases routing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,18 @@ jobs:
       - name: Build with Maven
         run: mvn -B clean install -Dno-format
 
+  build-native:
+    name: Native Build
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: 'maven'
       - name: Build with Maven (Native)
         run: mvn -B install -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip
-        if: ${{ !startsWith(matrix.os, 'windows') }}

--- a/plugin/aliases/deployment/src/main/java/io/quarkiverse/roq/plugin/aliases/deployment/RoqPluginAliasesProcessor.java
+++ b/plugin/aliases/deployment/src/main/java/io/quarkiverse/roq/plugin/aliases/deployment/RoqPluginAliasesProcessor.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.roq.plugin.aliases.deployment;
 
+import static io.quarkiverse.roq.util.PathUtils.addTrailingSlash;
+import static io.quarkiverse.roq.util.PathUtils.prefixWithSlash;
+
 import java.util.*;
 
 import io.quarkiverse.roq.frontmatter.deployment.TemplateLink;
@@ -14,7 +17,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.vertx.core.json.JsonArray;
@@ -64,7 +66,7 @@ public class RoqPluginAliasesProcessor {
         for (Map.Entry<String, String> alias : aliasMap.entrySet()) {
             aliasesProducer.produce(new RoqFrontMatterAliasesBuildItem(alias.getKey(), alias.getValue()));
             selectedPathsProducer.produce(new SelectedPathBuildItem(
-                    alias.getKey(), null));
+                    addTrailingSlash(alias.getKey()), null));
             notFoundPageDisplayableEndpointProducer.produce(
                     new NotFoundPageDisplayableEndpointBuildItem(alias.getKey(),
                             "Roq URL alias for " + alias.getValue() + " URL."));
@@ -74,13 +76,12 @@ public class RoqPluginAliasesProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     public void createVertxRedirects(
-            HttpRootPathBuildItem httpRootPath,
             RoqFrontMatterAliasesRecorder recorder,
             BuildProducer<RouteBuildItem> routes,
             List<RoqFrontMatterAliasesBuildItem> aliases) {
         for (RoqFrontMatterAliasesBuildItem item : aliases) {
             routes.produce(RouteBuildItem.builder()
-                    .route(httpRootPath.relativePath(item.alias()))
+                    .route(prefixWithSlash(item.alias()))
                     .handler(recorder.sendRedirectPage(item.target()))
                     .build());
         }

--- a/roq-generator/runtime/src/main/java/io/quarkiverse/roq/generator/runtime/RoqGenerator.java
+++ b/roq-generator/runtime/src/main/java/io/quarkiverse/roq/generator/runtime/RoqGenerator.java
@@ -130,11 +130,12 @@ public class RoqGenerator implements Handler<RoutingContext> {
             host = httpConfiguration.host;
             port = httpConfiguration.port;
         }
-        return client().get(port, host, PathUtils.join(httpBuildTimeConfig.rootPath, path))
+        final String fullPath = PathUtils.join(httpBuildTimeConfig.rootPath, path);
+        return client().get(port, host, fullPath)
                 .send()
                 .expecting(HttpResponseExpectation.status(200))
-                .onSuccess(r -> LOGGER.debugf("Roq request completed %s", path))
-                .onFailure(t -> LOGGER.errorf("Roq request failed %s", path, t))
+                .onSuccess(r -> LOGGER.debugf("Roq request completed %s", fullPath))
+                .onFailure(t -> LOGGER.errorf("Roq request failed %s", fullPath, t))
                 .toCompletionStage();
     }
 


### PR DESCRIPTION
- root-path is already handled by the RouteBuildItem (removing it)
- we need a trailing slash on the SelectedItem to be considered as a html page


Split native build in a separate optional Job


cc @mcruzdev 