### PR TITLE
Correct bad guides link

### DIFF
--- a/roq/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/roq/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -12,7 +12,7 @@ metadata:
     - site
     - generator
     - web
-  guide: https://quarkiverse.github.io/quarkiverse-docs/roq/dev/
+  guide: https://docs.quarkiverse.io/quarkus-roq/dev/
   icon-url: "https://raw.githubusercontent.com/quarkiverse/quarkus-roq/main/docs/modules/ROOT/assets/images/roq.svg"
   categories:
     - "web"


### PR DESCRIPTION
See https://github.com/quarkusio/extensions/issues/1199

The root of the URL doesn't matter, but `s/roq/quarkus-roq` does. 