### PR TITLE
Better DataMapping logging

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-roq-data.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-roq-data.adoc
@@ -42,5 +42,22 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-data_quarkus-roq-data-log-data-beans]] [.property-path]##link:#quarkus-roq-data_quarkus-roq-data-log-data-beans[`quarkus.roq.data.log-data-beans`]##
+
+[.description]
+--
+Log data beans as info during build
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ROQ_DATA_LOG_DATA_BEANS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ROQ_DATA_LOG_DATA_BEANS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-roq-data_quarkus.roq.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-roq-data_quarkus.roq.adoc
@@ -42,5 +42,22 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-data_quarkus-roq-data-log-data-beans]] [.property-path]##link:#quarkus-roq-data_quarkus-roq-data-log-data-beans[`quarkus.roq.data.log-data-beans`]##
+
+[.description]
+--
+Log data beans as info during build
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ROQ_DATA_LOG_DATA_BEANS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ROQ_DATA_LOG_DATA_BEANS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 |===
 

--- a/roq-data/deployment/src/main/java/io/quarkiverse/roq/data/deployment/RoqDataConfig.java
+++ b/roq-data/deployment/src/main/java/io/quarkiverse/roq/data/deployment/RoqDataConfig.java
@@ -29,6 +29,12 @@ public interface RoqDataConfig {
     @WithDefault("false")
     boolean enforceBean();
 
+    /**
+     * Log data beans as info during build
+     */
+    @WithDefault("true")
+    boolean logDataBeans();
+
     static boolean isEqual(RoqDataConfig q1, RoqDataConfig q2) {
         return Objects.equals(q1.dir(), q2.dir()) && Objects.equals(q1.enforceBean(), q2.enforceBean());
     }

--- a/roq-data/deployment/src/test/java/io/quarkiverse/roq/data/test/RoqDataBindingEnforceBeanDataFileSideTest.java
+++ b/roq-data/deployment/src/test/java/io/quarkiverse/roq/data/test/RoqDataBindingEnforceBeanDataFileSideTest.java
@@ -17,9 +17,9 @@ public class RoqDataBindingEnforceBeanDataFileSideTest {
                     .add(new StringAsset("quarkus.roq.dir=src/test/roq\nquarkus.roq.data.enforce-bean=true"),
                             "application.properties"))
             .assertException(e -> {
-                assertThat(e).isInstanceOf(IllegalStateException.class)
+                assertThat(e).isInstanceOf(RuntimeException.class)
                         .hasMessageContaining(
-                                "The Roq data configuration is not valid. The data mapping and data files are not matching:")
+                                "Roq data is configured to enforce beans for data. Some data mapping and data files are not matching:")
                         .hasMessageContaining("The data file 'bar' does not match with any @DataMapping class");
             });
 

--- a/roq-data/deployment/src/test/java/io/quarkiverse/roq/data/test/RoqDataBindingEnforceBeanDataMappingSideTest.java
+++ b/roq-data/deployment/src/test/java/io/quarkiverse/roq/data/test/RoqDataBindingEnforceBeanDataMappingSideTest.java
@@ -19,9 +19,9 @@ public class RoqDataBindingEnforceBeanDataMappingSideTest {
                     .add(new StringAsset("quarkus.roq.dir=src/test/site\nquarkus.roq.data.enforce-bean=true"),
                             "application.properties"))
             .assertException(e -> {
-                assertThat(e).isInstanceOf(IllegalStateException.class)
+                assertThat(e).isInstanceOf(RuntimeException.class)
                         .hasMessageContaining(
-                                "The Roq data configuration is not valid. The data mapping and data files are not matching:")
+                                "Roq data is configured to enforce beans for data. Some data mapping and data files are not matching:")
                         .hasMessageContaining("The @DataMapping#value('why') does not match with any data file");
             });
 

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/scan/RoqFrontMatterScanProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/scan/RoqFrontMatterScanProcessor.java
@@ -45,6 +45,7 @@ import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.qute.deployment.TemplatePathBuildItem;
 import io.quarkus.qute.deployment.TemplateRootBuildItem;
 import io.quarkus.runtime.configuration.ConfigurationException;
+import io.vertx.core.http.impl.MimeMapping;
 import io.vertx.core.json.JsonObject;
 
 public class RoqFrontMatterScanProcessor {
@@ -407,7 +408,8 @@ public class RoqFrontMatterScanProcessor {
             if (theme.isPresent()) {
                 normalized = normalized.replace(":theme", theme.get());
             } else {
-                throw new ConfigurationException("Using :theme in 'layout: " + layout + " is only possible with a theme.");
+                throw new ConfigurationException(
+                        "No theme detected! Using :theme in 'layout: " + layout + " is only possible with a theme installed.");
             }
         }
 
@@ -418,11 +420,15 @@ public class RoqFrontMatterScanProcessor {
     }
 
     private static String resolveOutputExtension(Map<String, QuteMarkupSection> markups, String fileName) {
-        if (find(markups, fileName, null) == null) {
-            final String extension = getExtension(fileName);
-            if (extension == null) {
-                return "";
-            }
+        if (find(markups, fileName, null) != null) {
+            return ".html";
+        }
+        final String extension = getExtension(fileName);
+        if (extension == null) {
+            return "";
+        }
+        final String mimeTypeForExtension = MimeMapping.getMimeTypeForExtension(extension);
+        if (mimeTypeForExtension != null) {
             return "." + extension;
         }
         return ".html";


### PR DESCRIPTION
- Fix file extension for non mime-types (use html)
- Fix warn logging for missing data mapping (Fixes #240)

```
2024-11-06 14:33:15,535 INFO  [io.qua.roq.dat.dep.RoqDataBeanProcessor] (build-21) Roq data beans (* use @DataMapping to enable type-safety):
    - io.vertx.core.json.JsonObject[name=bar]*
    - io.vertx.core.json.JsonObject[name=baz]*
    - io.vertx.core.json.JsonArray[name=list]*
    - io.quarkiverse.roq.data.test.util.Foo[name=foo]
    - io.quarkiverse.roq.data.test.util.Foos[name=foos]