### PR TITLE
Add heading anchor

### DIFF
--- a/blog/pom.xml
+++ b/blog/pom.xml
@@ -16,6 +16,7 @@
         <quarkus-roq.version>999-SNAPSHOT</quarkus-roq.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
+        <quarkus.qute.web.version>3.2.2</quarkus.qute.web.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -76,7 +77,12 @@
         <dependency>
             <groupId>io.quarkiverse.qute.web</groupId>
             <artifactId>quarkus-qute-web-markdown-autolink</artifactId>
-            <version>3.2.2</version>
+            <version>${quarkus.qute.web.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.qute.web</groupId>
+            <artifactId>quarkus-qute-web-markdown-heading-anchor</artifactId>
+            <version>${quarkus.qute.web.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mvnpm</groupId>


### PR DESCRIPTION
Using `.adoc` we have the following behavior:

<img width="335" alt="image" src="https://github.com/user-attachments/assets/4b803568-04eb-424b-8b66-d4d91ac0c658" />

This pull request aims to do somtehing similar to `markdown`.

Fixes #206 

