### PR TITLE
Add test for dots in file name

### DIFF
--- a/roq/integration-tests/src/main/resources/application.properties
+++ b/roq/integration-tests/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+%no-file-slugify.site.slugify-files=false

--- a/roq/integration-tests/src/main/resources/content/posts/2010-08-05-hello-world/index.md
+++ b/roq/integration-tests/src/main/resources/content/posts/2010-08-05-hello-world/index.md
@@ -2,7 +2,7 @@
 
 Here are the links: {page.file('hello.pdf')} and {page.file('./hello.pdf')}
 
-and an images: {site.image('hello.png')} and {page.image('hello-page.png')} and  {page.image('./hello-page.png')}
+and an images: {site.image('hello.png')}, {site.image('hello.foo.png')} and {page.image('hello-page.png')} and  {page.image('./hello-page.png')}
 
 page by path: {site.page('élo you$@.html').url}
 document by path: {site.document('posts/markdown-post-k8s.md').url}

--- a/roq/integration-tests/src/test/java/io/quarkiverse/roq/RoqNoSlugifyFilesTest.java
+++ b/roq/integration-tests/src/test/java/io/quarkiverse/roq/RoqNoSlugifyFilesTest.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.roq;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@TestProfile(RoqNoSlugifyFilesTest.NoSlugifyConfig.class)
+public class RoqNoSlugifyFilesTest {
+
+    @Test
+    public void testPageDir() {
+        RestAssured.when().get("/posts/2010-08-05-hello-world").then().statusCode(200).log().ifValidationFails()
+                .body(containsString(
+                        "and an images: /images/hello.png, /images/hello.foo.png and /posts/2010-08-05-hello-world/hello-page.png and  /posts/2010-08-05-hello-world/hello-page.png"));
+        RestAssured.when().get("/images/hello.foo.png").then().statusCode(200).log().ifValidationFails();
+    }
+
+    public static class NoSlugifyConfig implements QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            return "no-file-slugify";
+        }
+    }
+
+}

--- a/roq/integration-tests/src/test/java/io/quarkiverse/roq/RoqTest.java
+++ b/roq/integration-tests/src/test/java/io/quarkiverse/roq/RoqTest.java
@@ -65,9 +65,10 @@ public class RoqTest {
                 .body(containsString(
                         "Here are the links: /posts/2010-08-05-hello-world/hello.pdf and /posts/2010-08-05-hello-world/hello.pdf"))
                 .body(containsString(
-                        "and an images: /images/hello.png and /posts/2010-08-05-hello-world/hello-page.png and  /posts/2010-08-05-hello-world/hello-page.png"))
+                        "and an images: /images/hello.png, /images/hello-foo.png and /posts/2010-08-05-hello-world/hello-page.png and  /posts/2010-08-05-hello-world/hello-page.png"))
                 .body(containsString("page by path: /lo-you/"))
                 .body(containsString("document by path: /posts/k8s-post/"));
+        RestAssured.when().get("/images/hello-foo.png").then().statusCode(200).log().ifValidationFails();
     }
 
     @Test


### PR DESCRIPTION
Closes #376 

## Handling Special Characters in Static File Names

There are two ways to handle special characters in static file names:

### 1. Slugify by Default
By default, special characters in file names are replaced with `"-"` when serving them. If you use:

```qute
page.image("something space.foo.bar")
```

It will work because `page.image` automatically slugifies the file name before searching. However, if you're not using `page.image`, you'll need to replace special characters yourself (`"something-space-foo.bar"`)

### 2. Disable Slugification (require Quarkus 3.18.1)
You can disable slugification by setting:

```properties
site.slugify-files=false
```

This keeps special characters unchanged in file names. In this mode, `page.image("something space.foo.bar")` will still work without modifications, as it adapts to the configuration automatically.

