### PR TITLE
Allow overriding "Contact me" label

### DIFF
--- a/roq-theme/default/src/main/resources/templates/partials/roq-default/sidebar-contact.html
+++ b/roq-theme/default/src/main/resources/templates/partials/roq-default/sidebar-contact.html
@@ -1,5 +1,5 @@
 <section class="contact">
-    <h3 class="contact-title">Contact me</h3>
+    <h3 class="contact-title">{site.contact-title ?: "Contact me"}</h3>
     <ul>
         {#if site.data.social-twitter??}
         <li><a href="https://twitter.com/{site.data.social-twitter}" target="_blank"><i class="fa-brands fa-twitter" aria-hidden="true"></i></a></li>


### PR DESCRIPTION
E.g. to replace with "Contact us"

Would `site.contact-title` work for you?

cc @ia3andy @melloware 