### PR TITLE
Code snippets: dark theme and no word break

### DIFF
--- a/blog/src/main/resources/web/app/main.js
+++ b/blog/src/main/resources/web/app/main.js
@@ -1,4 +1,4 @@
 import hljs from 'highlight.js';
-import 'highlight.js/scss/github.scss';
+import 'highlight.js/scss/a11y-dark.scss';
 
 hljs.highlightAll();

--- a/roq-theme/default/src/main/web/roq.scss
+++ b/roq-theme/default/src/main/web/roq.scss
@@ -68,15 +68,9 @@ pre {
     padding-right: 0;
     padding-left: 0;
     overflow: auto;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    word-break: break-all;
-    background-color: #d8d8d8;
+    white-space: pre;
+    background-color: #222;
     border-radius: 5px;
-  }
-
-  code.hljs {
-    background-color: #d8d8d8;
   }
 }
 
@@ -150,6 +144,7 @@ pre {
 }
 
 .post, .article-page, .page-content  {
+	width: 100%;
   background-color: #fff;
 }
 

--- a/roq-theme/default/src/main/web/roq.scss
+++ b/roq-theme/default/src/main/web/roq.scss
@@ -144,7 +144,7 @@ pre {
 }
 
 .post, .article-page, .page-content  {
-	width: 100%;
+  width: 100%;
   background-color: #fff;
 }
 


### PR DESCRIPTION
Fixes #404

It's mostly to fix the word-break problem mentioned in the issue.
With also a proposal to use a dark theme for hljs - that's a matter of preference of course, idk what you folks prefer

**Before:**
![image](https://github.com/user-attachments/assets/af6b3641-a832-4f79-b48a-db3646565a36)


**After:**
![image](https://github.com/user-attachments/assets/8d00eadf-69af-40fc-8543-389973c08fff)
