### PR TITLE
Add warning log for future pages

### DIFF
--- a/blog/config/application.properties
+++ b/blog/config/application.properties
@@ -1,5 +1,5 @@
 quarkus.web-bundler.dependencies.auto-import=all
-quarkus.log.category."io.quarkiverse.roq.frontmatter.deployment".level=DEBUG
+#quarkus.log.category."io.quarkiverse.roq.frontmatter.deployment".level=DEBUG
 #quarkus.log.category."io.quarkiverse.roq.generator".level=DEBUG
 quarkus.default-locale=en
 quarkus.asciidoctorj.attributes.icons=font

--- a/blog/content/posts/2025-03-21-updating-roq/index.md
+++ b/blog/content/posts/2025-03-21-updating-roq/index.md
@@ -1,0 +1,5 @@
+---
+title: "Updating Roq is very easy"
+image: https://images.unsplash.com/photo-1560092056-5669e776fc68?q=80&w=4144&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
+tags: blogging
+---

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/scan/RoqFrontMatterScanProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/scan/RoqFrontMatterScanProcessor.java
@@ -411,7 +411,11 @@ public class RoqFrontMatterScanProcessor {
             }
             ZonedDateTime date = parsePublishDate(file, fm, config.dateFormat(), config.timeZone());
             final boolean noFuture = !config.future() && (collection == null || !collection.future());
-            if (date != null && noFuture && date.isAfter(ZonedDateTime.now())) {
+            ZonedDateTime now = ZonedDateTime.now();
+            if (date != null && noFuture && date.isAfter(now)) {
+                LOGGER.warnf("Ignoring page '%s' because it's scheduled for later (%s > %s)." +
+                        " To display future articles, use -Dsite.future=true%s.", sourcePath, date, now,
+                        collection == null ? "" : " or -Dsite.collections.%s.future=true".formatted(collection.id()));
                 return;
             }
             String dateString = date.format(DateTimeFormatter.ISO_ZONED_DATE_TIME);


### PR DESCRIPTION
Fixes #429 

```
2025-03-20 11:49:01,979 WARN  [io.qua.roq.fro.dep.sca.RoqFrontMatterScanProcessor] (build-14) Ignoring page 'posts/2025-03-21-updating-roq/index.md' because it's scheduled for later ( '2025-03-21T00:00+01:00[Europe/Paris]' > '2025-03-20T11:49:01.979553+01:00[Europe/Paris]' ). 
To display future articles, use -Dsite.future=true or -Dsite.collections.posts.future=true.
```