### PR TITLE
Dev UI: always produce JsonRPCProvidersBuildItem

### DIFF
--- a/roq-generator/deployment/src/main/java/io/quarkiverse/roq/generator/deployment/RoqGeneratorProcessor.java
+++ b/roq-generator/deployment/src/main/java/io/quarkiverse/roq/generator/deployment/RoqGeneratorProcessor.java
@@ -53,7 +53,7 @@ class RoqGeneratorProcessor {
         return pageBuildItem;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {
         return new JsonRPCProvidersBuildItem(RoqGeneratorJsonRPCService.class);
     }


### PR DESCRIPTION
This is due to an upcoming change in Execution Model Validation [1] where we need the `JsonRPCProvidersBuildItem` produced always, not only in dev mode. JSON RPC providers can use execution model affecting annotations, so we need to know about them, otherwise a non-dev build would fail with an incorrect validation error.

[1] https://github.com/quarkusio/quarkus/pull/46965