### PR TITLE
[Breaking] Rename site.root-path to site.path-prefix and improve doc

### DIFF
--- a/docs/modules/ROOT/pages/_includes/quarkus-roq-frontmatter.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-roq-frontmatter.adoc
@@ -7,27 +7,6 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-root-path]] [.property-path]##link:#quarkus-roq-frontmatter_site-root-path[`site.root-path`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++site.root-path+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The root path of your site (e.g. /blog) relative the quarkus http root path. This is to be used only when the site is living next to a Quarkus application. Use `quarkus.http.root-path` for GitHub Pages relative url.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++SITE_ROOT_PATH+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++SITE_ROOT_PATH+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`/`
-
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-url]] [.property-path]##link:#quarkus-roq-frontmatter_site-url[`site.url`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++site.url+++[]
@@ -424,6 +403,29 @@ Environment variable: env_var_with_copy_button:+++SITE_COLLECTIONS__COLLECTIONS_
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++SITE_COLLECTIONS__COLLECTIONS_MAP__LAYOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-base-path]] [.property-path]##link:#quarkus-roq-frontmatter_site-base-path[`site.base-path`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++site.base-path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+*READ CAREFULLY:* +
+The root path of your site (e.g. `/blog`) should be set using `quarkus.http.root-path`. +
+This path should be relative to the Quarkus HTTP root path and is meant to be used only when the Roq site is served alongside a Quarkus application.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++SITE_BASE_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++SITE_BASE_PATH+++`
 endif::add-copy-button-to-env-var[]
 --
 |string

--- a/docs/modules/ROOT/pages/_includes/quarkus-roq-frontmatter_site.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-roq-frontmatter_site.adoc
@@ -7,27 +7,6 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-root-path]] [.property-path]##link:#quarkus-roq-frontmatter_site-root-path[`site.root-path`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++site.root-path+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The root path of your site (e.g. /blog) relative the quarkus http root path. This is to be used only when the site is living next to a Quarkus application. Use `quarkus.http.root-path` for GitHub Pages relative url.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++SITE_ROOT_PATH+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++SITE_ROOT_PATH+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`/`
-
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-url]] [.property-path]##link:#quarkus-roq-frontmatter_site-url[`site.url`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++site.url+++[]
@@ -424,6 +403,29 @@ Environment variable: env_var_with_copy_button:+++SITE_COLLECTIONS__COLLECTIONS_
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++SITE_COLLECTIONS__COLLECTIONS_MAP__LAYOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-base-path]] [.property-path]##link:#quarkus-roq-frontmatter_site-base-path[`site.base-path`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++site.base-path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+*READ CAREFULLY:* +
+The root path of your site (e.g. `/blog`) should be set using `quarkus.http.root-path`. +
+This path should be relative to the Quarkus HTTP root path and is meant to be used only when the Roq site is served alongside a Quarkus application.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++SITE_BASE_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++SITE_BASE_PATH+++`
 endif::add-copy-button-to-env-var[]
 --
 |string

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/TemplateLink.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/TemplateLink.java
@@ -84,23 +84,23 @@ public class TemplateLink {
         return slugify(title).toLowerCase();
     }
 
-    public static String pageLink(String rootPath, String template, PageLinkData data) {
-        return linkInternal(rootPath, template,
+    public static String pageLink(String basePath, String template, PageLinkData data) {
+        return linkInternal(basePath, template,
                 data.collection == null ? DEFAULT_PAGE_LINK_TEMPLATE : DEFAULT_DOC_LINK_TEMPLATE, data,
                 withBasePlaceHolders(data, null));
     }
 
-    public static String paginateLink(String rootPath, String template, PaginateLinkData data) {
-        return linkInternal(rootPath, template, DEFAULT_PAGINATE_LINK_TEMPLATE, data, withBasePlaceHolders(data, Map.of(
+    public static String paginateLink(String basePath, String template, PaginateLinkData data) {
+        return linkInternal(basePath, template, DEFAULT_PAGINATE_LINK_TEMPLATE, data, withBasePlaceHolders(data, Map.of(
                 ":page", () -> Objects.requireNonNull(data.page(), "page index is required to build the link"))));
     }
 
-    public static String link(String rootPath, String template, String defaultTemplate, LinkData data,
+    public static String link(String basePath, String template, String defaultTemplate, LinkData data,
             Map<String, Supplier<String>> placeHolders) {
-        return linkInternal(rootPath, template, defaultTemplate, data, withBasePlaceHolders(data, placeHolders));
+        return linkInternal(basePath, template, defaultTemplate, data, withBasePlaceHolders(data, placeHolders));
     }
 
-    private static String linkInternal(String rootPath, String template, String defaultTemplate,
+    private static String linkInternal(String basePath, String template, String defaultTemplate,
             LinkData data, Map<String, Supplier<String>> mapping) {
         String link = template != null ? template : defaultTemplate;
         // Replace each placeholder in the template if it exists
@@ -118,7 +118,7 @@ public class TemplateLink {
         if (link.endsWith("index") || link.endsWith("index.html")) {
             link = link.replaceAll("index(\\.html)?", "");
         }
-        return addTrailingSlashIfNoExt(removeLeadingSlash(PathUtils.join(rootPath, link)));
+        return addTrailingSlashIfNoExt(removeLeadingSlash(PathUtils.join(basePath, link)));
     }
 
 }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/data/RoqFrontMatterDataProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/data/RoqFrontMatterDataProcessor.java
@@ -48,7 +48,7 @@ public class RoqFrontMatterDataProcessor {
             JsonObject data = mergeParents(config, item, byId);
             RoqUrl url = null;
             if (item.published()) {
-                final String link = TemplateLink.pageLink(config.rootPath(),
+                final String link = TemplateLink.pageLink(config.pathPrefixOrEmpty(),
                         data.getString(LINK_KEY),
                         new TemplateLink.PageLinkData(item.info(), item.collectionId(), data));
                 url = rootUrl.resolve(link);

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/publish/RoqFrontMatterPublishProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/publish/RoqFrontMatterPublishProcessor.java
@@ -86,7 +86,7 @@ class RoqFrontMatterPublishProcessor {
                 if (i == 1) {
                     paginatedUrl = pagination.url();
                 } else {
-                    final String link = TemplateLink.paginateLink(config.rootPath(), linkTemplate,
+                    final String link = TemplateLink.paginateLink(config.pathPrefixOrEmpty(), linkTemplate,
                             new TemplateLink.PaginateLinkData(pagination.info(),
                                     paginate.collection(), Integer.toString(i), data));
                     paginatedUrl = rootUrl.resolve(link);

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/record/RoqFrontMatterInitProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/record/RoqFrontMatterInitProcessor.java
@@ -1,7 +1,5 @@
 package io.quarkiverse.roq.frontmatter.deployment.record;
 
-import static io.quarkiverse.roq.util.PathUtils.removeTrailingSlash;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -24,6 +22,7 @@ import io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterRecorder;
 import io.quarkiverse.roq.frontmatter.runtime.config.ConfiguredCollection;
 import io.quarkiverse.roq.frontmatter.runtime.config.RoqSiteConfig;
 import io.quarkiverse.roq.frontmatter.runtime.model.*;
+import io.quarkiverse.roq.util.PathUtils;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeansRuntimeInitBuildItem;
 import io.quarkus.deployment.annotations.*;
@@ -177,7 +176,7 @@ class RoqFrontMatterInitProcessor {
             return null;
         }
         return httpRootPath.routeBuilder()
-                .routeFunction(httpRootPath.relativePath(removeTrailingSlash(config.rootPath()) + "/*"),
+                .routeFunction(httpRootPath.relativePath(PathUtils.join(config.pathPrefixOrEmpty(), "/*")),
                         recorder.initializeRoute())
                 .handlerType(HandlerType.BLOCKING)
                 .handler(recorder.handler(httpRootPath.getRootPath(), roqFrontMatterOutput.allPagesByPath()))

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/TemplateLinkTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/TemplateLinkTest.java
@@ -19,7 +19,7 @@ class TemplateLinkTest {
         JsonObject frontMatter = new JsonObject().put("title", "My First Blog Post");
         final PageInfo pageInfo = createPageInfo("posts/my-first-blog-post.md", "posts/my-first-blog-post.md", true, true);
 
-        String generatedLink = pageLink("/", ":year/:month/:day/:slug", new PageLinkData(pageInfo, null, frontMatter));
+        String generatedLink = pageLink("", ":year/:month/:day/:slug", new PageLinkData(pageInfo, null, frontMatter));
         assertEquals("2024/08/27/my-first-blog-post/", generatedLink);
     }
 
@@ -28,10 +28,10 @@ class TemplateLinkTest {
         JsonObject frontMatter = new JsonObject().put("title", "My First Blog Post");
         final PageInfo pageInfo = createPageInfo("posts/my-first-blog-post.md", "posts/my-first-blog-post.md", true, true);
 
-        String generatedLink = pageLink("/", ":year/:month/:day/:slug:ext!", new PageLinkData(pageInfo, null, frontMatter));
+        String generatedLink = pageLink("", ":year/:month/:day/:slug:ext!", new PageLinkData(pageInfo, null, frontMatter));
         assertEquals("2024/08/27/my-first-blog-post.html", generatedLink);
 
-        String generatedLink2 = pageLink("/", ":year/:month/:day/:slug:ext", new PageLinkData(pageInfo, null, frontMatter));
+        String generatedLink2 = pageLink("", ":year/:month/:day/:slug:ext", new PageLinkData(pageInfo, null, frontMatter));
         assertEquals("2024/08/27/my-first-blog-post/", generatedLink2);
     }
 
@@ -40,7 +40,7 @@ class TemplateLinkTest {
         JsonObject frontMatter = new JsonObject();
         final PageInfo pageInfo = createPageInfo("foo.json", "bar/foo.json", false, false);
 
-        String generatedLink = pageLink("/", ":path:ext", new PageLinkData(pageInfo, null, frontMatter));
+        String generatedLink = pageLink("", ":path:ext", new PageLinkData(pageInfo, null, frontMatter));
         assertEquals("bar/foo.json", generatedLink);
     }
 
@@ -49,8 +49,8 @@ class TemplateLinkTest {
         JsonObject frontMatter = new JsonObject().put("title", "My First Blog Post");
         final PageInfo pageInfo = createPageInfo("posts/my-first-blog-post.html", "posts/my-first-blog-post.md", true, true);
 
-        String generatedLink = paginateLink("/", null, new PaginateLinkData(pageInfo, "posts", "3", frontMatter));
-        assertEquals("posts/page3/", generatedLink);
+        String generatedLink = paginateLink("foo", null, new PaginateLinkData(pageInfo, "posts", "3", frontMatter));
+        assertEquals("foo/posts/page3/", generatedLink);
     }
 
     private PageInfo createPageInfo(String sourcePath, String contentPath, boolean draft, boolean indexable) {

--- a/roq-frontmatter/deployment/src/test/resources/application.properties
+++ b/roq-frontmatter/deployment/src/test/resources/application.properties
@@ -2,7 +2,7 @@ quarkus.roq.resource-dir=site
 quarkus.http.root-path=/foo/
 
 site.url=https://mywebsite.com
-site.root-path=/bar/
+site.path-prefix=/bar/
 site.time-zone=UTC
 
 quarkus.log.category."io.quarkiverse.roq.frontmatter".level=DEBUG

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/config/RoqSiteConfig.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/config/RoqSiteConfig.java
@@ -26,15 +26,6 @@ public interface RoqSiteConfig {
             .of(new ConfiguredCollection("posts", false, false, false, ":theme/post"));
 
     /**
-     * The root path of your site (e.g. /blog) relative the quarkus http root path.
-     * This is to be used only when the site is living next to a Quarkus application.
-     * Use `quarkus.http.root-path` for GitHub Pages relative url.
-     */
-    @WithName("root-path")
-    @WithDefault("/")
-    String rootPath();
-
-    /**
      * the base hostname & protocol for your site, e.g. http://example.com
      */
     @WithName("url")
@@ -156,6 +147,19 @@ public interface RoqSiteConfig {
                 .map(e -> new ConfiguredCollection(e.getKey(), false, e.getValue().hidden(), e.getValue().future(),
                         e.getValue().layout().orElse(null)))
                 .toList();
+    }
+
+    /**
+     * <strong>READ CAREFULLY:</strong><br>
+     * The root path of your site (e.g. <code>/blog</code>) should be set using
+     * <code>quarkus.http.root-path</code>.<br>
+     * This path prefix should be relative to the Quarkus HTTP root path and is meant to be used
+     * only when the Roq site is served alongside a Quarkus application on a separate path.
+     */
+    Optional<String> pathPrefix();
+
+    default String pathPrefixOrEmpty() {
+        return pathPrefix().orElse("");
     }
 
     interface CollectionConfig {

--- a/roq-plugin/aliases/deployment/src/main/java/io/quarkiverse/roq/plugin/aliases/deployment/RoqPluginAliasesProcessor.java
+++ b/roq-plugin/aliases/deployment/src/main/java/io/quarkiverse/roq/plugin/aliases/deployment/RoqPluginAliasesProcessor.java
@@ -61,7 +61,7 @@ public class RoqPluginAliasesProcessor {
             }
             RoqUrl url = item.url();
             for (String alias : aliasesName) {
-                String aliasLink = TemplateLink.pageLink(config.rootPath(), alias, new TemplateLink.PageLinkData(
+                String aliasLink = TemplateLink.pageLink(config.pathPrefixOrEmpty(), alias, new TemplateLink.PageLinkData(
                         item.raw().info(), item.raw().collectionId(), item.data()));
                 aliasMap.put(aliasLink, url.absolute());
             }

--- a/roq-plugin/tagging/deployment/src/main/java/io/quarkiverse/roq/plugin/tagging/deployment/RoqPluginTaggingProcessor.java
+++ b/roq-plugin/tagging/deployment/src/main/java/io/quarkiverse/roq/plugin/tagging/deployment/RoqPluginTaggingProcessor.java
@@ -86,7 +86,7 @@ public class RoqPluginTaggingProcessor {
                 derivedCollectionProducer
                         .produce(new RoqFrontMatterPublishDerivedCollectionBuildItem(configuredCollection, e.getValue(), data));
 
-                final String link = TemplateLink.link(config.rootPath(),
+                final String link = TemplateLink.link(config.pathPrefixOrEmpty(),
                         tagging.link(),
                         DEFAULT_TAGGING_COLLECTION_LINK_TEMPLATE,
                         new PageLinkData(item.raw().info(), tagCollection, data),


### PR DESCRIPTION
Closes https://github.com/quarkiverse/quarkus-roq/issues/478

- [Breaking] Rename config `site.root-path` to `site.path-prefix`, this change should not affect anybody as it shouldn't be used in generated site (it's only for hybrid usage which is not yet tested or documented).
- Improve documentation to explain that `quarkus.http.root-path` should be used to change the Roq site base path.