### PR TITLE
Fix resource layouts

### DIFF
--- a/blog/content/docs/advanced.adoc
+++ b/blog/content/docs/advanced.adoc
@@ -284,6 +284,12 @@ TIP: Those links are also available in the Qute data to allow <<roq-url>>.
 | `my-page`, `search` or `docs/my-doc`
 
 | All
+| `:raw-path`
+| The raw file path of the page without the extension.
+| `My$`, `my car` or `été/2024`
+
+
+| All
 | `:slug`
 | The slugified title of the page, derived from the title. Defaults to the `slug` property in data, if available or using the slugified title, falling back to the file name.
 | `my-page-title`
@@ -329,6 +335,8 @@ TIP: Those links are also available in the Qute data to allow <<roq-url>>.
 | `1`, `2`
 |===
 
+
+NOTE: The slug derivation replaces all non-alphanumeric characters by `-` to make them url friendly.
 
 Default link value:
 

--- a/roq-data/deployment/src/main/java/io/quarkiverse/roq/data/deployment/RoqDataReaderProcessor.java
+++ b/roq-data/deployment/src/main/java/io/quarkiverse/roq/data/deployment/RoqDataReaderProcessor.java
@@ -233,8 +233,8 @@ public class RoqDataReaderProcessor {
                 try {
                     items.put(name, new RoqDataBuildItem(name, file, Files.readAllBytes(file), dataConverter));
                 } catch (IOException e) {
-                    throw new UncheckedIOException("Error while decoding using %s converter: %s "
-                            .formatted(filename, converter.getClass()), e);
+                    throw new UncheckedIOException("Error while reading data file: '%s'"
+                            .formatted(filename), e);
                 }
             }
         };

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/TemplateLink.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/TemplateLink.java
@@ -57,6 +57,7 @@ public class TemplateLink {
                         () -> Optional.ofNullable(data.pageInfo().date()).orElse(ZonedDateTime.now()).format(MONTH_FORMAT)),
                 Map.entry(":day",
                         () -> Optional.ofNullable(data.pageInfo().date()).orElse(ZonedDateTime.now()).format(DAY_FORMAT)),
+                Map.entry(":raw-path", () -> removeExtension(data.pageInfo().sourceFilePath())),
                 Map.entry(":path", () -> slugify(removeExtension(data.pageInfo().sourceFilePath()), true, false).toLowerCase()),
                 Map.entry(":ext",
                         () -> data.pageInfo().isHtml() ? ""

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/scan/RoqFrontMatterScanProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/scan/RoqFrontMatterScanProcessor.java
@@ -70,7 +70,6 @@ public class RoqFrontMatterScanProcessor {
     public static final String LAYOUTS_DIR = "layouts";
     public static final String THEME_LAYOUTS_DIR_PREFIX = "theme-";
     public static final String TEMPLATES_DIR = "templates";
-    public static final Pattern NON_PATH_CHAR_PATTERN = Pattern.compile("[^a-zA-Z0-9_\\\\/.\\-]");
 
     // We might need to allow plugins to contribute to this at some point
     private static final Set<String> HTML_OUTPUT_EXTENSIONS = Set.of("md", "markdown", "html", "htm", "xhtml", "asciidoc",
@@ -403,9 +402,9 @@ public class RoqFrontMatterScanProcessor {
             TemplateType type) {
         return file -> {
             String sourcePath = toUnixPath(contentDir.relativize(file).toString());
-            String normalizedPath = normalizePath(sourcePath);
-            String quteTemplatePath = ROQ_GENERATED_QUTE_PREFIX + removeExtension(normalizedPath)
-                    + resolveOutputExtension(markups, normalizedPath);
+            String cleanPath = replaceWhitespaceChars(sourcePath);
+            String quteTemplatePath = ROQ_GENERATED_QUTE_PREFIX + removeExtension(cleanPath)
+                    + resolveOutputExtension(markups, cleanPath);
             boolean published = type.isPage();
             String id = type.isPage() ? sourcePath : removeExtension(sourcePath);
             final boolean isHtml = isPageTargetHtml(file);
@@ -538,8 +537,8 @@ public class RoqFrontMatterScanProcessor {
         return new JsonObject(map);
     }
 
-    private static String normalizePath(String sourcePath) {
-        return NON_PATH_CHAR_PATTERN.matcher(sourcePath).replaceAll("-");
+    private static String replaceWhitespaceChars(String sourcePath) {
+        return sourcePath.replaceAll("\\s+", "-");
     }
 
     protected static ZonedDateTime parsePublishDate(Path file, JsonObject frontMatter, String dateFormat,

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqQuteEngineObserver.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqQuteEngineObserver.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.roq.frontmatter.runtime;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import io.quarkus.qute.EngineBuilder;
+
+@ApplicationScoped
+public class RoqQuteEngineObserver {
+
+    void configureEngine(@Observes EngineBuilder builder) {
+        builder.addParserHook(c -> {
+            if (c.getTemplateId().startsWith("layouts")) {
+                // Fixes https://github.com/quarkiverse/quarkus-roq/issues/530
+                c.addContentFilter(s -> "");
+                return;
+            }
+        });
+    }
+}

--- a/roq/integration-tests/src/main/resources/content/élo you$@.html
+++ b/roq/integration-tests/src/main/resources/content/élo you$@.html
@@ -1,1 +1,5 @@
-{site.page('élo you.html').url}
+---
+layout: test
+---
+
+<a href="{site.page('élo you$@.html').url}">link</a>

--- a/roq/integration-tests/src/main/resources/templates/layouts/test.html
+++ b/roq/integration-tests/src/main/resources/templates/layouts/test.html
@@ -1,0 +1,11 @@
+---
+layout: :theme/page
+link: /:raw-path:ext
+---
+
+This is a test layout:
+{#insert /}
+
+{#after-page}
+It should work fine
+{/}

--- a/roq/integration-tests/src/test/java/io/quarkiverse/roq/RoqTest.java
+++ b/roq/integration-tests/src/test/java/io/quarkiverse/roq/RoqTest.java
@@ -12,6 +12,15 @@ import io.restassured.RestAssured;
 public class RoqTest {
 
     @Test
+    public void testSpecialChars() {
+        RestAssured.when().get("/élo you$@").then().statusCode(200).log().ifValidationFails()
+                .body("html.head.title", equalTo("élo you$@.html - Hello, world! I'm Roq"))
+                .body(containsString("This is a test layout:"))
+                .body(containsString("href=\"/%C3%A9lo%20you$@/\""))
+                .body(containsString("It should work fine"));
+    }
+
+    @Test
     public void testErrorFilePage() {
         RestAssured.when().get("/posts/error-file").then().statusCode(500).log().ifValidationFails().body(containsString(
                 "RoqStaticFileException: Can't find file 'not-found.pdf' attached to the page"));
@@ -79,7 +88,7 @@ public class RoqTest {
                         "Here are the links: /posts/2010-08-05-hello-world/hello.pdf and /posts/2010-08-05-hello-world/hello.pdf"))
                 .body(containsString(
                         "and an images: /images/hello.png, /images/hello.foo.png and /posts/2010-08-05-hello-world/hello-page.png and  /posts/2010-08-05-hello-world/hello-page.png"))
-                .body(containsString("page by path: /lo-you/"))
+                .body(containsString("page by path: /%C3%A9lo%20you$@/"))
                 .body(containsString("document by path: /posts/k8s-post/"));
         RestAssured.when().get("/images/hello.foo.png").then().statusCode(200).log().ifValidationFails();
     }


### PR DESCRIPTION
Fixes #530 


This also introduce the way to use `:raw-path` in `link` allowing special characters in page names (based on the file name)..