### PR TITLE
trim unnecssary jbang arguments

### DIFF
--- a/docs/modules/ROOT/pages/quarkus-roq-generator.adoc
+++ b/docs/modules/ROOT/pages/quarkus-roq-generator.adoc
@@ -23,7 +23,7 @@ TIP: When used within the Roq Static Site Generator extension, it is already pre
 You can now try or deploy your static website with any static file server. We provide a small tool to try it:
 [source,shell]
 ----
-$ jbang app install --verbose --fresh --force roq@quarkiverse/quarkus-roq
+$ jbang app install --fresh roq@quarkiverse/quarkus-roq
 $ roq                                                                                                                         decks->!+(ia3andy/decks)
 Serving: target/roq/
 Server started on port http://localhost:8181


### PR DESCRIPTION
removing --verbose as otherwise you get lots of noise and will miss the question to trust roq.

removing --force because its only needed if you already installed roq - and jbang will tell user to run with --force if needed and it should be users choice.