### PR TITLE
[Breaking] Better ignored files

### DIFF
--- a/blog/content/docs/_includes/configs/quarkus-roq-frontmatter.adoc
+++ b/blog/content/docs/_includes/configs/quarkus-roq-frontmatter.adoc
@@ -59,7 +59,9 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The ignored files in the site directory. Supports glob expressions.
+Add new ignored files to the default list. The ignored files (relative to the site directory).
+
+Only the `content/`, `public/`, and `static/` directories are scanned.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -70,7 +72,36 @@ Environment variable: `+++SITE_IGNORED_FILES+++`
 endif::add-copy-button-to-env-var[]
 --
 |list of string
-|`&#42;&#42;/_&#42;&#42;,_&#42;&#42;,.&#42;&#42;,&#42;&#42;/.&#42;&#42;`
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-default-ignored-files]] [.property-path]##link:#quarkus-roq-frontmatter_site-default-ignored-files[`site.default-ignored-files`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++site.default-ignored-files+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The default ignored files (relative to the site directory) include:
+
+ - `.DS_Store`
+ - `Thumbs.db`
+ - All files or directories starting with an underscore (`_`)
+
+
+
+Only the `content/`, `public/`, and `static/` directories are scanned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++SITE_DEFAULT_IGNORED_FILES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++SITE_DEFAULT_IGNORED_FILES+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|``**.DS_Store,**Thumbs.db,**/_**,_**``
 
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-escaped-pages]] [.property-path]##link:#quarkus-roq-frontmatter_site-escaped-pages[`site.escaped-pages`]##
 ifdef::add-copy-button-to-config-props[]

--- a/blog/content/docs/_includes/configs/quarkus-roq-frontmatter_site.adoc
+++ b/blog/content/docs/_includes/configs/quarkus-roq-frontmatter_site.adoc
@@ -59,7 +59,9 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The ignored files in the site directory. Supports glob expressions.
+Add new ignored files to the default list. The ignored files (relative to the site directory).
+
+Only the `content/`, `public/`, and `static/` directories are scanned.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -70,7 +72,36 @@ Environment variable: `+++SITE_IGNORED_FILES+++`
 endif::add-copy-button-to-env-var[]
 --
 |list of string
-|`&#42;&#42;/_&#42;&#42;,_&#42;&#42;,.&#42;&#42;,&#42;&#42;/.&#42;&#42;`
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-default-ignored-files]] [.property-path]##link:#quarkus-roq-frontmatter_site-default-ignored-files[`site.default-ignored-files`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++site.default-ignored-files+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The default ignored files (relative to the site directory) include:
+
+ - `.DS_Store`
+ - `Thumbs.db`
+ - All files or directories starting with an underscore (`_`)
+
+
+
+Only the `content/`, `public/`, and `static/` directories are scanned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++SITE_DEFAULT_IGNORED_FILES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++SITE_DEFAULT_IGNORED_FILES+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|``**.DS_Store,**Thumbs.db,**/_**,_**``
 
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-escaped-pages]] [.property-path]##link:#quarkus-roq-frontmatter_site-escaped-pages[`site.escaped-pages`]##
 ifdef::add-copy-button-to-config-props[]

--- a/blog/content/docs/advanced.adoc
+++ b/blog/content/docs/advanced.adoc
@@ -518,6 +518,12 @@ Search has also been improved:
 
 * Make sure your style is still valid with the new search result dom.
 
+Ignored files:
+
+* `site.ignored-files` now *extends* `site.default-ignored-files` instead of replacing it.
+The default ignore list was updated to allow files starting with `.` (except `DS_Store` and `Thumbs.db`).
+Check your config to ensure it still works as expected.
+
 == Site Configuration
 
 Site configuration is done in `config/application.properties` (or `src/main/resources/application.properties`):

--- a/docs/modules/ROOT/pages/_includes/quarkus-roq-frontmatter.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-roq-frontmatter.adoc
@@ -59,7 +59,9 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The ignored files in the site directory. Supports glob expressions.
+Add new ignored files to the default list. The ignored files (relative to the site directory).
+
+Only the `content/`, `public/`, and `static/` directories are scanned.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -70,7 +72,36 @@ Environment variable: `+++SITE_IGNORED_FILES+++`
 endif::add-copy-button-to-env-var[]
 --
 |list of string
-|`&#42;&#42;/_&#42;&#42;,_&#42;&#42;,.&#42;&#42;,&#42;&#42;/.&#42;&#42;`
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-default-ignored-files]] [.property-path]##link:#quarkus-roq-frontmatter_site-default-ignored-files[`site.default-ignored-files`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++site.default-ignored-files+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The default ignored files (relative to the site directory) include:
+
+ - `.DS_Store`
+ - `Thumbs.db`
+ - All files or directories starting with an underscore (`_`)
+
+
+
+Only the `content/`, `public/`, and `static/` directories are scanned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++SITE_DEFAULT_IGNORED_FILES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++SITE_DEFAULT_IGNORED_FILES+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|``**.DS_Store,**Thumbs.db,**/_**,_**``
 
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-escaped-pages]] [.property-path]##link:#quarkus-roq-frontmatter_site-escaped-pages[`site.escaped-pages`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/_includes/quarkus-roq-frontmatter_site.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-roq-frontmatter_site.adoc
@@ -59,7 +59,9 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The ignored files in the site directory. Supports glob expressions.
+Add new ignored files to the default list. The ignored files (relative to the site directory).
+
+Only the `content/`, `public/`, and `static/` directories are scanned.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -70,7 +72,36 @@ Environment variable: `+++SITE_IGNORED_FILES+++`
 endif::add-copy-button-to-env-var[]
 --
 |list of string
-|`&#42;&#42;/_&#42;&#42;,_&#42;&#42;,.&#42;&#42;,&#42;&#42;/.&#42;&#42;`
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-default-ignored-files]] [.property-path]##link:#quarkus-roq-frontmatter_site-default-ignored-files[`site.default-ignored-files`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++site.default-ignored-files+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The default ignored files (relative to the site directory) include:
+
+ - `.DS_Store`
+ - `Thumbs.db`
+ - All files or directories starting with an underscore (`_`)
+
+
+
+Only the `content/`, `public/`, and `static/` directories are scanned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++SITE_DEFAULT_IGNORED_FILES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++SITE_DEFAULT_IGNORED_FILES+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|``**.DS_Store,**Thumbs.db,**/_**,_**``
 
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-escaped-pages]] [.property-path]##link:#quarkus-roq-frontmatter_site-escaped-pages[`site.escaped-pages`]##
 ifdef::add-copy-button-to-config-props[]

--- a/roq-frontmatter/deployment/pom.xml
+++ b/roq-frontmatter/deployment/pom.xml
@@ -80,6 +80,12 @@
             <artifactId>quarkus-rest-qute</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/scan/RoqFrontMatterScanProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/scan/RoqFrontMatterScanProcessor.java
@@ -681,7 +681,13 @@ public class RoqFrontMatterScanProcessor {
     }
 
     private static Predicate<Path> isFileExcluded(Path siteDir, RoqSiteConfig config) {
-        return path -> config.ignoredFiles().stream()
+        List<String> ignored = new ArrayList<>(config.defaultIgnoredFiles());
+        config.ignoredFiles().ifPresent(ignored::addAll);
+        return isFileExcluded(siteDir, ignored);
+    }
+
+    static Predicate<Path> isFileExcluded(Path siteDir, List<String> ignoredFiles) {
+        return path -> ignoredFiles.stream()
                 .anyMatch(s -> path.getFileSystem().getPathMatcher("glob:" + s).matches(siteDir.relativize(path)));
     }
 

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/scan/RoqFrontMatterScanProcessorTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/scan/RoqFrontMatterScanProcessorTest.java
@@ -1,0 +1,85 @@
+package io.quarkiverse.roq.frontmatter.deployment.scan;
+
+import static io.quarkiverse.roq.frontmatter.deployment.scan.RoqFrontMatterScanProcessor.isFileExcluded;
+import static org.assertj.core.api.Assertions.*;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RoqFrontMatterScanProcessorTest {
+
+    private Path siteDir;
+
+    @BeforeEach
+    void setUp() {
+        siteDir = Paths.get("/site");
+    }
+
+    @Test
+    void shouldMatchDotDSStoreAnywhere() {
+        Predicate<Path> predicate = isFileExcluded(siteDir, List.of("**.DS_Store"));
+
+        assertThat(predicate.test(Paths.get("/site/.DS_Store"))).isTrue();
+        assertThat(predicate.test(Paths.get("/site/assets/.DS_Store"))).isTrue();
+        assertThat(predicate.test(Paths.get("/site/.hidden/.DS_Store"))).isTrue();
+        assertThat(predicate.test(Paths.get("/site/index.html"))).isFalse();
+    }
+
+    @Test
+    void shouldMatchThumbsDbAnywhere() {
+        Predicate<Path> predicate = isFileExcluded(siteDir, List.of("**Thumbs.db", "**Thumbs.db"));
+
+        assertThat(predicate.test(Paths.get("/site/Thumbs.db"))).isTrue();
+        assertThat(predicate.test(Paths.get("/site/images/Thumbs.db"))).isTrue();
+    }
+
+    @Test
+    void shouldMatchFilesInGitDirectory() {
+        Predicate<Path> predicate = isFileExcluded(siteDir, List.of(".git/**"));
+
+        assertThat(predicate.test(Paths.get("/site/.git/config"))).isTrue();
+        assertThat(predicate.test(Paths.get("/site/.git/objects/abc"))).isTrue();
+        assertThat(predicate.test(Paths.get("/site/git/.config"))).isFalse();
+    }
+
+    @Test
+    void shouldNotMatchNestedNodeModules() {
+        Predicate<Path> predicate = isFileExcluded(siteDir, List.of("**node_modules/**"));
+
+        assertThat(predicate.test(Paths.get("/site/node_modules/lodash.js"))).isTrue();
+        assertThat(predicate.test(Paths.get("/site/src/node_modules/lodash.js"))).isTrue();
+    }
+
+    @Test
+    void shouldMatchMultiplePatterns() {
+        Predicate<Path> predicate = isFileExcluded(siteDir, List.of("**.DS_Store", "**Thumbs.db"));
+
+        assertThat(predicate.test(Paths.get("/site/assets/.DS_Store"))).isTrue();
+        assertThat(predicate.test(Paths.get("/site/assets/Thumbs.db"))).isTrue();
+        assertThat(predicate.test(Paths.get("/site/assets/image.png"))).isFalse();
+    }
+
+    @Test
+    void shouldMatchGlobOnRelativePath() {
+        Predicate<Path> predicate = isFileExcluded(siteDir, List.of("assets/**"));
+
+        assertThat(predicate.test(Paths.get("/site/assets/css/style.css"))).isTrue();
+        assertThat(predicate.test(Paths.get("/site/assets/script.js"))).isTrue();
+        assertThat(predicate.test(Paths.get("/site/scripts/script.js"))).isFalse();
+    }
+
+    @Test
+    void shouldThrowIfPathNotInsideSiteDir() {
+        Predicate<Path> predicate = isFileExcluded(siteDir, List.of("**.tmp"));
+
+        assertThatThrownBy(() -> predicate.test(Paths.get("tmp/foo.tmp")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("'other' is different type of Path");
+    }
+
+}

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/config/RoqSiteConfig.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/config/RoqSiteConfig.java
@@ -21,7 +21,8 @@ public interface RoqSiteConfig {
     String CONTENT_DIR = "content";
     String STATIC_DIR = "static";
     String PUBLIC_DIR = "public";
-    String IGNORED_FILES = "**/_**,_**,.**,**/.**";
+    String IGNORED_FILES = "**.DS_Store,**Thumbs.db,**/_**,_**";
+
     List<ConfiguredCollection> DEFAULT_COLLECTIONS = List
             .of(new ConfiguredCollection("posts", false, false, false, ":theme/post"));
 
@@ -42,12 +43,31 @@ public interface RoqSiteConfig {
     int routeOrder();
 
     /**
-     * The ignored files in the site directory.
-     * Supports glob expressions.
+     * Add new ignored files to the default list.
+     *
+     * The ignored files (relative to the site directory).
+     *
+     * <p>
+     * Only the <code>content/</code>, <code>public/</code>, and <code>static/</code> directories are scanned.
+     * </p>
+     */
+    Optional<List<String>> ignoredFiles();
+
+    /**
+     * The default ignored files (relative to the site directory) include:
+     * <ul>
+     * <li><code>.DS_Store</code></li>
+     * <li><code>Thumbs.db</code></li>
+     * <li>All files or directories starting with an underscore (<code>_</code>)</li>
+     * </ul>
+     *
+     * <p>
+     * Only the <code>content/</code>, <code>public/</code>, and <code>static/</code> directories are scanned.
+     * </p>
      */
     @WithDefault(IGNORED_FILES)
-    @ConfigDocDefault("&#42;&#42;/_&#42;&#42;,_&#42;&#42;,.&#42;&#42;,&#42;&#42;/.&#42;&#42;")
-    List<String> ignoredFiles();
+    @ConfigDocDefault("`**.DS_Store,**Thumbs.db,**/_**,_**`")
+    List<String> defaultIgnoredFiles();
 
     /**
      * Pages whose content should be escaped&mdash;


### PR DESCRIPTION
`site.ignored-files` now *extends* `site.default-ignored-files` instead of replacing it.
The default ignore list was updated to allow files starting with `.` (except `DS_Store` and `Thumbs.db`).
Check your config to ensure it still works as expected.