### PR TITLE
feat: configurable list of social brands via data

### DIFF
--- a/roq-theme/default/src/main/java/SocialBrands.java
+++ b/roq-theme/default/src/main/java/SocialBrands.java
@@ -1,0 +1,25 @@
+import io.quarkus.qute.TemplateGlobal;
+import java.util.List;
+import java.util.Map;
+
+@TemplateGlobal
+public class SocialBrands {
+
+    public static List<Map<String, String>> brands = List.of(
+            Map.of(
+                    "id", "twitter",
+                    "icon", "fa-brands fa-twitter",
+                    "url", "https://twitter.com/quarkusio"
+            ),
+            Map.of(
+                    "id", "github",
+                    "icon", "fa-brands fa-github",
+                    "url", "https://github.com/quarkiverse/quarkus-roq"
+            ),
+            Map.of(
+                    "id", "linkedin",
+                    "icon", "fa-brands fa-linkedin",
+                    "url", "https://linkedin.com/in/quarkusio"
+            )
+    );
+}

--- a/roq-theme/default/src/main/resources/templates/partials/roq-default/sidebar-contact.html
+++ b/roq-theme/default/src/main/resources/templates/partials/roq-default/sidebar-contact.html
@@ -1,35 +1,12 @@
 <section class="contact">
     <h3 class="contact-title">{roq_theme:contact_title}</h3>
     <ul>
-        {#if site.data.social-twitter??}
-        <li><a href="https://twitter.com/{site.data.social-twitter}" target="_blank"><i class="fa-brands fa-twitter" aria-hidden="true"></i></a></li>
-        {/if}
-        {#if site.data.social-bluesky??}
-        <li><a href="https://bsky.app/profile/{site.data.social-bluesky}" target="_blank"><i class="fa-brands fa-bluesky"></i></a></li>
-        {/if}
-        {#if site.data.social-mastodon??}
-        <li><a href="{site.data.social-mastodon}" rel="me" target="_blank"><i class="fa-brands fa-mastodon"></i></a></li>
-        {/if}
-        {#if site.data.social-facebook??}
-        <li><a href="https://facebook.com/{site.data.social-facebook}" target="_blank"><i class="fa-brands fa-facebook" aria-hidden="true"></i></a></li>
-        {/if}
-        {#if site.data.social-github??}
-        <li><a href="https://github.com/{site.data.social-github}" target="_blank"><i class="fa-brands fa-github" aria-hidden="true"></i></a></li>
-        {/if}
-        {#if site.data.social-linkedin??}
-        <li><a href="https://in.linkedin.com/in/{site.data.social-linkedin}" target="_blank"><i class="fa-brands fa-linkedin" aria-hidden="true"></i></a></li>
-        {/if}
-        {#if site.data.social-slack??}
-        <li><a href="{site.data.social-slack}" target="_blank"><i class="fa-brands fa-slack" aria-hidden="true"></i></a></li>
-        {/if}
-        {#if site.data.social-email??}
-        <li><a href="mailto:{site.data.social-email}"><i class="fa fa-envelope" aria-hidden="true"></i></a></li>
-        {/if}
-        {#if site.data.social-discord??}
-        <li><a href="{site.data.social-discord}" target="_blank"><i class="fa-brands fa-discord" aria-hidden="true"></i></a></li>
-        {/if}
-        {#if site.data.social-youtube??}
-        <li><a href="{site.data.social-youtube}" target="_blank"><i class="fa-brands fa-youtube" aria-hidden="true"></i></a></li>
-        {/if}
+        {#for brand in brands}
+        <li>
+            <a href="{brand.url}" target="_blank">
+                <i class="{brand.icon}" aria-hidden="true"></i>
+            </a>
+        </li>
+        {/for}
     </ul>
 </section>


### PR DESCRIPTION
This PR implements a configurable list of social brands in the sidebar-contact.html using the @TemplateGlobal strategy, as suggested in the issue discussion.

Each brand's configuration (id and icon) is now defined in a global Java class, and the template dynamically builds the correct URL using site.data.

This avoids hardcoding HTML blocks and allows easier customization via site.data.