### PR TITLE
Fix and test for partials and tags issue in site dir

### DIFF
--- a/blog/src/test/java/io/quarkiverse/roq/it/RoqBlogTest.java
+++ b/blog/src/test/java/io/quarkiverse/roq/it/RoqBlogTest.java
@@ -22,7 +22,8 @@ public class RoqBlogTest {
                 .everything().body(containsString(
                         TITLE))
                 .body(containsString(DESCRIPTION)).body(containsString("minute(s) read"))
-                .body(containsString("Page 1 of")).body(containsString("&copy; ROQ"));
+                .body(containsString("Page 1 of")).body(containsString("&copy; ROQ"))
+                .body(containsString("<a href=\"https://central.sonatype.com/artifact/io.quarkiverse.roq/quarkus-roq-project-parent\" rel=\"nofollow\">"));
     }
 
     @Test

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplates.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplates.java
@@ -5,8 +5,9 @@ public final class RoqTemplates {
     private RoqTemplates() {
     }
 
-    public static final String ROQ_GENERATED_QUTE_PREFIX = "roq-templates/full/";
-    public static final String ROQ_GENERATED_CONTENT_QUTE_PREFIX = "roq-templates/content/";
+    public static final String ROQ_GENERATED_QUTE_PREFIX = "roq-templates/";
+    public static final String ROQ_GENERATED_PAGE_QUTE_PREFIX = ROQ_GENERATED_QUTE_PREFIX + "full/";
+    public static final String ROQ_GENERATED_CONTENT_QUTE_PREFIX = ROQ_GENERATED_QUTE_PREFIX + "content/";
     public static final String LAYOUTS_DIR = "layouts";
     public static final String THEME_LAYOUTS_DIR_PREFIX = "theme-";
 

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/TemplateSource.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/TemplateSource.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.roq.frontmatter.runtime.model;
 
 import static io.quarkiverse.roq.frontmatter.runtime.RoqTemplates.ROQ_GENERATED_CONTENT_QUTE_PREFIX;
+import static io.quarkiverse.roq.frontmatter.runtime.RoqTemplates.ROQ_GENERATED_PAGE_QUTE_PREFIX;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqTemplates.ROQ_GENERATED_QUTE_PREFIX;
 
 import java.util.function.Function;
@@ -66,7 +67,7 @@ public record TemplateSource(
     }
 
     public String generatedQuteTemplateId() {
-        return ROQ_GENERATED_QUTE_PREFIX + generatedQuteId;
+        return isLayout() ? ROQ_GENERATED_QUTE_PREFIX + generatedQuteId : ROQ_GENERATED_PAGE_QUTE_PREFIX + generatedQuteId;
     }
 
     public String generatedQuteContentTemplateId() {


### PR DESCRIPTION
## Pull Request Overview
This PR fixes a significant template resolution issue where partials, tags, and other templates in the site directory (excluding layouts) were not being found. The fix involves restructuring the template prefix hierarchy and ensuring that non-layout templates are properly generated as resources.

## Key changes:

Refactored template prefix constants to create a hierarchical structure
Modified template ID generation to differentiate between layouts and pages
Added resource generation for templates in the site directory to make them discoverable