### PR TITLE
Allow to define the locale that will be used by Qute for rendering.

### DIFF
--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqFrontMatterRecorder.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqFrontMatterRecorder.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 import io.quarkiverse.roq.frontmatter.runtime.config.ConfiguredCollection;
 import io.quarkiverse.roq.frontmatter.runtime.config.RoqSiteConfig;
 import io.quarkiverse.roq.frontmatter.runtime.model.*;
+import io.quarkus.runtime.LocalesBuildTimeConfig;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.vertx.core.Handler;
@@ -23,10 +24,12 @@ public class RoqFrontMatterRecorder {
 
     private final VertxHttpBuildTimeConfig httpConfig;
     private final RoqSiteConfig config;
+    private final LocalesBuildTimeConfig locales;
 
-    public RoqFrontMatterRecorder(VertxHttpBuildTimeConfig httpConfig, RoqSiteConfig config) {
+    public RoqFrontMatterRecorder(VertxHttpBuildTimeConfig httpConfig, RoqSiteConfig config, LocalesBuildTimeConfig locales) {
         this.httpConfig = httpConfig;
         this.config = config;
+        this.locales = locales;
     }
 
     public Supplier<RoqCollections> createRoqCollections(
@@ -79,7 +82,7 @@ public class RoqFrontMatterRecorder {
 
     public Handler<RoutingContext> handler(String rootPath,
             Map<String, Supplier<? extends Page>> pageSuppliers) {
-        return new RoqRouteHandler(rootPath, httpConfig, pageSuppliers);
+        return new RoqRouteHandler(rootPath, httpConfig, pageSuppliers, config, locales);
     }
 
     public Handler<RoutingContext> aliasRoute(String target) {

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/config/RoqSiteConfig.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/config/RoqSiteConfig.java
@@ -166,6 +166,13 @@ public interface RoqSiteConfig {
     Optional<String> timeZone();
 
     /**
+     * The default language to use when no language is specified in the frontmatter.
+     * This language will be used as a fallback for articles that don't have a 'locale' property.
+     */
+    @WithDefault("en")
+    String defaultLocale();
+
+    /**
      * Indicates whether file names in the public directory and files attached to pages should be slugified
      * (converted to a URL-friendly format).
      *


### PR DESCRIPTION
In ascending order of importance :

1. The value of `quarkus.default-locale`
1. The value of `site.default-locale`
1. The value of the accept-header locale
1. The value of the FM `locale` attribute

See #650