### PR TITLE
Use `RequestContext.acceptableLanguages()` not request header value

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-java = "temurin-22.0.1+8"
+java = "temurin-17.0.17+10"

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqRouteHandler.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqRouteHandler.java
@@ -156,8 +156,7 @@ public class RoqRouteHandler implements Handler<RoutingContext> {
             instance.setAttribute(RoqTemplateAttributes.SITE_PATH, site.get().url().relative());
             instance.setAttribute(RoqTemplateAttributes.PAGE_URL, page.url().absolute());
             instance.setAttribute(RoqTemplateAttributes.PAGE_PATH, page.url().relative());
-            instance.setAttribute(TemplateInstance.LOCALE,
-                    getLocale(page, rc.request().getHeader(HttpHeaders.ACCEPT_LANGUAGE)));
+            instance.setAttribute(TemplateInstance.LOCALE, getLocale(page, rc));
             instance.renderAsync().whenComplete((r, t) -> {
                 if (t != null) {
                     Throwable rootCause = rootCause(t);
@@ -192,13 +191,13 @@ public class RoqRouteHandler implements Handler<RoutingContext> {
         return null;
     }
 
-    private String getLocale(Page page, String requestedLocale) {
+    private String getLocale(Page page, RoutingContext rc) {
         Object pageLocale = page.data("locale");
         if (pageLocale != null) {
             return pageLocale.toString();
         }
-        if (requestedLocale != null) {
-            return requestedLocale;
+        if (!rc.acceptableLanguages().isEmpty()) {
+            return rc.acceptableLanguages().get(0).tag();
         }
         if (config.defaultLocale() != null) {
             return config.defaultLocale();

--- a/roq-plugin/faker/deployment/pom.xml
+++ b/roq-plugin/faker/deployment/pom.xml
@@ -62,14 +62,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
We want something that looks like `en`, not like `en-US,en;q=0.5`

Also fixe mise java version.