### PR TITLE
Web Bundler 2.0 and / data mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <quarkus-qute-web.version>3.4.4</quarkus-qute-web.version>
         <asciidoctorj.version>3.0.1</asciidoctorj.version>
         <asciidoctorj-diagram.version>3.1.0</asciidoctorj-diagram.version>
-        <quarkus-web-bundler.version>2.0.0.CR7</quarkus-web-bundler.version>
+        <quarkus-web-bundler.version>2.0.0</quarkus-web-bundler.version>
         <asciidoc-java.version>1.2.12</asciidoc-java.version>
         <jandex.version>3.5.3</jandex.version>
         <jsoup.version>1.21.2</jsoup.version>

--- a/roq-data/deployment/src/main/java/io/quarkiverse/roq/data/deployment/RoqDataReaderProcessor.java
+++ b/roq-data/deployment/src/main/java/io/quarkiverse/roq/data/deployment/RoqDataReaderProcessor.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.roq.data.deployment;
 
+import static io.quarkiverse.roq.util.PathUtils.removeExtension;
+import static io.quarkiverse.roq.util.PathUtils.toUnixPath;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -226,7 +229,7 @@ public class RoqDataReaderProcessor {
             Path rootDir,
             Map<String, RoqDataBuildItem> items) {
         return file -> {
-            var name = rootDir.relativize(file).toString().replaceAll("\\..*", "").replaceAll("/", "_");
+            var name = toUnixPath(removeExtension(rootDir.relativize(file).toString()));
             if (items.containsKey(name)) {
                 throw new DataConflictException("Multiple data files found for the name: '%s'.".formatted(name));
             }

--- a/roq-data/deployment/src/test/java/io/quarkiverse/roq/data/test/RoqDataInjectableBeanLookingCustomLocationTest.java
+++ b/roq-data/deployment/src/test/java/io/quarkiverse/roq/data/test/RoqDataInjectableBeanLookingCustomLocationTest.java
@@ -28,6 +28,18 @@ public class RoqDataInjectableBeanLookingCustomLocationTest {
     JsonObject bar;
 
     @Inject
+    @Named("dir/bar")
+    JsonObject dirBar;
+
+    @Inject
+    @Named("dir/foo")
+    JsonObject dirFoo;
+
+    @Inject
+    @Named("dir")
+    JsonObject dir;
+
+    @Inject
     @Named("baz")
     JsonObject baz;
 
@@ -49,6 +61,14 @@ public class RoqDataInjectableBeanLookingCustomLocationTest {
     public void baz() {
         String fromYml = baz.getString("name");
         Assertions.assertEquals("Super Heroes from Yml custom", fromYml);
+    }
+
+    @Test
+    public void dir() {
+        Assertions.assertEquals("Super Heroes Foo from Yml in dir", dirFoo.getString("name"));
+        Assertions.assertEquals("Super Heroes Bar from Yaml in dir", dirBar.getString("name"));
+        Assertions.assertEquals("Super Heroes Foo from Yml in dir", dir.getJsonObject("foo").getString("name"));
+        Assertions.assertEquals("Super Heroes Bar from Yaml in dir", dir.getJsonObject("bar").getString("name"));
     }
 
 }

--- a/roq-data/deployment/test-data/dir/bar.yaml
+++ b/roq-data/deployment/test-data/dir/bar.yaml
@@ -1,0 +1,1 @@
+name: Super Heroes Bar from Yaml in dir

--- a/roq-data/deployment/test-data/dir/foo.yml
+++ b/roq-data/deployment/test-data/dir/foo.yml
@@ -1,0 +1,1 @@
+name: Super Heroes Foo from Yml in dir

--- a/roq-theme/resume/deployment/pom.xml
+++ b/roq-theme/resume/deployment/pom.xml
@@ -14,7 +14,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkiverse.web-bundler</groupId>
-            <artifactId>quarkus-web-bundler-tailwind-css-deployment</artifactId>
+            <artifactId>quarkus-web-bundler-tailwindcss-deployment</artifactId>
             <version>${quarkus-web-bundler.version}</version>
         </dependency>
         <dependency>

--- a/roq-theme/resume/runtime/pom.xml
+++ b/roq-theme/resume/runtime/pom.xml
@@ -14,7 +14,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkiverse.web-bundler</groupId>
-            <artifactId>quarkus-web-bundler-tailwind-css</artifactId>
+            <artifactId>quarkus-web-bundler-tailwindcss</artifactId>
             <version>${quarkus-web-bundler.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
This PR upgrades to Web Bundler 2.0 (from 2.0.0.CR7) and changes the data mapping strategy from using underscores to slashes for representing nested directory structures.

- Upgraded `quarkus-web-bundler` to version 2.0.0 and updated artifact IDs to remove hyphens (e.g., `tailwind-css` → `tailwindcss`)
- Changed data file naming convention from underscore separators to slash separators for subdirectories (e.g., `dir_foo` → `dir/foo`)
- Enhanced data bean creation to support both individual file beans and aggregated directory beans
