### PR TITLE
feat: add default Front Matter CMS configuration for Roq #427

### DIFF
--- a/blog/frontmatter.json
+++ b/blog/frontmatter.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://frontmatter.codes/frontmatter.schema.json",
+  "frontMatter.taxonomy.contentTypes": [
+    {
+      "name": "default",
+      "pageBundle": false,
+      "previewPath": "/posts",
+      "fields": [
+        {
+          "title": "Title",
+          "name": "title",
+          "type": "string"
+        },
+        {
+          "title": "Description",
+          "name": "description",
+          "type": "string"
+        },
+        {
+          "title": "Author",
+          "name": "author",
+          "type": "string"
+        },
+        {
+          "title": "Publishing date",
+          "name": "date",
+          "type": "datetime",
+          "default": "{{now}}",
+          "isPublishDate": true
+        },
+        {
+          "title": "Content preview",
+          "name": "image",
+          "type": "image"
+        },
+        {
+          "title": "Is draft ?",
+          "name": "draft",
+          "type": "draft"
+        },
+        {
+          "title": "Layout",
+          "name": "layout",
+          "type": "choice",
+          "choices": ["post", "page"],
+          "default": "post"
+        },
+        {
+          "title": "Tags",
+          "name": "tags",
+          "type": "tags"
+        }
+       
+        
+      ]
+    }
+  ],
+  "frontMatter.content.pageFolders": [
+    {
+      "title": "posts",
+      "path": "[[workspace]]/blog/content/posts"
+    }
+  ],
+  "frontMatter.framework.id": "other",
+  "frontMatter.content.publicFolder": "blog/src/main/resources/META-INF/resources",
+  "frontMatter.preview.host": "http://localhost:8080"
+}


### PR DESCRIPTION
## Description
This PR addresses #427 by providing a pre-configured `frontmatter.json` for Quarkus Roq. This allows users to manage their blog content using the Front Matter CMS extension in VS Code with zero manual setup.

## Key Changes
- **Content Registration**: Automatically maps `blog/content/posts` for the dashboard.
- **Metadata Mapping**: Defined fields for `title`, `description`, `author`, `date`, `layout`, and `image` to match Roq's frontmatter requirements.
- **Live Preview**: Configured `previewPath` and `preview.host` (localhost:8080) for real-time editing.
- **Asset Support**: Set `publicFolder` to ensure images are correctly displayed in the CMS dashboard.

## Testing
- Initialized the extension in a Roq project.
- Verified that all posts are correctly listed in the dashboard.
- Tested the "Eye" icon for live preview on localhost:8080.
- Confirmed that new content creation uses the correct `layout: post` template.


Screenshots 
<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/a0305e30-d1d4-4264-a0c2-bac5d2b00dc8" />

![Image](https://github.com/user-attachments/assets/a8e1a0a1-8d0d-4da1-ba8d-83c8e4a313eb)

![Image](https://github.com/user-attachments/assets/95d6b650-be0d-4a97-981b-2e69b075a919)
Fixes #427