### PR TITLE
Add Qute alt expression syntax support per template root

### DIFF
--- a/blog/content/about.md
+++ b/blog/content/about.md
@@ -9,7 +9,7 @@ page-class: page-alt
 
 ## Origins
 
-I wrote a [blog post]({site.url('posts/roq-with-blogs')}) explaining how it all started.
+I wrote a [blog post]({=site.url('posts/roq-with-blogs')}) explaining how it all started.
 
 ## Credits
 

--- a/blog/content/docs/advanced.adoc
+++ b/blog/content/docs/advanced.adoc
@@ -356,6 +356,21 @@ TIP: By default, url will be rendered as the path from the site root. You can al
 
 Sometimes, you want to create a link for a page without holding the variable, in this case, you can use `site.url(relativePath)` which will be automatically resolved from the site root path.
 
+== Alternative expression syntax
+
+Qute supports an alternative expression syntax where output expressions use `{=expr}` instead of `{expr}`. This makes templates safer when content contains curly braces (e.g. code samples, JSON) since only `{=...}` and `{#...}` are interpreted as Qute expressions, everything else is plain text.
+
+NOTE: This will become the default syntax for Roq in a future version.
+
+To enable it, add to your configuration:
+
+[source,properties]
+----
+quarkus.qute.alt-expr-syntax=true
+----
+
+With this enabled, templates use `{=page.title}` for expressions and `{#for ...}` / `{#include ...}` for sections (sections are unaffected). Regular `{foo}` is treated as plain text.
+
 == Escaping pages content
 
 There are cases where you might not want your page content to be parsed by Qute, to avoid conflicts with the content. You have different options:
@@ -506,6 +521,8 @@ The releases and migration info can be found xref:releases.adoc[here].
 == Site Configuration
 
 Site configuration is done in `config/application.properties` (or `src/main/resources/application.properties`):
+
+NOTE: In a multi-module Maven project, use `src/main/resources/application.properties` instead. The `config/application.properties` location is resolved relative to the JVM working directory, which may not match the module directory when building from the reactor root.
 
 
 include::../../includes/configs/quarkus-roq-frontmatter_site.adoc[]

--- a/blog/content/docs/basics.adoc
+++ b/blog/content/docs/basics.adoc
@@ -590,6 +590,10 @@ To enable llms.txt generation, create the following content files:
 
 To exclude a specific page, set `llmstxt: false` in its frontmatter.
 
+==== Loading Roq context in your AI assistant
+
+You can give your AI coding assistant full context about Roq by pointing it to https://iamroq.dev/llms.txt (or `/llms-full.txt` for complete content). This provides the project structure, quick start instructions, template syntax, and links to detailed skill files.
+
 [#variables]
 == Variables
 

--- a/blog/content/docs/getting-started.html
+++ b/blog/content/docs/getting-started.html
@@ -24,5 +24,5 @@ aliases:
 
 <div class="not-prose flex justify-center gap-4 mt-15 mb-12">
   <a href="http://localhost:8080" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">Open localhost</a>
-  <a href="{site.url('/docs/basics')}" class="btn btn-primary">Roq the basics &rarr;</a>
+  <a href="{=site.url('/docs/basics')}" class="btn btn-primary">Roq the basics &rarr;</a>
 </div>

--- a/blog/content/events.html
+++ b/blog/content/events.html
@@ -8,15 +8,15 @@ page-class: page-alt
 {#for event in cdi:events.list}
 <article class="event">
   <div class="post-date">
-    <span>{event.parsedDate.format('dd')}</span>
-    <span>{event.parsedDate.format('MMM yyyy')}</span>
+    <span>{=event.parsedDate.format('dd')}</span>
+    <span>{=event.parsedDate.format('MMM yyyy')}</span>
   </div>
 
   <div class="card event-content">
-    <h2 class="event-title">{event.title}</h2>
-    <p>{event.description}</p>
+    <h2 class="event-title">{=event.title}</h2>
+    <p>{=event.description}</p>
     {#if event.link}
-    <a href="{site.url.resolve(event.link)}">Learn more</a>
+    <a href="{=site.url.resolve(event.link)}">Learn more</a>
     {/if}
   </div>
 </article>

--- a/blog/content/index.html
+++ b/blog/content/index.html
@@ -38,7 +38,7 @@ layout: home
           <div class="rss-feed-slider" id="rssFeedSlider">
             <div class="rss-batch">
               {#for post in site.collections.get('posts')}
-              <span class="rss-line"><span class="rss-date">{post.date.format('yyyy-MM-dd')}</span> <a class="rss-title" href="{post.url}">{post.title}</a>{#if post.data.tags??} <a class="rss-tag" href="/posts/tag/{post.data.tags.asStrings.getFirst()}/">#{post.data.tags.asStrings.getFirst()}</a>{/if}</span>
+              <span class="rss-line"><span class="rss-date">{=post.date.format('yyyy-MM-dd')}</span> <a class="rss-title" href="{=post.url}">{=post.title}</a>{#if post.data.tags??} <a class="rss-tag" href="/posts/tag/{=post.data.tags.asStrings.getFirst()}/">#{=post.data.tags.asStrings.getFirst()}</a>{/if}</span>
               {/for}
             </div>
           </div>
@@ -51,11 +51,11 @@ layout: home
         {#if line.blank??}
         <span class="line">&nbsp;</span>
         {#else if line.prompt??}
-        <span class="line"><span class="prompt">{line.prompt}</span> <span class="cmd">{line.cmd}</span> {line.args??}</span>
+        <span class="line"><span class="prompt">{=line.prompt}</span> <span class="cmd">{=line.cmd}</span> {=line.args??}</span>
         {#else if line.output??}
-        <span class="line"><span class="output">{line.output}</span></span>
+        <span class="line"><span class="output">{=line.output}</span></span>
         {#else if line.success??}
-        <span class="line"><span class="success">{line.success}</span>{#if line.cursor??}<span class="cursor"></span>{/if}</span>
+        <span class="line"><span class="success">{=line.success}</span>{#if line.cursor??}<span class="cursor"></span>{/if}</span>
         {/if}
         {/for}
       </div>

--- a/blog/content/posts/2024-10-09-the-second-roq-plugin-is-for-redirecting-your-page-to-a-better-place.md
+++ b/blog/content/posts/2024-10-09-the-second-roq-plugin-is-for-redirecting-your-page-to-a-better-place.md
@@ -10,9 +10,9 @@ series: roq-plugins
 
 In the last post, we saw how easy it is to use Quarkus for static site generator (@ia3andy's was right!). I am excited to share that we now have a new plugin that allows you to set up redirects for your blog posts! For this post, I've created three aliases.
 
-- [aliases-very-cool](<{site.url('/aliases-very-cool/')}>)
-- [aliases-4-ever](<{site.url('/aliases-4-ever/')}>)
-- [aliases-again](<{site.url('/aliases-again/')}>)
+- [aliases-very-cool](<{=site.url('/aliases-very-cool/')}>)
+- [aliases-4-ever](<{=site.url('/aliases-4-ever/')}>)
+- [aliases-again](<{=site.url('/aliases-again/')}>)
 
 > If you click on at least one alias, you will be redirected here again!
 

--- a/blog/content/posts/2024-10-31-roq-with-blogs/index.md
+++ b/blog/content/posts/2024-10-31-roq-with-blogs/index.md
@@ -8,7 +8,7 @@ author: ia3andy
 
 Hello folks,
 
-First let me thanks the Roq [contributors]({site.url('about')}), they have been awesome and this has been so fun to create Roq!
+First let me thanks the Roq [contributors]({=site.url('about')}), they have been awesome and this has been so fun to create Roq!
 
 **If you want to get started quickly:**
 
@@ -57,7 +57,7 @@ At this point, I thought back on what my wife had said... maybe it was time to r
 
 🗓️ **May 7, 2024:**
 
-![Discussion with Max]({page.image('generator-runtime-discussion.png')})
+![Discussion with Max]({=page.image('generator-runtime-discussion.png')})
 
 My idea was to generate static pages at runtime… because then all of Quarkus could become static without any changes 😍.
 

--- a/blog/content/posts/2025-02-27-comparing-roq-with-hugo-jekyll-and-jbake-a-feature-breakdown/index.md
+++ b/blog/content/posts/2025-02-27-comparing-roq-with-hugo-jekyll-and-jbake-a-feature-breakdown/index.md
@@ -20,7 +20,7 @@ Here’s a feature comparison with some popular SSGs to highlight how Roq stacks
 
 ### A Quick Note About Roq
 
-Roq is highly extensible through [plugins]({site.url('/marketplace/#plugins')}), which are built as Quarkus extensions (dependencies). Key features like SEO, Search and Sitemap are already available, with more features in the works, including:
+Roq is highly extensible through [plugins]({=site.url('/marketplace/#plugins')}), which are built as Quarkus extensions (dependencies). Key features like SEO, Search and Sitemap are already available, with more features in the works, including:
 
 - Image processing ([Issue #42](https://github.com/quarkiverse/quarkus-web-bundler/issues/42))
 - Theme catalog to help get started ([Issue #270](https://github.com/quarkiverse/quarkus-roq/issues/270)). While it’s not difficult to convert themes from other SSGs to Roq, I’m working on an AI-based theme converter ([Issue #365](https://github.com/quarkiverse/quarkus-roq/issues/365)) to make this process even easier 😁.

--- a/blog/pom.xml
+++ b/blog/pom.xml
@@ -12,7 +12,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.34.2</quarkus.platform.version>
+        <quarkus.platform.version>3.35.0</quarkus.platform.version>
         <quarkus-roq.version>999-SNAPSHOT</quarkus-roq.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.5</surefire-plugin.version>

--- a/blog/src/main/resources/application.properties
+++ b/blog/src/main/resources/application.properties
@@ -1,3 +1,7 @@
+# NOTE: config is here instead of config/application.properties because
+# build-time Quarkus properties must be on the classpath to be visible
+# during multi-module reactor builds (where user.dir differs from the module directory).
+quarkus.qute.alt-expr-syntax=true
 quarkus.web-bundler.dependencies.auto-import=all
 #quarkus.log.category."io.quarkiverse.roq.frontmatter.deployment".level=DEBUG
 #quarkus.log.category."io.quarkiverse.roq.generator".level=DEBUG

--- a/blog/src/test/java/io/quarkiverse/roq/it/RoqBlogTest.java
+++ b/blog/src/test/java/io/quarkiverse/roq/it/RoqBlogTest.java
@@ -78,7 +78,7 @@ public class RoqBlogTest {
     public void testLlmsTxt() {
         RestAssured.when().get("/llms.txt").then().statusCode(200)
                 .contentType(containsString("text/plain"))
-                .body(containsString("# "))
+                .body(startsWith("## Using Roq"))
                 .body(containsString("## Posts"))
                 .body(containsString("## Pages"))
                 .body(containsString("[Welcome to Roq!]"))
@@ -89,7 +89,7 @@ public class RoqBlogTest {
     public void testLlmsFullTxt() {
         RestAssured.when().get("/llms-full.txt").then().statusCode(200)
                 .contentType(containsString("text/plain"))
-                .body(containsString("# "))
+                .body(startsWith("## Using Roq"))
                 .body(containsString("## Posts"))
                 .body(containsString("### [Welcome to Roq!]"))
                 .body(not(containsString("<div")))

--- a/blog/templates/layouts/marketplace-detail.html
+++ b/blog/templates/layouts/marketplace-detail.html
@@ -8,16 +8,16 @@ content-toc-levels: 3
 
 {#page-header}
 <section class="page-header">
-  <a href="/marketplace/#{page.data.kind}s" class="marketplace-back"><i class="fa-solid fa-arrow-left"></i> Marketplace</a>
-  <h1 class="page-title">{page.title}</h1>
+  <a href="/marketplace/#{=page.data.kind}s" class="marketplace-back"><i class="fa-solid fa-arrow-left"></i> Marketplace</a>
+  <h1 class="page-title">{=page.title}</h1>
   <div class="marketplace-detail-header">
-    <div class="marketplace-detail-icon"><i class="{page.data.icon}"></i></div>
-    <span class="marketplace-type-badge marketplace-type-{page.data.kind}">{page.data.kind}</span>
+    <div class="marketplace-detail-icon"><i class="{=page.data.icon}"></i></div>
+    <span class="marketplace-type-badge marketplace-type-{=page.data.kind}">{=page.data.kind}</span>
     {#if page.data.source??}
-    <a href="{page.data.source}" class="btn btn-link" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-github"></i> Source</a>
+    <a href="{=page.data.source}" class="btn btn-link" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-github"></i> Source</a>
     {/if}
   </div>
-  <p class="page-header-intro">{page.description}</p>
+  <p class="page-header-intro">{=page.description}</p>
 </section>
 {/page-header}
 
@@ -26,11 +26,11 @@ content-toc-levels: 3
 <div class="roq-gallery">
   {#for shot in page.data.screenshots}
   <figure>
-    <img src="{page.image(shot.source)}" alt="{shot.label}">
+    <img src="{=page.image(shot.source)}" alt="{=shot.label}">
     {#if shot.label?? || shot.description??}
     <figcaption>
-      {#if shot.label??}<strong>{shot.label}</strong>{/if}
-      {#if shot.description??}<span>{shot.description}</span>{/if}
+      {#if shot.label??}<strong>{=shot.label}</strong>{/if}
+      {#if shot.description??}<span>{=shot.description}</span>{/if}
     </figcaption>
     {/if}
   </figure>
@@ -48,16 +48,16 @@ content-toc-levels: 3
       <span class="roq-terminal-dot green"></span>
       <span class="roq-terminal-title">Terminal</span>
       {#if page.data.kind == 'theme'}
-      <button class="roq-copy-btn" title="Copy command" data-copy="roq create -x theme:{page.data.install-name}"><i class="fa-regular fa-copy"></i></button>
+      <button class="roq-copy-btn" title="Copy command" data-copy="roq create -x theme:{=page.data.install-name}"><i class="fa-regular fa-copy"></i></button>
       {#else}
-      <button class="roq-copy-btn" title="Copy command" data-copy="roq add {page.data.kind}:{page.data.install-name}"><i class="fa-regular fa-copy"></i></button>
+      <button class="roq-copy-btn" title="Copy command" data-copy="roq add {=page.data.kind}:{=page.data.install-name}"><i class="fa-regular fa-copy"></i></button>
       {/if}
     </div>
     <div class="roq-terminal-body">
       {#if page.data.kind == 'theme'}
-      <span class="line"><span class="prompt">$</span> <span class="cmd">roq</span> create -x theme:{page.data.install-name}</span>
+      <span class="line"><span class="prompt">$</span> <span class="cmd">roq</span> create -x theme:{=page.data.install-name}</span>
       {#else}
-      <span class="line"><span class="prompt">$</span> <span class="cmd">roq</span> add {page.data.kind}:{page.data.install-name}</span>
+      <span class="line"><span class="prompt">$</span> <span class="cmd">roq</span> add {=page.data.kind}:{=page.data.install-name}</span>
       {/if}
     </div>
   </div>
@@ -70,7 +70,7 @@ content-toc-levels: 3
 {#after-page}
 {#if page.data.doc??}
 <div class="marketplace-detail-links">
-  <a href="{page.data.doc}" class="btn btn-primary"><i class="fa-solid fa-book"></i> Documentation</a>
+  <a href="{=page.data.doc}" class="btn btn-primary"><i class="fa-solid fa-book"></i> Documentation</a>
 </div>
 {/if}
 {/after-page}

--- a/blog/templates/layouts/marketplace.html
+++ b/blog/templates/layouts/marketplace.html
@@ -7,7 +7,7 @@ page-class: page-alt page-wide
 
 {#page-header}
 <section class="marketplace-header">
-  <h1 class="marketplace-title">{page.title}</h1>
+  <h1 class="marketplace-title">{=page.title}</h1>
   <div class="marketplace-search">
     <i class="fa-solid fa-magnifying-glass marketplace-search-icon"></i>
     <input type="text" id="marketplace-search" placeholder="Search plugins and themes..." class="marketplace-search-input" autocomplete="off">
@@ -27,25 +27,25 @@ page-class: page-alt page-wide
 <div class="marketplace-grid" id="marketplace-grid">
   {#for item in site.collections.get('marketplace').sortBy('title', false)}
   {#if item.data.kind??}
-  <a href="{item.url}" class="card marketplace-card{#if item.image??} marketplace-card-featured{/if}" data-type="{item.data.kind}" data-tags="{#if item.data.tags??}{#for tag in item.data.tags.asStrings}{tag}{#if tag_hasNext} {/if}{/for}{/if}">
+  <a href="{=item.url}" class="card marketplace-card{#if item.image??} marketplace-card-featured{/if}" data-type="{=item.data.kind}" data-tags="{#if item.data.tags??}{#for tag in item.data.tags.asStrings}{=tag}{#if tag_hasNext} {/if}{/for}{/if}">
     <div class="marketplace-card-topbar">
-      <div class="marketplace-card-icon-wrap"><i class="{item.data.icon ?: ''}"></i></div>
-      <span class="marketplace-type-badge marketplace-type-{item.data.kind}">{item.data.kind}</span>
+      <div class="marketplace-card-icon-wrap"><i class="{=item.data.icon ?: ''}"></i></div>
+      <span class="marketplace-type-badge marketplace-type-{=item.data.kind}">{=item.data.kind}</span>
       {#if item.data.tags??}
       {#for tag in item.data.tags.asStrings}
-      <span class="marketplace-tag">{tag}</span>
+      <span class="marketplace-tag">{=tag}</span>
       {/for}
       {/if}
     </div>
     <div class="marketplace-card-lower">
       {#if item.image??}
       <div class="marketplace-card-screenshot">
-        <img src="{item.image}" alt="{item.title}">
+        <img src="{=item.image}" alt="{=item.title}">
       </div>
       {/if}
       <div class="marketplace-card-body">
-        <h3 class="marketplace-card-title">{item.title}</h3>
-        <p class="marketplace-card-desc">{item.description}</p>
+        <h3 class="marketplace-card-title">{=item.title}</h3>
+        <p class="marketplace-card-desc">{=item.description}</p>
       </div>
     </div>
   </a>

--- a/blog/templates/partials/roq-default/sidebar-about.html
+++ b/blog/templates/partials/roq-default/sidebar-about.html
@@ -1,12 +1,12 @@
 <section class="about">
   {#if site.data.logo?? || site.image}
   <div class="site-logo">
-    <a href="{site.url}"><img src="{#if site.data.logo??}{site.image(site.data.logo)}{#else}{site.image}{/if}" alt="{site.data.name}"></a>
+    <a href="{=site.url}"><img src="{#if site.data.logo??}{=site.image(site.data.logo)}{#else}{=site.image}{/if}" alt="{=site.data.name}"></a>
   </div>
   {/if}
-  <div class="site-name">{site.data.name}</div>
+  <div class="site-name">{=site.data.name}</div>
   <p class="roq-tagline">Java Static Site Generator</p>
   <div class="roq-version">
-    <a href="https://central.sonatype.com/artifact/io.quarkiverse.roq/quarkus-roq" target="_blank" rel="nofollow noopener noreferrer">{cdi:project-info.release.current-version}</a>
+    <a href="https://central.sonatype.com/artifact/io.quarkiverse.roq/quarkus-roq" target="_blank" rel="nofollow noopener noreferrer">{=cdi:project-info.release.current-version}</a>
   </div>
 </section>

--- a/blog/templates/partials/roq-default/sidebar-contact.html
+++ b/blog/templates/partials/roq-default/sidebar-contact.html
@@ -1,11 +1,11 @@
 <section class="contact">
-    <h3 class="section-title contact-title">{roq_theme:contact_title}</h3>
+    <h3 class="section-title contact-title">{=roq_theme:contact_title}</h3>
     <ul>
         {#for entry in brand.entrySet()}
         {#if site.data.get(entry.key)??}
         <li>
-            <a href="{entry.value.prefix()}{site.data.get(entry.key)}" target="_blank" rel="noopener noreferrer">
-                <i class="{entry.value.icon()}" aria-hidden="true"></i>
+            <a href="{=entry.value.prefix()}{=site.data.get(entry.key)}" target="_blank" rel="noopener noreferrer">
+                <i class="{=entry.value.icon()}" aria-hidden="true"></i>
             </a>
         </li>
         {/if}

--- a/blog/templates/partials/roq-default/sidebar-copyright.html
+++ b/blog/templates/partials/roq-default/sidebar-copyright.html
@@ -1,3 +1,3 @@
 <section class="copyright overridden">
-  <p>{now.format('Y')} &copy; {site.data.simple-name}</p>
+  <p>{=now.format('Y')} &copy; {=site.data.simple-name}</p>
 </section>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.34.3</quarkus.version>
+        <quarkus.version>3.35.0</quarkus.version>
         <quarkus-qute-web.version>3.4.5</quarkus-qute-web.version>
         <asciidoctorj.version>3.0.1</asciidoctorj.version><asciidoctorj-diagram.version>3.2.1</asciidoctorj-diagram.version>
         <quarkus-web-bundler.version>2.3.1</quarkus-web-bundler.version>

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep1ScanProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep1ScanProcessor.java
@@ -9,6 +9,7 @@ import static io.quarkiverse.tools.stringpaths.StringPaths.fileName;
 import static io.quarkiverse.tools.stringpaths.StringPaths.toUnixPath;
 import static io.quarkus.qute.deployment.TemplatePathBuildItem.ROOT_ARCHIVE_PRIORITY;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -16,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -25,6 +27,7 @@ import org.jboss.logging.Logger;
 import io.quarkiverse.roq.deployment.items.RoqProjectBuildItem;
 import io.quarkiverse.roq.frontmatter.deployment.items.assemble.RoqFrontMatterAttachment;
 import io.quarkiverse.roq.frontmatter.deployment.items.scan.FrontMatterTemplateMetadata;
+import io.quarkiverse.roq.frontmatter.deployment.items.scan.RoqFrontMatterDependencyParserConfigsBuildItem;
 import io.quarkiverse.roq.frontmatter.deployment.items.scan.RoqFrontMatterHeaderParserBuildItem;
 import io.quarkiverse.roq.frontmatter.deployment.items.scan.RoqFrontMatterQuteMarkupBuildItem;
 import io.quarkiverse.roq.frontmatter.deployment.items.scan.RoqFrontMatterScannedContentBuildItem;
@@ -43,6 +46,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.SuppressNonRuntimeConfigChangedWarningBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.qute.ParserConfig;
 import io.quarkus.qute.deployment.TemplatePathBuildItem;
 import io.quarkus.qute.deployment.TemplateRootBuildItem;
 import io.quarkus.qute.runtime.QuteConfig;
@@ -91,6 +95,60 @@ public class RoqFrontMatterStep1ScanProcessor {
         roqProject.addScannerForLocalRoqDir(scanLocalDirProducer, TEMPLATES_DIR);
     }
 
+    // ── Dependency parser config scanning ─────────────────────────────────
+
+    private static final String QUTE_CONFIG_FILE = ".qute";
+    private static final String ALT_EXPR_PROPERTY = "alt-expr-syntax";
+
+    @BuildStep
+    RoqFrontMatterDependencyParserConfigsBuildItem scanDependencyParserConfigs(
+            RoqProjectBuildItem roqProject,
+            ProjectScannerBuildItem scanner) throws IOException {
+        if (!roqProject.isActive()) {
+            return new RoqFrontMatterDependencyParserConfigsBuildItem(Map.of());
+        }
+
+        Map<Path, ParserConfig> result = new HashMap<>();
+
+        // Query .qute files from the main templates dir
+        List<ProjectFile> quteFiles = scanner.query()
+                .scopeDir(TEMPLATES_DIR)
+                .matchingGlob(QUTE_CONFIG_FILE)
+                .origin(ProjectFile.Origin.DEPENDENCY_RESOURCE)
+                .list();
+
+        // Also check the roq resource sub-dir for themes
+        if (!roqProject.isRoqResourcesInRoot()) {
+            List<ProjectFile> roqResourceQuteFiles = scanner.query()
+                    .scopeDir(roqProject.resolveRoqResourceSubDir(TEMPLATES_DIR))
+                    .matchingGlob(QUTE_CONFIG_FILE)
+                    .origin(ProjectFile.Origin.DEPENDENCY_RESOURCE)
+                    .list();
+            quteFiles = ScanQueryBuilder.mergeByScopedPath(quteFiles, roqResourceQuteFiles);
+        }
+
+        for (ProjectFile f : quteFiles) {
+            Path templateRoot = resolveTemplateRoot(f);
+            if (templateRoot == null) {
+                continue;
+            }
+            Properties props = new Properties();
+            try {
+                props.load(new ByteArrayInputStream(f.content()));
+            } catch (IOException e) {
+                LOGGER.warnf("Unable to read %s file: %s", f.file(), e);
+                continue;
+            }
+            String altExprValue = props.getProperty(ALT_EXPR_PROPERTY, "false");
+            if (Boolean.parseBoolean(altExprValue)) {
+                LOGGER.debugf("Dependency template root %s has alt-expr-syntax enabled", templateRoot);
+                result.put(templateRoot, TemplatePathBuildItem.ALT_PARSER_CONFIG);
+            }
+        }
+
+        return new RoqFrontMatterDependencyParserConfigsBuildItem(result);
+    }
+
     // ── Content scanning ─────────────────────────────────────────────────
 
     record ContentEntry(ProjectFile file, boolean isIndex, boolean isSiteIndex,
@@ -103,6 +161,7 @@ public class RoqFrontMatterStep1ScanProcessor {
             ProjectScannerBuildItem scanner,
             RoqSiteConfig config,
             QuteConfig quteConfig,
+            RoqFrontMatterDependencyParserConfigsBuildItem depParserConfigs,
             List<RoqFrontMatterQuteMarkupBuildItem> markupList,
             List<RoqFrontMatterHeaderParserBuildItem> headerParserList,
             BuildProducer<RoqFrontMatterScannedContentBuildItem> scannedContentProducer) throws IOException {
@@ -176,7 +235,8 @@ public class RoqFrontMatterStep1ScanProcessor {
 
         // Second pass: collect metadata (front matter, markup) and produce scanned build items
         for (ContentEntry entry : entries) {
-            FrontMatterTemplateMetadata metadata = collectMetadata(entry.file(), false, markupList, headerParserList);
+            FrontMatterTemplateMetadata metadata = collectMetadata(entry.file(), false, markupList, headerParserList,
+                    quteConfig, depParserConfigs.configs());
 
             LOGGER.debugf("Roq content scan producing scanned template '%s'", metadata.templateId());
             scannedContentProducer.produce(new RoqFrontMatterScannedContentBuildItem(
@@ -191,6 +251,8 @@ public class RoqFrontMatterStep1ScanProcessor {
     void scanLayouts(RoqProjectBuildItem roqProject,
             ProjectScannerBuildItem scanner,
             RoqSiteConfig config,
+            QuteConfig quteConfig,
+            RoqFrontMatterDependencyParserConfigsBuildItem depParserConfigs,
             List<RoqFrontMatterQuteMarkupBuildItem> markupList,
             List<RoqFrontMatterHeaderParserBuildItem> headerParserList,
             BuildProducer<RoqFrontMatterScannedLayoutBuildItem> scannedLayoutProducer) throws IOException {
@@ -227,7 +289,7 @@ public class RoqFrontMatterStep1ScanProcessor {
                 continue;
             }
             FrontMatterTemplateMetadata metadata = collectMetadata(file, true, markupList,
-                    headerParserList);
+                    headerParserList, quteConfig, depParserConfigs.configs());
 
             LOGGER.debugf("Roq layout scan producing scanned layout '%s'", metadata.templateId());
             scannedLayoutProducer
@@ -259,7 +321,7 @@ public class RoqFrontMatterStep1ScanProcessor {
                 continue;
             }
             FrontMatterTemplateMetadata metadata = collectMetadata(file, true, markupList,
-                    headerParserList);
+                    headerParserList, quteConfig, depParserConfigs.configs());
 
             LOGGER.debugf("Roq theme-layout scan producing scanned layout '%s'", metadata.templateId());
             scannedLayoutProducer
@@ -290,6 +352,10 @@ public class RoqFrontMatterStep1ScanProcessor {
             templateRootProducer.produce(new TemplateRootBuildItem(
                     StringPaths.join(roqProject.roqResourceDir(), TEMPLATES_DIR)));
         }
+
+        ParserConfig appParserConfig = quteConfig.altExprSyntax()
+                ? TemplatePathBuildItem.ALT_PARSER_CONFIG
+                : ParserConfig.DEFAULT;
 
         List<ProjectFile> files = scanner.query()
                 .scopeDir(TEMPLATES_DIR)
@@ -323,6 +389,7 @@ public class RoqFrontMatterStep1ScanProcessor {
                     .path(link)
                     .fullPath(file.file())
                     .content(content)
+                    .parserConfig(appParserConfig)
                     .extensionInfo(RoqFrontMatterStep6BindProcessor.FEATURE)
                     .build());
 

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep2AssembleProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep2AssembleProcessor.java
@@ -78,7 +78,8 @@ public class RoqFrontMatterStep2AssembleProcessor {
             LOGGER.debugf("Roq content processing producing raw page '%s'", processed.id());
             rawPageProducer.produce(new RoqFrontMatterRawPageBuildItem(
                     processed.templateSource(), processed.layout(), processed.data(),
-                    scanned.collection(), processed.generatedTemplate(),
+                    scanned.collection(), scanned.metadata().parserConfig(),
+                    processed.generatedTemplate(),
                     scanned.attachments()));
         }
     }
@@ -109,6 +110,7 @@ public class RoqFrontMatterStep2AssembleProcessor {
             LOGGER.debugf("Roq layout processing producing raw layout '%s'", processed.id());
             rawLayoutProducer.produce(new RoqFrontMatterRawLayoutBuildItem(
                     processed.templateSource(), processed.layout(), processed.data(),
+                    scanned.metadata().parserConfig(),
                     processed.generatedTemplate(), isThemeLayout));
         }
     }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep6BindProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep6BindProcessor.java
@@ -69,7 +69,6 @@ public class RoqFrontMatterStep6BindProcessor {
     }
 
     // Write generated Qute templates to disk and register them with the Qute engine.
-    // Each page produces two templates: "full" (with layout include) and "content" (body only).
     // Also sets up type-safe validation so Qute knows page/site variable types.
     @BuildStep
     void bindQuteTemplates(
@@ -106,6 +105,7 @@ public class RoqFrontMatterStep6BindProcessor {
                                 .fullPath(filePath)
                                 .path(item.raw().templateSource().generatedQuteTemplateId())
                                 .content(item.raw().generatedTemplate())
+                                .parserConfig(item.raw().parserConfig())
                                 .extensionInfo(FEATURE)
                                 .build());
 
@@ -126,6 +126,7 @@ public class RoqFrontMatterStep6BindProcessor {
                         .produce(TemplatePathBuildItem.builder()
                                 .path(item.raw().templateSource().generatedQuteTemplateId())
                                 .fullPath(filePath)
+                                .parserConfig(item.raw().parserConfig())
                                 .extensionInfo(FEATURE)
                                 .content(item.raw().generatedTemplate()).build());
                 layoutTemplates.add(item.raw().templateSource().generatedQuteTemplateId());

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/items/assemble/RoqFrontMatterRawLayoutBuildItem.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/items/assemble/RoqFrontMatterRawLayoutBuildItem.java
@@ -2,6 +2,7 @@ package io.quarkiverse.roq.frontmatter.deployment.items.assemble;
 
 import io.quarkiverse.roq.frontmatter.runtime.model.TemplateSource;
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.qute.ParserConfig;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -13,14 +14,22 @@ public final class RoqFrontMatterRawLayoutBuildItem extends MultiBuildItem {
     private final TemplateSource templateSource;
     private final String layout;
     private final JsonObject data;
+    private final ParserConfig parserConfig;
     private final String generatedTemplate;
     private final boolean themeLayout;
 
+    // null parserConfig defaults to ParserConfig.DEFAULT at bind time (same as TemplatePathBuildItem convention)
     public RoqFrontMatterRawLayoutBuildItem(TemplateSource templateSource, String layout, JsonObject data,
             String generatedTemplate, boolean themeLayout) {
+        this(templateSource, layout, data, null, generatedTemplate, themeLayout);
+    }
+
+    public RoqFrontMatterRawLayoutBuildItem(TemplateSource templateSource, String layout, JsonObject data,
+            ParserConfig parserConfig, String generatedTemplate, boolean themeLayout) {
         this.templateSource = templateSource;
         this.layout = layout;
         this.data = data;
+        this.parserConfig = parserConfig;
         this.generatedTemplate = generatedTemplate;
         this.themeLayout = themeLayout;
     }
@@ -39,6 +48,10 @@ public final class RoqFrontMatterRawLayoutBuildItem extends MultiBuildItem {
 
     public JsonObject data() {
         return data;
+    }
+
+    public ParserConfig parserConfig() {
+        return parserConfig;
     }
 
     public String generatedTemplate() {

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/items/assemble/RoqFrontMatterRawPageBuildItem.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/items/assemble/RoqFrontMatterRawPageBuildItem.java
@@ -5,6 +5,7 @@ import java.util.List;
 import io.quarkiverse.roq.frontmatter.runtime.config.ConfiguredCollection;
 import io.quarkiverse.roq.frontmatter.runtime.model.TemplateSource;
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.qute.ParserConfig;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -20,16 +21,25 @@ public final class RoqFrontMatterRawPageBuildItem extends MultiBuildItem {
     private final String layout;
     private final JsonObject data;
     private final ConfiguredCollection collection;
+    private final ParserConfig parserConfig;
     private final String generatedTemplate;
     private final List<RoqFrontMatterAttachment> attachments;
 
+    // null parserConfig defaults to ParserConfig.DEFAULT at bind time (same as TemplatePathBuildItem convention)
     public RoqFrontMatterRawPageBuildItem(TemplateSource templateSource, String layout, JsonObject data,
             ConfiguredCollection collection, String generatedTemplate,
+            List<RoqFrontMatterAttachment> attachments) {
+        this(templateSource, layout, data, collection, null, generatedTemplate, attachments);
+    }
+
+    public RoqFrontMatterRawPageBuildItem(TemplateSource templateSource, String layout, JsonObject data,
+            ConfiguredCollection collection, ParserConfig parserConfig, String generatedTemplate,
             List<RoqFrontMatterAttachment> attachments) {
         this.templateSource = templateSource;
         this.layout = layout;
         this.data = data;
         this.collection = collection;
+        this.parserConfig = parserConfig;
         this.generatedTemplate = generatedTemplate;
         this.attachments = attachments;
     }
@@ -56,6 +66,10 @@ public final class RoqFrontMatterRawPageBuildItem extends MultiBuildItem {
 
     public String collectionId() {
         return collection != null ? collection.id() : null;
+    }
+
+    public ParserConfig parserConfig() {
+        return parserConfig;
     }
 
     public String generatedTemplate() {

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/items/scan/FrontMatterTemplateMetadata.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/items/scan/FrontMatterTemplateMetadata.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 
 import io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterTemplateUtils;
 import io.quarkiverse.roq.frontmatter.runtime.model.SourceFile;
+import io.quarkus.qute.ParserConfig;
 
 /**
  * All file-derived information extracted at scan time.
@@ -17,5 +18,6 @@ public record FrontMatterTemplateMetadata(
         String templateId,
         String outputPath,
         boolean isHtml,
-        boolean isPartial) {
+        boolean isPartial,
+        ParserConfig parserConfig) {
 }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/items/scan/RoqFrontMatterDependencyParserConfigsBuildItem.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/items/scan/RoqFrontMatterDependencyParserConfigsBuildItem.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.roq.frontmatter.deployment.items.scan;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.qute.ParserConfig;
+
+/**
+ * Holds the pre-scanned {@link ParserConfig} for each dependency template root,
+ * derived from {@code .qute} config files found in dependency JARs.
+ */
+public final class RoqFrontMatterDependencyParserConfigsBuildItem extends SimpleBuildItem {
+
+    private final Map<Path, ParserConfig> configs;
+
+    public RoqFrontMatterDependencyParserConfigsBuildItem(Map<Path, ParserConfig> configs) {
+        this.configs = Map.copyOf(configs);
+    }
+
+    public Map<Path, ParserConfig> configs() {
+        return configs;
+    }
+}

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterScanUtils.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterScanUtils.java
@@ -34,6 +34,8 @@ import io.quarkiverse.tools.projectscanner.ProjectFile;
 import io.quarkiverse.tools.projectscanner.ProjectScannerBuildItem;
 import io.quarkiverse.tools.projectscanner.ScanQueryBuilder;
 import io.quarkiverse.tools.stringpaths.StringPaths;
+import io.quarkus.qute.ParserConfig;
+import io.quarkus.qute.deployment.TemplatePathBuildItem;
 import io.quarkus.qute.runtime.QuteConfig;
 import io.vertx.core.http.impl.MimeMapping;
 
@@ -220,6 +222,44 @@ public final class RoqFrontMatterScanUtils {
         return null;
     }
 
+    // ── Parser config resolution ──────────────────────────────────────────
+
+    /**
+     * Resolve the {@link ParserConfig} for a scanned file based on its origin.
+     * <p>
+     * For local project files and application resources, the app-level
+     * {@code quarkus.qute.alt-expr-syntax} config is used.
+     * For dependency resources (themes), the pre-scanned {@code .qute} config map is consulted.
+     */
+    public static ParserConfig resolveParserConfig(ProjectFile file, QuteConfig quteConfig,
+            Map<Path, ParserConfig> depParserConfigs) {
+        if (file.origin() != ProjectFile.Origin.DEPENDENCY_RESOURCE) {
+            return quteConfig.altExprSyntax()
+                    ? TemplatePathBuildItem.ALT_PARSER_CONFIG
+                    : ParserConfig.DEFAULT;
+        }
+        Path templateRoot = resolveTemplateRoot(file);
+        return templateRoot != null
+                ? depParserConfigs.getOrDefault(templateRoot, ParserConfig.DEFAULT)
+                : ParserConfig.DEFAULT;
+    }
+
+    /**
+     * Derive the template root directory from a ProjectFile by stripping the scopedPath from the absolute path.
+     */
+    public static Path resolveTemplateRoot(ProjectFile file) {
+        Path filePath = file.file().normalize().toAbsolutePath();
+        int scopedDepth = Path.of(file.scopedPath()).getNameCount();
+        Path root = filePath;
+        for (int i = 0; i < scopedDepth; i++) {
+            root = root.getParent();
+            if (root == null) {
+                return null;
+            }
+        }
+        return root;
+    }
+
     // ── Template metadata ────────────────────────────────────────────────
 
     /**
@@ -229,7 +269,9 @@ public final class RoqFrontMatterScanUtils {
     public static FrontMatterTemplateMetadata collectMetadata(
             ProjectFile file, boolean isLayout,
             List<RoqFrontMatterQuteMarkupBuildItem> markupList,
-            List<RoqFrontMatterHeaderParserBuildItem> headerParserList) {
+            List<RoqFrontMatterHeaderParserBuildItem> headerParserList,
+            QuteConfig quteConfig,
+            Map<Path, ParserConfig> depParserConfigs) {
 
         String referencePath = normalizeReferencePath(file.scopedPath());
         String relativePath = toUnixPath(file.indexPath());
@@ -252,8 +294,10 @@ public final class RoqFrontMatterScanUtils {
         boolean isHtml = isTemplateTargetHtml(referencePath);
         boolean isPartial = isPartialHtmlDocument(parsed.content(), isHtml);
 
+        ParserConfig parserConfig = resolveParserConfig(file, quteConfig, depParserConfigs);
+
         return new FrontMatterTemplateMetadata(file.file(), referencePath, sourceFile, markup, parsed,
-                templateId, outputPath, isHtml, isPartial);
+                templateId, outputPath, isHtml, isPartial, parserConfig);
     }
 
 }

--- a/roq-frontmatter/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/roq-frontmatter/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -224,7 +224,10 @@ paginate:
 - `page.date` — page date (`ZonedDateTime`, null for normal pages without a date; always set for collection documents)
 - `page.data` — all frontmatter data (`JsonObject`)
 - `page.data(name)` — get specific frontmatter value
-- `page.rawContent` — raw content without frontmatter or layouts
+- `page.content` — rendered inner content (without layouts), use only outside of layouts to avoid recursion
+- `page.contentAbstract` — first 75 words of rendered content (HTML stripped)
+- `page.contentAbstract(n)` — first N words of rendered content (HTML stripped)
+- `page.rawTemplate` — the raw generated Qute template for this page
 - `page.source` — page source info (`PageSource`), e.g. `page.source.isTargetHtml`
 - `page.sourcePath` — source file relative path (e.g. `posts/my-post.md`)
 - `page.sourceFileName` — file name only

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterAltSyntaxTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterAltSyntaxTest.java
@@ -1,0 +1,60 @@
+package io.quarkiverse.roq.frontmatter.deployment.apptest;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Site: {@code alt-syntax-site} (resource)
+ * <p>
+ * Config: {@code quarkus.qute.alt-expr-syntax=true}
+ * <p>
+ * Verifies that pages and layouts using {@code {=expr}} alternative
+ * expression syntax render correctly.
+ */
+@DisplayName("Roq FrontMatter - Alt expression syntax")
+public class RoqFrontMatterAltSyntaxTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.roq.resource-dir", "alt-syntax-site")
+            .overrideConfigKey("quarkus.default-locale", "en")
+            .overrideConfigKey("site.time-zone", "UTC")
+            .overrideConfigKey("quarkus.qute.alt-expr-syntax", "true")
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("alt-syntax-site"));
+
+    @Test
+    @DisplayName("Page renders with alt syntax expressions")
+    public void testPage() {
+        RestAssured.when().get("/page/alt-page").then().statusCode(200).log().ifValidationFails()
+                .body("html.head.title", equalTo("Alt Syntax Page - Alt Syntax Site"))
+                .body("html.body.article.h1", equalTo("Alt Syntax Page"))
+                .body("html.body.article.p", equalTo("Alt syntax works"))
+                .body("html.body.article.span.find { it.@class == 'literal' }.text()", equalTo("{not-evaluated}"));
+    }
+
+    @Test
+    @DisplayName("Post renders with alt syntax expressions")
+    public void testPost() {
+        RestAssured.when().get("/the-posts/alt-post").then().statusCode(200).log().ifValidationFails()
+                .body("html.head.title", equalTo("Alt Post - Alt Syntax Site"))
+                .body("html.body.article.h1", equalTo("Alt post heading"))
+                .body("html.body.article.p", equalTo("This post uses alt expression syntax."));
+    }
+
+    @Test
+    @DisplayName("Index lists posts with alt syntax")
+    public void testIndex() {
+        RestAssured.when().get("/").then().statusCode(200).log().ifValidationFails()
+                .body("html.head.title", equalTo("Alt Syntax Site - Alt Syntax Site"))
+                .body("html.body.div.h1", containsString("Alt Post"))
+                .body("html.body.span.find { it.@class == 'site-title' }.text()", equalTo("Alt Syntax Site"));
+    }
+}

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterBasicTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterBasicTest.java
@@ -117,4 +117,11 @@ public class RoqFrontMatterBasicTest {
                 .body("html.body.article.span.find { it.@class == 'has-date' }.text()", equalTo("no"));
     }
 
+    @Test
+    @DisplayName("{=expr} is literal text when alt-expr-syntax is disabled")
+    public void testAltSyntaxNotActive() {
+        RestAssured.when().get("/page/some-page").then().statusCode(200).log().ifValidationFails()
+                .body("html.body.article.span.find { it.@class == 'literal' }.text()", equalTo("{=not-alt-syntax}"));
+    }
+
 }

--- a/roq-frontmatter/deployment/src/test/resources/alt-syntax-site/content/index.html
+++ b/roq-frontmatter/deployment/src/test/resources/alt-syntax-site/content/index.html
@@ -1,0 +1,11 @@
+---
+title: Alt Syntax Site
+layout: default
+---
+
+<div>
+  {#for post in site.collections.posts}
+    <h1>{=post.title}</h1>
+  {/for}
+</div>
+<span class="site-title">{=site.title}</span>

--- a/roq-frontmatter/deployment/src/test/resources/alt-syntax-site/content/pages/alt-page.html
+++ b/roq-frontmatter/deployment/src/test/resources/alt-syntax-site/content/pages/alt-page.html
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Alt Syntax Page
+link: /page/alt-page
+some-text: Alt syntax works
+---
+
+<h1>{=page.title}</h1>
+<p>{=page.data.some-text}</p>
+<span class="literal">{not-evaluated}</span>

--- a/roq-frontmatter/deployment/src/test/resources/alt-syntax-site/content/posts/2024-10-09-alt-post.html
+++ b/roq-frontmatter/deployment/src/test/resources/alt-syntax-site/content/posts/2024-10-09-alt-post.html
@@ -1,0 +1,7 @@
+---
+layout: post
+title: Alt Post
+---
+
+<h1>Alt post heading</h1>
+<p>This post uses alt expression syntax.</p>

--- a/roq-frontmatter/deployment/src/test/resources/alt-syntax-site/templates/layouts/default.html
+++ b/roq-frontmatter/deployment/src/test/resources/alt-syntax-site/templates/layouts/default.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+{#include partials/header.html /}
+</head>
+<body>
+{#insert /}
+</body>
+</html>

--- a/roq-frontmatter/deployment/src/test/resources/alt-syntax-site/templates/layouts/page.html
+++ b/roq-frontmatter/deployment/src/test/resources/alt-syntax-site/templates/layouts/page.html
@@ -1,0 +1,7 @@
+---
+layout: default
+---
+
+<article class="page">
+  {#insert /}
+</article>

--- a/roq-frontmatter/deployment/src/test/resources/alt-syntax-site/templates/layouts/post.html
+++ b/roq-frontmatter/deployment/src/test/resources/alt-syntax-site/templates/layouts/post.html
@@ -1,0 +1,10 @@
+---
+layout: default
+link: /the-posts/:slug
+---
+{@io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage page}
+<article class="post">
+  {#insert /}
+  <span class="post-date">{=page.date}</span>
+  <span class="collection-id">{=page.collectionId}</span>
+</article>

--- a/roq-frontmatter/deployment/src/test/resources/alt-syntax-site/templates/partials/header.html
+++ b/roq-frontmatter/deployment/src/test/resources/alt-syntax-site/templates/partials/header.html
@@ -1,0 +1,1 @@
+<title>{=page.title} - {=site.title}</title>

--- a/roq-frontmatter/deployment/src/test/resources/basic-site/content/pages/some-page.html
+++ b/roq-frontmatter/deployment/src/test/resources/basic-site/content/pages/some-page.html
@@ -16,3 +16,4 @@ some-text: We can also use data
 <span class="base-file-name">{page.baseFileName}</span>
 <span class="source-file-name">{page.sourceFileName}</span>
 <span class="has-date">{#if page.date}yes{#else}no{/if}</span>
+<span class="literal">{=not-alt-syntax}</span>

--- a/roq-frontmatter/deployment/src/test/resources/draft-site/templates/layouts/post.html
+++ b/roq-frontmatter/deployment/src/test/resources/draft-site/templates/layouts/post.html
@@ -7,7 +7,7 @@
     <article>
         <h1>{page.title}</h1>
         <span class="draft-status">{page.draft}</span>
-        {page.rawContent}
+        {page.rawTemplate}
     </article>
 </body>
 </html>

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/Page.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/Page.java
@@ -44,7 +44,7 @@ public class Page {
     private final JsonObject data;
     private final PageSource source;
     private final SoftLazyValue<String> contentLazy = new SoftLazyValue<>(this::resolveContentLazy);
-    private final SoftLazyValue<String> rawContentLazy = new SoftLazyValue<>(this::resolveRawContentLazy);
+    private final SoftLazyValue<String> rawTemplateLazy = new SoftLazyValue<>(this::resolveRawTemplateLazy);
     private final ThreadLocal<Boolean> resolvingContent = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
     protected Page(RoqUrl url, PageSource source, JsonObject data) {
@@ -93,11 +93,18 @@ public class Page {
     }
 
     /**
-     * The content of the file or template, without any frontmatter header or layouts.
-     * If applicable, this includes the markup block (e.g. {@code <md>...</md>}).
+     * The raw generated Qute template for this page, including layout include directives and fragment wrappers.
      */
+    public String rawTemplate() {
+        return rawTemplateLazy.get();
+    }
+
+    /**
+     * @deprecated Use {@link #rawTemplate()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public String rawContent() {
-        return rawContentLazy.get();
+        return rawTemplate();
     }
 
     private String resolveContentLazy() {
@@ -120,7 +127,7 @@ public class Page {
         return "";
     }
 
-    private String resolveRawContentLazy() {
+    private String resolveRawTemplateLazy() {
         final String templateResource = "/templates/" + source().template().generatedQuteTemplateId();
         try (InputStream resource = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream(templateResource)) {

--- a/roq/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/roq/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -233,7 +233,10 @@ paginate:
 - `page.date` — page date (`ZonedDateTime`, null for normal pages without a date; always set for collection documents)
 - `page.data` — all frontmatter data (`JsonObject`)
 - `page.data(name)` — get specific frontmatter value
-- `page.rawContent` — raw content without frontmatter or layouts
+- `page.content` — rendered inner content (without layouts), use only outside of layouts to avoid recursion
+- `page.contentAbstract` — first 75 words of rendered content (HTML stripped)
+- `page.contentAbstract(n)` — first N words of rendered content (HTML stripped)
+- `page.rawTemplate` — the raw generated Qute template for this page
 - `page.sourcePath` — source file relative path (e.g. `posts/my-post.md`)
 - `page.sourceFileName` — file name only
 - `page.baseFileName` — file name without extension


### PR DESCRIPTION
## Summary

- Add per-template-root `ParserConfig` resolution following the spec from quarkusio/quarkus#47882
- App templates (local + application resources) use the `quarkus.qute.alt-expr-syntax` config property
- Dependency templates (themes) use `.qute` config files at their template root
- `.qute` files are scanned early via the project scanner (while JAR filesystems are mounted) and cached in a `SimpleBuildItem` for later lookup
- Convert blog templates to `{=expr}` alt syntax
- Rename `Page.rawContent()` to `Page.rawTemplate()` (old method deprecated)
- Add `page.content`, `page.contentAbstract`, `page.rawTemplate` to skill docs
- Add overloaded `RoqFrontMatterRawPageBuildItem` constructor without `parserConfig` (for plugins)
- Add `RoqFrontMatterAltSyntaxTest` covering pages, posts, and index with alt syntax
- Move blog config to `src/main/resources/application.properties` (required for multi-module reactor builds where `config/` is resolved relative to `user.dir`)
- Document multi-module config location caveat in advanced docs

Depends on quarkusio/quarkus#47882