### PR TITLE
Skip redundant resources:resources in CLI start and generate

### DIFF
--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/GenerateCommand.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/GenerateCommand.java
@@ -16,6 +16,11 @@ public class GenerateCommand extends BuildToolDelegatingCommand {
             BuildTool.GRADLE_KOTLIN_DSL, "build quarkusRun -x test");
 
     @Override
+    public void prepareMaven(BuildToolContext context) {
+        // Skip resources:resources, already part of the package lifecycle
+    }
+
+    @Override
     public Map<BuildTool, String> getActionMapping() {
         return ACTION_MAPPING;
     }

--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/StartCommand.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/StartCommand.java
@@ -16,6 +16,11 @@ public class StartCommand extends BuildToolDelegatingCommand {
     }
 
     @Override
+    public void prepareMaven(BuildToolContext context) {
+        // Skip resources:resources, dev mode handles resources itself
+    }
+
+    @Override
     public Map<BuildTool, String> getActionMapping() {
         return Map.of(
                 BuildTool.MAVEN, "quarkus:dev",


### PR DESCRIPTION
## Summary
- `BuildToolDelegatingCommand.prepareMaven()` runs `resources:resources` before the actual goal
- This is unnecessary for `start` (`quarkus:dev` handles resources itself) and `generate` (`package` already includes resources in its lifecycle)
- Override `prepareMaven()` to no-op in both `StartCommand` and `GenerateCommand`

## Test plan
- [x] `roq start --dry-run` shows only `quarkus:dev` (no `resources:resources` pre-step)
- [x] `roq generate --dry-run` shows only `package quarkus:run` (no `resources:resources` pre-step)
- [x] `roq start` launches dev mode normally
- [x] `roq generate` generates the static site normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)