### PR TITLE
Use Qute fragment for page content rendering

### DIFF
--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep2AssembleProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep2AssembleProcessor.java
@@ -79,7 +79,7 @@ public class RoqFrontMatterStep2AssembleProcessor {
             rawPageProducer.produce(new RoqFrontMatterRawPageBuildItem(
                     processed.templateSource(), processed.layout(), processed.data(),
                     scanned.collection(), processed.generatedTemplate(),
-                    processed.generatedContentTemplate(), scanned.attachments()));
+                    scanned.attachments()));
         }
     }
 

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep6BindProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep6BindProcessor.java
@@ -94,7 +94,7 @@ public class RoqFrontMatterStep6BindProcessor {
             // Produce generated Qute templates
             for (RoqFrontMatterPageTemplateBuildItem item : pageTemplatesItems) {
                 final Path filePath = roqTemplatesOutputDir
-                        .resolve("full")
+                        .resolve("content")
                         .resolve(item.raw().templateSource().generatedQuteId());
                 createTemplateResource(generatedResourceProducer, nativeImageResourceProducer, filePath,
                         item.raw().generatedTemplate(), item.raw().templateSource().generatedQuteTemplateId());
@@ -106,29 +106,9 @@ public class RoqFrontMatterStep6BindProcessor {
                                 .extensionInfo(FEATURE)
                                 .build());
 
-                // Add the template for the content
-                final Path contentFilePath = roqTemplatesOutputDir
-                        .resolve("content")
-                        .resolve(item.raw().templateSource().generatedQuteId());
-                Files.createDirectories(contentFilePath.getParent());
-                Files.writeString(contentFilePath, item.raw().generatedContentTemplate());
-                final String contentResourceName = "templates/" + item.raw().templateSource().generatedQuteContentTemplateId();
-                generatedResourceProducer
-                        .produce(new GeneratedResourceBuildItem(
-                                contentResourceName,
-                                item.raw().generatedContentTemplate().getBytes(StandardCharsets.UTF_8)));
-                nativeImageResourceProducer.produce(new NativeImageResourceBuildItem(contentResourceName));
-                templatePathProducer.produce(TemplatePathBuildItem.builder()
-                        .fullPath(contentFilePath)
-                        .path(item.raw().templateSource().generatedQuteContentTemplateId())
-                        .content(item.raw().generatedContentTemplate())
-                        .extensionInfo(FEATURE)
-                        .build());
                 if (item.raw().collection() != null) {
-                    docTemplates.add(item.raw().templateSource().generatedQuteContentTemplateId());
                     docTemplates.add(item.raw().templateSource().generatedQuteTemplateId());
                 } else {
-                    pageTemplates.add(item.raw().templateSource().generatedQuteContentTemplateId());
                     pageTemplates.add(item.raw().templateSource().generatedQuteTemplateId());
                 }
 

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/items/assemble/RoqFrontMatterRawPageBuildItem.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/items/assemble/RoqFrontMatterRawPageBuildItem.java
@@ -21,18 +21,16 @@ public final class RoqFrontMatterRawPageBuildItem extends MultiBuildItem {
     private final JsonObject data;
     private final ConfiguredCollection collection;
     private final String generatedTemplate;
-    private final String generatedContentTemplate;
     private final List<RoqFrontMatterAttachment> attachments;
 
     public RoqFrontMatterRawPageBuildItem(TemplateSource templateSource, String layout, JsonObject data,
-            ConfiguredCollection collection, String generatedTemplate, String generatedContentTemplate,
+            ConfiguredCollection collection, String generatedTemplate,
             List<RoqFrontMatterAttachment> attachments) {
         this.templateSource = templateSource;
         this.layout = layout;
         this.data = data;
         this.collection = collection;
         this.generatedTemplate = generatedTemplate;
-        this.generatedContentTemplate = generatedContentTemplate;
         this.attachments = attachments;
     }
 
@@ -62,10 +60,6 @@ public final class RoqFrontMatterRawPageBuildItem extends MultiBuildItem {
 
     public String generatedTemplate() {
         return generatedTemplate;
-    }
-
-    public String generatedContentTemplate() {
-        return generatedContentTemplate;
     }
 
     public List<RoqFrontMatterAttachment> attachments() {

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterAssembleUtils.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterAssembleUtils.java
@@ -34,8 +34,7 @@ public final class RoqFrontMatterAssembleUtils {
             TemplateSource templateSource,
             String layout,
             JsonObject data,
-            String generatedTemplate,
-            String generatedContentTemplate) {
+            String generatedTemplate) {
 
         public String id() {
             return templateSource.id();
@@ -66,7 +65,7 @@ public final class RoqFrontMatterAssembleUtils {
         }
 
         boolean escaped = Boolean.parseBoolean(data.getString(ESCAPE, "false"));
-        TransformedContent transformed = applyContentTransforms(content, escaped, metadata.markup(), layoutId);
+        TransformedContent transformed = applyContentTransforms(content, escaped, metadata.markup(), layoutId, isPage);
 
         TemplateSource source = TemplateSource.create(
                 metadata.templateId(),
@@ -80,8 +79,7 @@ public final class RoqFrontMatterAssembleUtils {
                 isSiteIndex);
 
         return new ProcessedTemplate(source, layoutId, data,
-                transformed.generatedTemplate(),
-                transformed.contentWithMarkup());
+                transformed.generatedTemplate());
     }
 
     // ── Layout helpers ──────────────────────────────────────────────────

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterLayoutUtils.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterLayoutUtils.java
@@ -2,6 +2,7 @@ package io.quarkiverse.roq.frontmatter.deployment.util;
 
 import static io.quarkiverse.roq.frontmatter.runtime.RoqTemplates.LAYOUTS_DIR;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqTemplates.ROQ_GENERATED_QUTE_PREFIX;
+import static io.quarkiverse.roq.frontmatter.runtime.RoqTemplates.ROQ_PAGE_CONTENT_FRAGMENT;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqTemplates.THEME_LAYOUTS_DIR;
 
 import java.util.Optional;
@@ -65,11 +66,20 @@ public final class RoqFrontMatterLayoutUtils {
 
     // ── Include filter ──────────────────────────────────────────────────
 
-    public static WrapperFilter getIncludeFilter(String layout) {
+    public static WrapperFilter getIncludeFilter(String layout, boolean isPage) {
         if (layout == null) {
             return WrapperFilter.EMPTY;
         }
-        String prefix = "{#include %s%s}\n".formatted(ROQ_GENERATED_QUTE_PREFIX, layout);
-        return new WrapperFilter(prefix, "\n{/include}");
+        String prefix;
+        String suffix;
+        if (isPage) {
+            prefix = "{#include %s%s}\n{#fragment %s}\n".formatted(ROQ_GENERATED_QUTE_PREFIX, layout,
+                    ROQ_PAGE_CONTENT_FRAGMENT);
+            suffix = "\n{/fragment}\n{/include}";
+        } else {
+            prefix = "{#include %s%s}\n".formatted(ROQ_GENERATED_QUTE_PREFIX, layout);
+            suffix = "\n{/include}";
+        }
+        return new WrapperFilter(prefix, suffix);
     }
 }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterTemplateUtils.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterTemplateUtils.java
@@ -117,7 +117,7 @@ public final class RoqFrontMatterTemplateUtils {
 
     // ── Content transforms ──────────────────────────────────────────────
 
-    public record TransformedContent(String generatedTemplate, String contentWithMarkup) {
+    public record TransformedContent(String generatedTemplate) {
     }
 
     static WrapperFilter getEscapeFilter(boolean escaped) {
@@ -138,12 +138,12 @@ public final class RoqFrontMatterTemplateUtils {
      * Apply escape filter, markup wrapper, and layout include to produce the final generated templates.
      */
     public static TransformedContent applyContentTransforms(String content, boolean escaped,
-            RoqFrontMatterQuteMarkupBuildItem markup, String layoutId) {
+            RoqFrontMatterQuteMarkupBuildItem markup, String layoutId, boolean isPage) {
         WrapperFilter escapeFilter = getEscapeFilter(escaped);
-        WrapperFilter includeFilter = getIncludeFilter(layoutId);
+        WrapperFilter includeFilter = getIncludeFilter(layoutId, isPage);
         String escapedContent = escapeFilter.apply(content);
         String contentWithMarkup = markup != null ? markup.toWrapperFilter().apply(escapedContent) : escapedContent;
         String generatedTemplate = includeFilter.apply(contentWithMarkup);
-        return new TransformedContent(generatedTemplate, contentWithMarkup);
+        return new TransformedContent(generatedTemplate);
     }
 }

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterBasicTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterBasicTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.roq.frontmatter.deployment.apptest;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -52,8 +53,8 @@ public class RoqFrontMatterBasicTest {
     public void testIndex() {
         RestAssured.when().get("/").then().statusCode(200).log().ifValidationFails()
                 .body("html.head.title", equalTo("Simple Site"))
-                .body("html.body.div.h1[0]", containsString("New Post"))
-                .body("html.body.div.h1[1]", containsString("Some Post"));
+                .body("html.body.div.h1[0]", containsString("Override Post"))
+                .body("html.body.div.h1[1]", containsString("New Post"));
     }
 
     @Test
@@ -82,6 +83,31 @@ public class RoqFrontMatterBasicTest {
     @DisplayName("Static image file is served")
     public void testStatic() {
         RestAssured.when().get("/images/iamroq.png").then().statusCode(200).log().ifValidationFails();
+    }
+
+    @Test
+    @DisplayName("Page can render another page's content and contentAbstract")
+    public void testPageContent() {
+        String body = RestAssured.when().get("/page/content-test").then().statusCode(200).log().ifValidationFails()
+                .extract().body().asString();
+        // Verify page.content renders the post's inner content (without layout)
+        assertTrue(body.contains("New post with html"), "Should contain post heading from content");
+        assertTrue(body.contains("This is a new post."), "Should contain post paragraph from content");
+        // Verify contentAbstract strips HTML and limits words
+        assertTrue(body.contains("post-abstract-"), "Should contain abstract div");
+        // Verify content of a post with insert overrides (override-post)
+        assertTrue(body.contains("Override post content"), "Should contain override post's heading from content");
+        assertTrue(body.contains("This post uses an insert override."),
+                "Should contain override post's paragraph from content");
+    }
+
+    @Test
+    @DisplayName("Post with insert override renders content")
+    public void testInsertOverride() {
+        // TODO: insert overrides inside fragments not supported yet (https://github.com/quarkusio/quarkus/issues/53518)
+        String body = RestAssured.when().get("/the-posts/override-post").then().statusCode(200).log().ifValidationFails()
+                .extract().body().asString();
+        assertTrue(body.contains("Override post content"), "Should contain the main post content");
     }
 
     @Test

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterLayoutUtilsTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterLayoutUtilsTest.java
@@ -376,18 +376,31 @@ public class RoqFrontMatterLayoutUtilsTest {
         @Test
         @DisplayName("Null layout produces identity filter")
         void nullLayout() {
-            WrapperFilter filter = RoqFrontMatterLayoutUtils.getIncludeFilter(null);
+            WrapperFilter filter = RoqFrontMatterLayoutUtils.getIncludeFilter(null, true);
             assertEquals("content", filter.apply("content"));
         }
 
         @Test
-        @DisplayName("Non-null layout wraps with Qute include")
-        void wrapsContent() {
-            WrapperFilter filter = RoqFrontMatterLayoutUtils.getIncludeFilter("layouts/default");
+        @DisplayName("Page with layout wraps with Qute include and fragment")
+        void pageWrapsContentWithFragment() {
+            WrapperFilter filter = RoqFrontMatterLayoutUtils.getIncludeFilter("layouts/default", true);
             String result = filter.apply("body");
             assertTrue(result.contains("{#include"));
             assertTrue(result.contains("{/include}"));
             assertTrue(result.contains("layouts/default"));
+            assertTrue(result.contains("{#fragment RoqPageContent}"));
+            assertTrue(result.contains("{/fragment}"));
+        }
+
+        @Test
+        @DisplayName("Layout-to-layout wraps with Qute include without fragment")
+        void layoutWrapsContentWithoutFragment() {
+            WrapperFilter filter = RoqFrontMatterLayoutUtils.getIncludeFilter("layouts/default", false);
+            String result = filter.apply("body");
+            assertTrue(result.contains("{#include"));
+            assertTrue(result.contains("{/include}"));
+            assertTrue(result.contains("layouts/default"));
+            assertFalse(result.contains("{#fragment"));
         }
     }
 }

--- a/roq-frontmatter/deployment/src/test/resources/basic-site/content/pages/content-test.html
+++ b/roq-frontmatter/deployment/src/test/resources/basic-site/content/pages/content-test.html
@@ -1,0 +1,11 @@
+---
+layout: page
+title: Content Test
+link: /page/content-test
+---
+
+<h1>Content Test Page</h1>
+{#for post in site.collections.posts}
+<div class="post-content-{post.baseFileName}">{post.content}</div>
+<div class="post-abstract-{post.baseFileName}">{post.contentAbstract(5)}</div>
+{/for}

--- a/roq-frontmatter/deployment/src/test/resources/basic-site/content/posts/2024-11-01-override-post.html
+++ b/roq-frontmatter/deployment/src/test/resources/basic-site/content/posts/2024-11-01-override-post.html
@@ -1,0 +1,12 @@
+---
+layout: post
+title: Override Post
+---
+
+<h1>Override post content</h1>
+<p>This post uses an insert override.</p>
+{! TODO: insert overrides inside fragments are not supported yet (https://github.com/quarkusio/quarkus/issues/53518)
+{#before-content}
+<div class="custom-banner">Custom banner</div>
+{/before-content}
+!}

--- a/roq-frontmatter/deployment/src/test/resources/basic-site/templates/layouts/post.html
+++ b/roq-frontmatter/deployment/src/test/resources/basic-site/templates/layouts/post.html
@@ -4,6 +4,7 @@ link: /the-posts/:slug
 ---
 {@io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage page}
 <article class="post">
+  {#insert before-content /}
   {#insert /}
   <span>{page.date}</span>
   <span class="date-iso">{page.date.iso}</span>

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqQuteEngineObserver.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqQuteEngineObserver.java
@@ -57,9 +57,6 @@ public class RoqQuteEngineObserver {
         templatePathMapping.putAll(sources.list().stream()
                 .collect(Collectors.toMap(TemplateSource::generatedQuteTemplateId, TemplateSource::file,
                         (a, b) -> a)));
-        templatePathMapping.putAll(sources.list().stream()
-                .collect(Collectors.toMap(TemplateSource::generatedQuteContentTemplateId, TemplateSource::file,
-                        (a, b) -> a)));
         return templatePathMapping;
     }
 }

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplates.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplates.java
@@ -6,10 +6,10 @@ public final class RoqTemplates {
     }
 
     public static final String ROQ_GENERATED_QUTE_PREFIX = "roq-templates/";
-    public static final String ROQ_GENERATED_PAGE_QUTE_PREFIX = ROQ_GENERATED_QUTE_PREFIX + "full/";
-    public static final String ROQ_GENERATED_CONTENT_QUTE_PREFIX = ROQ_GENERATED_QUTE_PREFIX + "content/";
+    public static final String ROQ_GENERATED_PAGE_QUTE_PREFIX = ROQ_GENERATED_QUTE_PREFIX + "content/";
     public static final String LAYOUTS_DIR = "layouts/"; // includes trailing slash
     public static final String THEME_LAYOUTS_DIR = "theme-layouts/"; // includes trailing slash
+    public static final String ROQ_PAGE_CONTENT_FRAGMENT = "RoqPageContent";
 
     public static boolean isLayoutSourceTemplate(String templateId) {
         return templateId.startsWith(LAYOUTS_DIR) || templateId.startsWith(THEME_LAYOUTS_DIR);

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/Page.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/Page.java
@@ -2,6 +2,7 @@ package io.quarkiverse.roq.frontmatter.runtime.model;
 
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.DESCRIPTION;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.TITLE;
+import static io.quarkiverse.roq.frontmatter.runtime.RoqTemplates.ROQ_PAGE_CONTENT_FRAGMENT;
 import static io.quarkiverse.roq.frontmatter.runtime.utils.Pages.getImgFromData;
 import static io.quarkiverse.roq.frontmatter.runtime.utils.Pages.normaliseName;
 import static io.quarkiverse.roq.frontmatter.runtime.utils.Pages.resolveFile;
@@ -101,12 +102,14 @@ public class Page {
     private String resolveContentLazy() {
         try {
             final Engine engine = Arc.container().instance(Engine.class).get();
-            final String id = source().template().generatedQuteContentTemplateId();
+            final String id = source().template().generatedQuteTemplateId();
             final Template template = engine.getTemplate(id);
             if (template == null) {
                 return "";
             }
-            return template.render(Map.of(
+            // Use the fragment for pages with a layout, or the full template otherwise
+            final Template contentTemplate = template.getFragment(ROQ_PAGE_CONTENT_FRAGMENT);
+            return (contentTemplate != null ? contentTemplate : template).render(Map.of(
                     "page", this,
                     "site", site()));
 
@@ -117,7 +120,7 @@ public class Page {
     }
 
     private String resolveRawContentLazy() {
-        final String templateResource = "/templates/" + source().template().generatedQuteContentTemplateId();
+        final String templateResource = "/templates/" + source().template().generatedQuteTemplateId();
         try (InputStream resource = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream(templateResource)) {
             if (resource != null) {

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/TemplateSource.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/TemplateSource.java
@@ -1,6 +1,5 @@
 package io.quarkiverse.roq.frontmatter.runtime.model;
 
-import static io.quarkiverse.roq.frontmatter.runtime.RoqTemplates.ROQ_GENERATED_CONTENT_QUTE_PREFIX;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqTemplates.ROQ_GENERATED_PAGE_QUTE_PREFIX;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqTemplates.ROQ_GENERATED_QUTE_PREFIX;
 
@@ -69,10 +68,6 @@ public record TemplateSource(
 
     public String generatedQuteTemplateId() {
         return isLayout() ? ROQ_GENERATED_QUTE_PREFIX + generatedQuteId : ROQ_GENERATED_PAGE_QUTE_PREFIX + generatedQuteId;
-    }
-
-    public String generatedQuteContentTemplateId() {
-        return ROQ_GENERATED_CONTENT_QUTE_PREFIX + generatedQuteId;
     }
 
     /**

--- a/roq-plugin/faker/deployment/src/main/java/io/quarkiverse/roq/plugin/faker/deployment/RoqPluginFakerProcessor.java
+++ b/roq-plugin/faker/deployment/src/main/java/io/quarkiverse/roq/plugin/faker/deployment/RoqPluginFakerProcessor.java
@@ -142,8 +142,7 @@ public class RoqPluginFakerProcessor {
                                                 .format(DateTimeFormatter.ofPattern(siteConfig.dateFormat())))
                                 .put("tags", new JsonArray(document.tags())),
                         collection,
-                        getIncludeFilter(layoutId).apply(document.content()),
-                        document.content(),
+                        getIncludeFilter(layoutId, true).apply(document.content()),
                         List.of()));
             }
         }


### PR DESCRIPTION
## Summary

- Replace dual-template approach (full + content) with a single template using a Qute fragment (`RoqPageContent`) for `page.content()` rendering
- Rename generated templates directory from `roq-templates/full/` to `roq-templates/content/` (no more partial templates)
- Fragment is only added for pages with layouts (not layout-to-layout includes)

**Breaking:** removes `generatedQuteContentTemplateId()` from `TemplateSource` and `generatedContentTemplate` from `RoqFrontMatterRawPageBuildItem`.

**Known limitation:** Qute does not support insert overrides inside fragments (https://github.com/quarkusio/quarkus/issues/53518).

