### PR TITLE
Centralize dev-mode directory watching for livereload

### DIFF
--- a/roq-common/deployment/src/main/java/io/quarkiverse/roq/deployment/items/RoqProjectBuildItem.java
+++ b/roq-common/deployment/src/main/java/io/quarkiverse/roq/deployment/items/RoqProjectBuildItem.java
@@ -1,12 +1,16 @@
 package io.quarkiverse.roq.deployment.items;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import io.quarkiverse.tools.projectscanner.ScanLocalDirBuildItem;
 import io.quarkiverse.tools.projectscanner.util.ProjectUtils;
 import io.quarkiverse.tools.stringpaths.StringPaths;
 import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 
 public final class RoqProjectBuildItem extends SimpleBuildItem {
     private final RoqLocalDir local;
@@ -56,6 +60,23 @@ public final class RoqProjectBuildItem extends SimpleBuildItem {
             return subDir;
         }
         return StringPaths.join(roqResourceDir, subDir);
+    }
+
+    /**
+     * Walk a local directory recursively and register every subdirectory as a
+     * {@link HotDeploymentWatchedFileBuildItem}. This lets Quarkus detect directory
+     * mtime changes (from new/deleted files) during doScan(forceRestart=false).
+     */
+    public static void watchDirRecursively(Path dir, BuildProducer<HotDeploymentWatchedFileBuildItem> watch) {
+        if (dir == null || !Files.isDirectory(dir)) {
+            return;
+        }
+        try (Stream<Path> walk = Files.walk(dir)) {
+            walk.filter(Files::isDirectory).forEach(d -> watch.produce(HotDeploymentWatchedFileBuildItem.builder()
+                    .setLocation(d.toAbsolutePath().toString()).build()));
+        } catch (IOException e) {
+            // directory not accessible, skip
+        }
     }
 
     /**

--- a/roq-data/deployment/src/main/java/io/quarkiverse/roq/data/deployment/RoqDataReaderProcessor.java
+++ b/roq-data/deployment/src/main/java/io/quarkiverse/roq/data/deployment/RoqDataReaderProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.roq.data.deployment;
 
+import static io.quarkiverse.tools.stringpaths.StringPaths.addTrailingSlash;
 import static io.quarkiverse.tools.stringpaths.StringPaths.removeExtension;
 import static io.quarkiverse.tools.stringpaths.StringPaths.toUnixPath;
 
@@ -58,13 +59,11 @@ public class RoqDataReaderProcessor {
             ProjectScannerBuildItem scanner,
             RoqDataConfig config,
             RoqJacksonBuildItem jackson,
-            BuildProducer<RoqDataBuildItem> dataProducer,
-            BuildProducer<HotDeploymentWatchedFileBuildItem> watchedFilesProducer) {
+            BuildProducer<RoqDataBuildItem> dataProducer) {
         if (roqProject.isActive()) {
             DataConverterFinder converter = new DataConverterFinder(jackson.getJsonMapper(), jackson.getYamlMapper());
             try {
-                Collection<RoqDataBuildItem> items = scanDataFiles(roqProject, scanner, converter, watchedFilesProducer,
-                        config);
+                Collection<RoqDataBuildItem> items = scanDataFiles(roqProject, scanner, converter, config);
 
                 for (RoqDataBuildItem item : items) {
                     dataProducer.produce(item);
@@ -211,18 +210,22 @@ public class RoqDataReaderProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     void watch(RoqDataConfig config, RoqProjectBuildItem roqProject,
-            BuildProducer<WebBundlerWatchedDirBuildItem> webBundlerWatch) {
+            BuildProducer<WebBundlerWatchedDirBuildItem> webBundlerWatch,
+            BuildProducer<HotDeploymentWatchedFileBuildItem> hotWatch) {
         final Path localDataDir = roqProject.fromLocalRoqDir(config.dir());
-        if (localDataDir == null) {
-            return;
+        if (localDataDir != null) {
+            webBundlerWatch.produce(new WebBundlerWatchedDirBuildItem(localDataDir));
+            RoqProjectBuildItem.watchDirRecursively(localDataDir, hotWatch);
         }
-        webBundlerWatch.produce(new WebBundlerWatchedDirBuildItem(localDataDir));
+        String prefix = addTrailingSlash(roqProject.resolveRoqResourceSubDir(config.dir()));
+        hotWatch.produce(HotDeploymentWatchedFileBuildItem.builder()
+                .setLocationPredicate(p -> p.startsWith(prefix))
+                .build());
     }
 
     public Collection<RoqDataBuildItem> scanDataFiles(RoqProjectBuildItem roqProject,
             ProjectScannerBuildItem scanner,
             DataConverterFinder converter,
-            BuildProducer<HotDeploymentWatchedFileBuildItem> watchedFilesProducer,
             RoqDataConfig config)
             throws IOException {
 
@@ -245,10 +248,6 @@ public class RoqDataReaderProcessor {
         final List<ProjectFile> files = ScanQueryBuilder.mergeByScopedPath(localFiles, resourceFiles);
         for (ProjectFile file : files) {
             var name = removeExtension(toUnixPath(file.scopedPath()));
-            String watchPath = file.liveReloadWatchPath();
-            if (watchPath != null) {
-                watchedFilesProducer.produce(new HotDeploymentWatchedFileBuildItem(watchPath, true));
-            }
             DataConverter dataConverter = converter.fromFileName(file.scopedPath());
             if (dataConverter != null) {
                 items.add(new RoqDataBuildItem(name, file.file(), file.content(), dataConverter));

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep0SetupProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep0SetupProcessor.java
@@ -5,6 +5,7 @@ import static io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterConst
 import static io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterTemplateUtils.*;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.DRAFT;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.ESCAPE;
+import static io.quarkiverse.tools.stringpaths.StringPaths.addTrailingSlash;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -23,6 +24,7 @@ import io.quarkiverse.web.bundler.spi.items.WebBundlerWatchedDirBuildItem;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 
 public class RoqFrontMatterStep0SetupProcessor {
 
@@ -75,16 +77,26 @@ public class RoqFrontMatterStep0SetupProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     void watch(RoqSiteConfig config, RoqProjectBuildItem roqProject,
-            BuildProducer<WebBundlerWatchedDirBuildItem> webBundlerWatch) {
-        // In dev mode, tell WebBundler to watch Roq directories so changes trigger a rebuild
-        if (roqProject.local() == null) {
-            return;
+            BuildProducer<WebBundlerWatchedDirBuildItem> webBundlerWatch,
+            BuildProducer<HotDeploymentWatchedFileBuildItem> hotWatch) {
+        List<String> dirs = List.of(config.contentDir(), config.staticDir(), config.publicDir(), TEMPLATES_DIR);
+        if (roqProject.local() != null) {
+            Path roqDir = roqProject.local().roqDir();
+            for (String dirName : dirs) {
+                Path dir = roqDir.resolve(dirName);
+                webBundlerWatch.produce(new WebBundlerWatchedDirBuildItem(dir));
+                RoqProjectBuildItem.watchDirRecursively(dir, hotWatch);
+            }
         }
-        Path roqDir = roqProject.local().roqDir();
-        webBundlerWatch.produce(new WebBundlerWatchedDirBuildItem(roqDir.resolve(config.contentDir())));
-        webBundlerWatch.produce(new WebBundlerWatchedDirBuildItem(roqDir.resolve(config.staticDir())));
-        webBundlerWatch.produce(new WebBundlerWatchedDirBuildItem(roqDir.resolve(config.publicDir())));
-        webBundlerWatch.produce(new WebBundlerWatchedDirBuildItem(roqDir.resolve(TEMPLATES_DIR)));
+        for (String dirName : dirs) {
+            if (TEMPLATES_DIR.equals(dirName) && roqProject.roqResourceDir() == null) {
+                continue;
+            }
+            String prefix = addTrailingSlash(roqProject.resolveRoqResourceSubDir(dirName));
+            hotWatch.produce(HotDeploymentWatchedFileBuildItem.builder()
+                    .setLocationPredicate(p -> p.startsWith(prefix))
+                    .build());
+        }
     }
 
     private static Predicate<String> isPageEscaped(RoqSiteConfig config) {

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep1ScanProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep1ScanProcessor.java
@@ -41,7 +41,6 @@ import io.quarkiverse.tools.stringpaths.StringPaths;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
-import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.SuppressNonRuntimeConfigChangedWarningBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.qute.deployment.TemplatePathBuildItem;
@@ -106,8 +105,7 @@ public class RoqFrontMatterStep1ScanProcessor {
             QuteConfig quteConfig,
             List<RoqFrontMatterQuteMarkupBuildItem> markupList,
             List<RoqFrontMatterHeaderParserBuildItem> headerParserList,
-            BuildProducer<RoqFrontMatterScannedContentBuildItem> scannedContentProducer,
-            BuildProducer<HotDeploymentWatchedFileBuildItem> watch) throws IOException {
+            BuildProducer<RoqFrontMatterScannedContentBuildItem> scannedContentProducer) throws IOException {
         if (!roqProject.isActive()) {
             return;
         }
@@ -156,7 +154,7 @@ public class RoqFrontMatterStep1ScanProcessor {
                 if (isIdx) {
                     if (isSiteIdx) {
                         attachments = new ArrayList<>();
-                        scanSiteIndexAttachments(scanner, roqProject, config, watch, attachments);
+                        scanSiteIndexAttachments(scanner, roqProject, config, attachments);
                     } else {
                         attachments = pageAttachments.computeIfAbsent(parent, k -> new ArrayList<>());
                     }
@@ -172,7 +170,6 @@ public class RoqFrontMatterStep1ScanProcessor {
                         name = PageFiles.slugifyFile(name);
                     }
                     pageAttachments.get(ownerDir).add(new RoqFrontMatterAttachment(name, f.file()));
-                    produceWatch(f.liveReloadWatchPath(), watch);
                 }
             }
         }
@@ -180,7 +177,6 @@ public class RoqFrontMatterStep1ScanProcessor {
         // Second pass: collect metadata (front matter, markup) and produce scanned build items
         for (ContentEntry entry : entries) {
             FrontMatterTemplateMetadata metadata = collectMetadata(entry.file(), false, markupList, headerParserList);
-            produceWatch(entry.file().liveReloadWatchPath(), watch);
 
             LOGGER.debugf("Roq content scan producing scanned template '%s'", metadata.templateId());
             scannedContentProducer.produce(new RoqFrontMatterScannedContentBuildItem(
@@ -197,8 +193,7 @@ public class RoqFrontMatterStep1ScanProcessor {
             RoqSiteConfig config,
             List<RoqFrontMatterQuteMarkupBuildItem> markupList,
             List<RoqFrontMatterHeaderParserBuildItem> headerParserList,
-            BuildProducer<RoqFrontMatterScannedLayoutBuildItem> scannedLayoutProducer,
-            BuildProducer<HotDeploymentWatchedFileBuildItem> watch) throws IOException {
+            BuildProducer<RoqFrontMatterScannedLayoutBuildItem> scannedLayoutProducer) throws IOException {
         if (!roqProject.isActive()) {
             return;
         }
@@ -233,7 +228,6 @@ public class RoqFrontMatterStep1ScanProcessor {
             }
             FrontMatterTemplateMetadata metadata = collectMetadata(file, true, markupList,
                     headerParserList);
-            produceWatch(file.liveReloadWatchPath(), watch);
 
             LOGGER.debugf("Roq layout scan producing scanned layout '%s'", metadata.templateId());
             scannedLayoutProducer
@@ -266,7 +260,6 @@ public class RoqFrontMatterStep1ScanProcessor {
             }
             FrontMatterTemplateMetadata metadata = collectMetadata(file, true, markupList,
                     headerParserList);
-            produceWatch(file.liveReloadWatchPath(), watch);
 
             LOGGER.debugf("Roq theme-layout scan producing scanned layout '%s'", metadata.templateId());
             scannedLayoutProducer
@@ -287,8 +280,7 @@ public class RoqFrontMatterStep1ScanProcessor {
             BuildProducer<TemplatePathBuildItem> templatePathProducer,
             BuildProducer<GeneratedResourceBuildItem> generatedResourceProducer,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResourceProducer,
-            BuildProducer<TemplateRootBuildItem> templateRootProducer,
-            BuildProducer<HotDeploymentWatchedFileBuildItem> watch) throws IOException {
+            BuildProducer<TemplateRootBuildItem> templateRootProducer) throws IOException {
         if (!roqProject.isActive()) {
             return;
         }
@@ -334,11 +326,6 @@ public class RoqFrontMatterStep1ScanProcessor {
                     .extensionInfo(RoqFrontMatterStep6BindProcessor.FEATURE)
                     .build());
 
-            String watchPath = file.liveReloadWatchPath();
-            if (watchPath != null) {
-                watch.produce(HotDeploymentWatchedFileBuildItem.builder()
-                        .setLocation(watchPath).build());
-            }
         }
     }
 }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterScanUtils.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterScanUtils.java
@@ -34,8 +34,6 @@ import io.quarkiverse.tools.projectscanner.ProjectFile;
 import io.quarkiverse.tools.projectscanner.ProjectScannerBuildItem;
 import io.quarkiverse.tools.projectscanner.ScanQueryBuilder;
 import io.quarkiverse.tools.stringpaths.StringPaths;
-import io.quarkus.deployment.annotations.BuildProducer;
-import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.qute.runtime.QuteConfig;
 import io.vertx.core.http.impl.MimeMapping;
 
@@ -142,12 +140,6 @@ public final class RoqFrontMatterScanUtils {
         return sourcePath.replaceAll("\\s+", "-");
     }
 
-    public static void produceWatch(String watchPath, BuildProducer<HotDeploymentWatchedFileBuildItem> watch) {
-        if (watchPath != null) {
-            watch.produce(HotDeploymentWatchedFileBuildItem.builder().setLocation(watchPath).build());
-        }
-    }
-
     // ── Scanner query helpers ───────────────────────────────────────────
 
     /**
@@ -178,7 +170,6 @@ public final class RoqFrontMatterScanUtils {
             ProjectScannerBuildItem scanner,
             RoqProjectBuildItem roqProject,
             RoqSiteConfig config,
-            BuildProducer<HotDeploymentWatchedFileBuildItem> watch,
             List<RoqFrontMatterAttachment> attachments) throws IOException {
 
         final List<String> ignoredPatterns = buildIgnoredPatterns(config);
@@ -190,7 +181,6 @@ public final class RoqFrontMatterScanUtils {
                 attachmentName = PageFiles.slugifyFile(attachmentName);
             }
             attachments.add(new RoqFrontMatterAttachment(attachmentName, f.file()));
-            produceWatch(f.liveReloadWatchPath(), watch);
         }
 
         // Public dir files (served at root path)
@@ -200,7 +190,6 @@ public final class RoqFrontMatterScanUtils {
                 attachmentName = PageFiles.slugifyFile(attachmentName);
             }
             attachments.add(new RoqFrontMatterAttachment(attachmentName, f.file()));
-            produceWatch(f.liveReloadWatchPath(), watch);
         }
     }
 


### PR DESCRIPTION
## Summary

- Move per-file `HotDeploymentWatchedFileBuildItem` production from scan steps (Step1, ScanUtils, Data scan) into centralized `watch()` methods in Step0 and RoqDataReaderProcessor
- Local project directories use recursive directory walking (`watchDirRecursively` in roq-common) to detect new/deleted files via directory mtime changes
- Classpath resources use predicate-based watches (`startsWith` on resource path prefix) to cover all files under content, static, public, templates, and data dirs
- Remove `produceWatch` utility method and all per-file watch registration from scan processors