### PR TITLE
Add custom Roq error pages for dev mode

### DIFF
--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep0SetupProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep0SetupProcessor.java
@@ -20,6 +20,7 @@ import io.quarkiverse.roq.frontmatter.deployment.items.data.RoqFrontMatterDataMo
 import io.quarkiverse.roq.frontmatter.deployment.items.scan.RoqFrontMatterHeaderParserBuildItem;
 import io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterTemplateUtils;
 import io.quarkiverse.roq.frontmatter.runtime.config.RoqSiteConfig;
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 import io.quarkiverse.web.bundler.spi.items.WebBundlerWatchedDirBuildItem;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -70,7 +71,11 @@ public class RoqFrontMatterStep0SetupProcessor {
                 return readFM(jackson.getYamlMapper(), c.content());
             } catch (JsonProcessingException | IllegalArgumentException e) {
                 throw new RoqFrontMatterReadingException(
-                        "Error reading YAML FrontMatter block (enclosed by '---') in file: %s".formatted(c.templatePath()));
+                        RoqException.builder("Front matter reading error")
+                                .sourceFilePath(c.templatePath())
+                                .detail("Failed to parse the YAML front matter block (enclosed by '---').")
+                                .hint("Check that the YAML syntax between the --- delimiters is valid.")
+                                .cause(e));
             }
         }, RoqFrontMatterTemplateUtils::stripFrontMatter, FRONTMATTER_HEADER_PARSER_PRIORITY);
     }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep3DataProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep3DataProcessor.java
@@ -40,10 +40,12 @@ import io.quarkiverse.roq.frontmatter.deployment.items.data.RoqFrontMatterStatic
 import io.quarkiverse.roq.frontmatter.deployment.items.publish.RoqFrontMatterPublishNormalPageBuildItem;
 import io.quarkiverse.roq.frontmatter.deployment.util.TemplateLink;
 import io.quarkiverse.roq.frontmatter.runtime.config.RoqSiteConfig;
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 import io.quarkiverse.roq.frontmatter.runtime.model.PageFiles;
 import io.quarkiverse.roq.frontmatter.runtime.model.PageSource;
 import io.quarkiverse.roq.frontmatter.runtime.model.RootUrl;
 import io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl;
+import io.quarkiverse.roq.frontmatter.runtime.model.TemplateSource;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
@@ -89,18 +91,18 @@ public class RoqFrontMatterStep3DataProcessor {
         // Process layouts: merge front matter from parent layouts (child values override parents)
         for (RoqFrontMatterRawLayoutBuildItem item : rawLayouts) {
             JsonObject data = mergeParents(config, item.layout(), item.data(),
-                    item.templateSource().file().absolutePath(), layoutsById);
+                    item.templateSource(), layoutsById);
             layoutTemplateProducer.produce(new RoqFrontMatterLayoutTemplateBuildItem(item, data));
         }
 
         // Process pages: merge parent data, then filter by date/draft rules
         for (RoqFrontMatterRawPageBuildItem item : rawPages) {
             JsonObject data = mergeParents(config, item.layout(), item.data(),
-                    item.templateSource().file().absolutePath(), layoutsById);
+                    item.templateSource(), layoutsById);
 
             // Parse date from front matter "date" key, or from filename pattern (e.g. 2024-03-10-my-post)
             ZonedDateTime date = parsePublishDate(item.templateSource().path(), data, config.dateFormat(),
-                    config.timeZoneOrDefault());
+                    config.timeZoneOrDefault(), item.templateSource());
 
             // Collection documents (posts, etc.) always need a date since templates use {post.date.format(...)}.
             // Normal pages don't need one — null is fine.
@@ -199,7 +201,7 @@ public class RoqFrontMatterStep3DataProcessor {
     // Walk the layout chain (page -> layout -> parent layout -> ...) and merge front matter.
     // Uses a stack so parent values are applied first, then child values override them.
     public static JsonObject mergeParents(RoqSiteConfig config, String layout, JsonObject data,
-            String sourceAbsPath, Map<String, RoqFrontMatterRawLayoutBuildItem> byId) {
+            TemplateSource source, Map<String, RoqFrontMatterRawLayoutBuildItem> byId) {
         Stack<JsonObject> fms = new Stack<>();
         Set<String> visited = new HashSet<>();
         String parent = layout;
@@ -208,14 +210,15 @@ public class RoqFrontMatterStep3DataProcessor {
             if (!visited.add(parent)) {
                 throw new RuntimeException(
                         "Circular layout reference detected for file '%s': layout '%s' forms a cycle."
-                                .formatted(sourceAbsPath, parent));
+                                .formatted(source.file().relativePath(), parent));
             }
             if (!byId.containsKey(parent)) {
                 final String layoutKey = getLayoutKey(config.theme(), parent);
                 throw new RoqLayoutNotFoundException(
-                        "Layout '%s' not found for file '%s'. Available layouts are: %s."
-                                .formatted(layoutKey, sourceAbsPath,
-                                        getAvailableLayouts(config, byId)));
+                        RoqException.builder("Layout not found")
+                                .source(source)
+                                .detail("Layout '%s' could not be resolved.".formatted(layoutKey))
+                                .hint("Available layouts: %s".formatted(getAvailableLayouts(config, byId))));
             }
             final RoqFrontMatterRawLayoutBuildItem parentItem = byId.get(parent);
             parent = parentItem.layout();
@@ -245,7 +248,7 @@ public class RoqFrontMatterStep3DataProcessor {
     }
 
     static ZonedDateTime parsePublishDate(String path, JsonObject frontMatter, String dateFormat,
-            ZoneId zoneId) {
+            ZoneId zoneId, TemplateSource source) {
         String dateString;
         final boolean fromFileName;
         if (frontMatter.containsKey(DATE) && frontMatter.getValue(DATE) != null) {
@@ -271,13 +274,18 @@ public class RoqFrontMatterStep3DataProcessor {
         } catch (DateTimeParseException e) {
             if (fromFileName) {
                 throw new RoqSiteScanningException(
-                        "Error while reading date '%s' in file name: '%s'\nreason: %s".formatted(dateString, path,
-                                e.getLocalizedMessage()));
+                        RoqException.builder("Invalid date in file name")
+                                .source(source)
+                                .detail("Could not parse date '%s' from the file name.".formatted(dateString))
+                                .hint("Rename the file so the date matches the configured format: '%s'.".formatted(dateFormat))
+                                .cause(e));
             } else {
                 throw new RoqFrontMatterReadingException(
-                        "Error while reading FrontMatter 'date' ('%s') in file: '%s'\nreason: %s".formatted(dateString,
-                                path,
-                                e.getLocalizedMessage()));
+                        RoqException.builder("Invalid date format")
+                                .source(source)
+                                .detail("Could not parse front matter 'date' value '%s'.".formatted(dateString))
+                                .hint("Use a date string matching the configured format: '%s'.".formatted(dateFormat))
+                                .cause(e));
             }
         }
 

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep5RecordProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep5RecordProcessor.java
@@ -27,6 +27,7 @@ import io.quarkiverse.roq.frontmatter.deployment.items.record.RoqFrontMatterReco
 import io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterRecorder;
 import io.quarkiverse.roq.frontmatter.runtime.config.ConfiguredCollection;
 import io.quarkiverse.roq.frontmatter.runtime.config.RoqSiteConfig;
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 import io.quarkiverse.roq.frontmatter.runtime.model.*;
 import io.quarkiverse.tools.stringpaths.StringPaths;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -132,6 +133,7 @@ class RoqFrontMatterStep5RecordProcessor {
         if (rootUrlItem == null) {
             return;
         }
+        List<RoqFrontMatterPublishNormalPageBuildItem> siteIndexPages = new ArrayList<>();
         for (RoqFrontMatterPublishNormalPageBuildItem page : pages) {
             final Supplier<NormalPage> recordedPage = recorder.createPage(page.url(),
                     page.source(), page.data(), page.paginator());
@@ -139,8 +141,20 @@ class RoqFrontMatterStep5RecordProcessor {
             normalPagesProducer
                     .produce(new RoqFrontMatterRecordedNormalPageBuildItem(page.source().id(), page.url(), recordedPage));
             if (page.source().isSiteIndex()) {
-                indexPageProducer.produce(new RoqFrontMatterRecordedSiteIndexBuildItem(recordedPage));
+                siteIndexPages.add(page);
+                if (siteIndexPages.size() == 1) {
+                    indexPageProducer.produce(new RoqFrontMatterRecordedSiteIndexBuildItem(recordedPage));
+                }
             }
+        }
+        if (siteIndexPages.size() > 1) {
+            String paths = siteIndexPages.stream()
+                    .map(p -> "'" + p.source().path() + "'")
+                    .collect(Collectors.joining(", "));
+            throw new RoqSiteIndexNotFoundException(
+                    RoqException.builder("Multiple site index pages found")
+                            .detail("Found %d index pages: %s".formatted(siteIndexPages.size(), paths))
+                            .hint("Remove the extra index files so only a single site index remains."));
         }
     }
 
@@ -163,7 +177,9 @@ class RoqFrontMatterStep5RecordProcessor {
         // Create Site bean
         if (indexPageItem == null) {
             throw new RoqSiteIndexNotFoundException(
-                    "Site index page (index.html, index.md, etc.) not found. A site index is required by Roq. Please create one to continue.");
+                    RoqException.builder("Site index not found")
+                            .detail("No site index page (index.html, index.md, etc.) was found.")
+                            .hint("Create an index file in your content or templates directory."));
 
         }
         final Map<ConfiguredCollection, List<Supplier<DocumentPage>>> collectionsMap = collectionItems.stream().collect(
@@ -201,9 +217,10 @@ class RoqFrontMatterStep5RecordProcessor {
                     continue;
                 } else {
                     throw new RoqPathConflictException(
-                            "Conflict detected: Duplicate path (%s) found in %s and %s".formatted(i.url().resourcePath(),
-                                    prev.id(),
-                                    i.id()));
+                            RoqException.builder("Path conflict")
+                                    .detail("Duplicate path '%s' produced by both '%s' and '%s'.".formatted(
+                                            i.url().resourcePath(), prev.id(), i.id()))
+                                    .hint("Ensure each page resolves to a unique URL path, or use 'link:' in front matter to customize the output path."));
                 }
             }
             allPagesByPath.put(i.url().resourcePath(), i.page());

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep6BindProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep6BindProcessor.java
@@ -27,6 +27,7 @@ import io.quarkiverse.roq.frontmatter.runtime.RoqQuteEngineObserver;
 import io.quarkiverse.roq.frontmatter.runtime.RoqTemplateExtension;
 import io.quarkiverse.roq.frontmatter.runtime.RoqTemplateGlobal;
 import io.quarkiverse.roq.frontmatter.runtime.config.RoqSiteConfig;
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 import io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage;
 import io.quarkiverse.roq.frontmatter.runtime.model.NormalPage;
 import io.quarkiverse.roq.frontmatter.runtime.model.Page;
@@ -250,7 +251,11 @@ public class RoqFrontMatterStep6BindProcessor {
                             + "\nIn development, the first occurrence will be kept, but this will cause an exception in normal mode.");
                     continue;
                 } else {
-                    throw new RoqPathConflictException(message);
+                    throw new RoqPathConflictException(
+                            RoqException.builder("Static file path conflict")
+                                    .detail("Multiple source files target the same endpoint '%s': '%s' and '%s'."
+                                            .formatted(endpoint, prev, staticFile.filePath()))
+                                    .hint("Rename or move one of the conflicting files so they produce different output paths."));
                 }
             }
 

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqFrontMatterReadingException.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqFrontMatterReadingException.java
@@ -1,13 +1,10 @@
 package io.quarkiverse.roq.frontmatter.deployment.exception;
 
-public class RoqFrontMatterReadingException extends RuntimeException {
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 
-    public RoqFrontMatterReadingException(String message) {
-        super(message);
+public class RoqFrontMatterReadingException extends RoqException {
+
+    public RoqFrontMatterReadingException(RoqException.Builder builder) {
+        super(builder);
     }
-
-    public RoqFrontMatterReadingException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqLayoutNotFoundException.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqLayoutNotFoundException.java
@@ -1,13 +1,10 @@
 package io.quarkiverse.roq.frontmatter.deployment.exception;
 
-public class RoqLayoutNotFoundException extends RuntimeException {
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 
-    public RoqLayoutNotFoundException(String message) {
-        super(message);
+public class RoqLayoutNotFoundException extends RoqException {
+
+    public RoqLayoutNotFoundException(RoqException.Builder builder) {
+        super(builder);
     }
-
-    public RoqLayoutNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqPathConflictException.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqPathConflictException.java
@@ -1,13 +1,10 @@
 package io.quarkiverse.roq.frontmatter.deployment.exception;
 
-public class RoqPathConflictException extends RuntimeException {
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 
-    public RoqPathConflictException(String message) {
-        super(message);
+public class RoqPathConflictException extends RoqException {
+
+    public RoqPathConflictException(RoqException.Builder builder) {
+        super(builder);
     }
-
-    public RoqPathConflictException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqPluginException.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqPluginException.java
@@ -1,13 +1,10 @@
 package io.quarkiverse.roq.frontmatter.deployment.exception;
 
-public class RoqPluginException extends RuntimeException {
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 
-    public RoqPluginException(String message) {
-        super(message);
+public class RoqPluginException extends RoqException {
+
+    public RoqPluginException(RoqException.Builder builder) {
+        super(builder);
     }
-
-    public RoqPluginException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqSiteIndexNotFoundException.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqSiteIndexNotFoundException.java
@@ -1,13 +1,10 @@
 package io.quarkiverse.roq.frontmatter.deployment.exception;
 
-public class RoqSiteIndexNotFoundException extends RuntimeException {
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 
-    public RoqSiteIndexNotFoundException(String message) {
-        super(message);
+public class RoqSiteIndexNotFoundException extends RoqException {
+
+    public RoqSiteIndexNotFoundException(RoqException.Builder builder) {
+        super(builder);
     }
-
-    public RoqSiteIndexNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqSiteScanningException.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqSiteScanningException.java
@@ -1,11 +1,10 @@
 package io.quarkiverse.roq.frontmatter.deployment.exception;
 
-public class RoqSiteScanningException extends RuntimeException {
-    public RoqSiteScanningException(String message, Throwable cause) {
-        super(message, cause);
-    }
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 
-    public RoqSiteScanningException(String message) {
-        super(message);
+public class RoqSiteScanningException extends RoqException {
+
+    public RoqSiteScanningException(RoqException.Builder builder) {
+        super(builder);
     }
 }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqTemplateLinkException.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqTemplateLinkException.java
@@ -1,7 +1,10 @@
 package io.quarkiverse.roq.frontmatter.deployment.exception;
 
-public class RoqTemplateLinkException extends RuntimeException {
-    public RoqTemplateLinkException(String message) {
-        super(message);
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
+
+public class RoqTemplateLinkException extends RoqException {
+
+    public RoqTemplateLinkException(RoqException.Builder builder) {
+        super(builder);
     }
 }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqThemeConfigurationException.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/exception/RoqThemeConfigurationException.java
@@ -1,13 +1,10 @@
 package io.quarkiverse.roq.frontmatter.deployment.exception;
 
-public class RoqThemeConfigurationException extends RuntimeException {
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 
-    public RoqThemeConfigurationException(String message) {
-        super(message);
+public class RoqThemeConfigurationException extends RoqException {
+
+    public RoqThemeConfigurationException(RoqException.Builder builder) {
+        super(builder);
     }
-
-    public RoqThemeConfigurationException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/items/scan/RoqFrontMatterAvailableLayoutsBuildItem.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/items/scan/RoqFrontMatterAvailableLayoutsBuildItem.java
@@ -15,6 +15,7 @@ import org.jboss.logging.Logger;
 import io.quarkiverse.roq.frontmatter.deployment.exception.RoqLayoutNotFoundException;
 import io.quarkiverse.roq.frontmatter.deployment.exception.RoqThemeConfigurationException;
 import io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterAssembleUtils.LayoutRef;
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 import io.quarkiverse.roq.frontmatter.runtime.model.SourceFile;
 import io.quarkus.builder.item.SimpleBuildItem;
 
@@ -93,8 +94,10 @@ public final class RoqFrontMatterAvailableLayoutsBuildItem extends SimpleBuildIt
             // 5. theme-layout: no "/" + from content/user -> theme-layouts/{active}/foo
             if (activeTheme.isEmpty()) {
                 throw new RoqThemeConfigurationException(
-                        "No theme detected! Using 'theme-layout: %s' requires a theme dependency."
-                                .formatted(layoutValue));
+                        RoqException.builder("No theme configured")
+                                .detail("'theme-layout: %s' requires a theme, but no theme dependency was detected."
+                                        .formatted(layoutValue))
+                                .hint("Add a Roq theme dependency to your project, or use 'layout:' instead of 'theme-layout:'."));
             }
             return findOrFail(THEME_LAYOUTS_DIR + activeTheme.get() + "/" + value, layoutValue);
         }
@@ -130,7 +133,7 @@ public final class RoqFrontMatterAvailableLayoutsBuildItem extends SimpleBuildIt
         if (layoutsById.containsKey(id)) {
             return id;
         }
-        throw new RoqLayoutNotFoundException(buildError(errorName, List.of(id)));
+        throw new RoqLayoutNotFoundException(buildErrorBuilder(errorName, List.of(id)));
     }
 
     private String firstMatchOrFail(String layoutValue, List<String> candidates) {
@@ -139,7 +142,7 @@ public final class RoqFrontMatterAvailableLayoutsBuildItem extends SimpleBuildIt
                 return candidate;
             }
         }
-        throw new RoqLayoutNotFoundException(buildError(layoutValue, candidates));
+        throw new RoqLayoutNotFoundException(buildErrorBuilder(layoutValue, candidates));
     }
 
     private static String stripThemeDirPrefix(String value) {
@@ -148,13 +151,13 @@ public final class RoqFrontMatterAvailableLayoutsBuildItem extends SimpleBuildIt
         return slash >= 0 ? afterDir.substring(slash + 1) : afterDir;
     }
 
-    private String buildError(String originalName, List<String> candidates) {
+    private RoqException.Builder buildErrorBuilder(String originalName, List<String> candidates) {
         String available = layoutsById.keySet().stream()
                 .limit(20)
                 .collect(Collectors.joining(", ", "[", layoutsById.size() > 20 ? ", ...]" : "]"));
-        return "Layout '%s' could not be resolved. Tried:\n%s\nAvailable layouts: %s".formatted(
-                originalName,
-                String.join("\n", candidates.stream().map(s -> "  - " + s).toList()),
-                available);
+        String tried = String.join("\n", candidates.stream().map(s -> "  - " + s).toList());
+        return RoqException.builder("Layout not found")
+                .detail("Layout '%s' could not be resolved. Tried:\n%s".formatted(originalName, tried))
+                .hint("Available layouts: %s".formatted(available));
     }
 }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/TemplateLink.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/TemplateLink.java
@@ -20,6 +20,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import io.quarkiverse.roq.frontmatter.deployment.exception.RoqTemplateLinkException;
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 import io.quarkiverse.roq.frontmatter.runtime.model.PageSource;
 import io.quarkiverse.tools.stringpaths.StringPaths;
 import io.vertx.core.json.JsonObject;
@@ -54,8 +55,10 @@ public class TemplateLink {
                 Map.entry(":collection", () -> {
                     if (data.collection() == null) {
                         throw new RoqTemplateLinkException(
-                                "Page '%s' uses ':collection' placeholder in the link, it should not be used outside of a collection."
-                                        .formatted(data.pageSource().path()));
+                                RoqException.builder("Invalid link placeholder")
+                                        .source(data.pageSource().template())
+                                        .detail("The ':collection' placeholder is used in the link template, but this page does not belong to a collection.")
+                                        .hint("Remove ':collection' from the link template, or move this page into a collection."));
                     }
                     return data.collection();
                 }),
@@ -129,8 +132,14 @@ public class TemplateLink {
             if (link.contains(entry.getKey())) {
                 String replacement = entry.getValue().get();
                 if (replacement == null) {
-                    throw new RoqTemplateLinkException("Link placeholder value for '%s' not found for 'link: %s' in page '%s'."
-                            .formatted(entry.getKey(), template, data.pageSource().file().relativePath()));
+                    throw new RoqTemplateLinkException(
+                            RoqException.builder("Link placeholder not resolved")
+                                    .source(data.pageSource().template())
+                                    .detail("Placeholder '%s' in link template '%s' resolved to null.".formatted(
+                                            entry.getKey(), template))
+                                    .hint("Provide a value for '%s' in the page front matter or remove it from the link template."
+                                            .formatted(
+                                                    entry.getKey())));
                 }
                 link = link.replace(entry.getKey(), replacement);
             }
@@ -142,10 +151,12 @@ public class TemplateLink {
             if (matcher.find()) {
                 String invalidPlaceholder = matcher.group();
                 throw new RoqTemplateLinkException(
-                        "Invalid placeholder '%s' found in link template '%s' for page '%s'. Valid placeholders are: %s"
-                                .formatted(invalidPlaceholder, template != null ? template : defaultTemplate,
-                                        data.pageSource().file().relativePath(),
-                                        String.join(", ", mapping.keySet())));
+                        RoqException.builder("Invalid link placeholder")
+                                .source(data.pageSource().template())
+                                .detail("Unknown placeholder '%s' in link template '%s'.".formatted(
+                                        invalidPlaceholder, template != null ? template : defaultTemplate))
+                                .hint("Valid placeholders: %s".formatted(
+                                        String.join(", ", mapping.keySet()))));
             }
         }
 

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/ParsePublishDateTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/ParsePublishDateTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkiverse.roq.frontmatter.deployment.exception.RoqFrontMatterReadingException;
 import io.quarkiverse.roq.frontmatter.deployment.exception.RoqSiteScanningException;
+import io.quarkiverse.roq.frontmatter.runtime.model.SourceFile;
+import io.quarkiverse.roq.frontmatter.runtime.model.TemplateSource;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -27,10 +29,14 @@ public class ParsePublishDateTest {
     private static final String DEFAULT_DATE_FORMAT = "yyyy-M-d[ HH:mm][:ss][ Z]";
     private static final ZoneId GMT = ZoneId.of("GMT");
 
+    private static TemplateSource testSource(String path) {
+        return new TemplateSource("test", null, new SourceFile("", path), path, null, false, true, false, false);
+    }
+
     @Test
     public void testDateInFilename() {
-        String publishDate = parsePublishDate("2004-09-07-title.md", JsonObject.of(), DEFAULT_DATE_FORMAT, GMT)
-                .format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
+        String publishDate = parsePublishDate("2004-09-07-title.md", JsonObject.of(), DEFAULT_DATE_FORMAT, GMT,
+                testSource("2004-09-07-title.md")).format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
 
         assertEquals("2004-09-07T00:00:00Z[GMT]", publishDate);
     }
@@ -38,8 +44,8 @@ public class ParsePublishDateTest {
     @Test
     @DisplayName("Single-digit day in filename is parsed")
     public void testSingleDigitDayInFilename() {
-        String publishDate = parsePublishDate("2024-10-9-title.md", JsonObject.of(), DEFAULT_DATE_FORMAT, GMT)
-                .format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
+        String publishDate = parsePublishDate("2024-10-9-title.md", JsonObject.of(), DEFAULT_DATE_FORMAT, GMT,
+                testSource("2024-10-9-title.md")).format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
 
         assertEquals("2024-10-09T00:00:00Z[GMT]", publishDate);
     }
@@ -47,8 +53,8 @@ public class ParsePublishDateTest {
     @Test
     @DisplayName("Single-digit month and day in filename is parsed")
     public void testSingleDigitMonthAndDayInFilename() {
-        String publishDate = parsePublishDate("2024-3-5-title.md", JsonObject.of(), DEFAULT_DATE_FORMAT, GMT)
-                .format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
+        String publishDate = parsePublishDate("2024-3-5-title.md", JsonObject.of(), DEFAULT_DATE_FORMAT, GMT,
+                testSource("2024-3-5-title.md")).format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
 
         assertEquals("2024-03-05T00:00:00Z[GMT]", publishDate);
     }
@@ -56,7 +62,7 @@ public class ParsePublishDateTest {
     @Test
     public void testDateInFrontMatter() {
         String publishDate = parsePublishDate("no-date-here.md", JsonObject.of("date", "2020-10-13"),
-                DEFAULT_DATE_FORMAT, GMT)
+                DEFAULT_DATE_FORMAT, GMT, testSource("no-date-here.md"))
                 .format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
 
         assertEquals("2020-10-13T00:00:00Z[GMT]", publishDate);
@@ -65,7 +71,7 @@ public class ParsePublishDateTest {
     @Test
     public void testDateTimeInFrontMatter() {
         String publishDate = parsePublishDate("no-date-here.md", JsonObject.of("date", "2020-10-13 13:10"),
-                DEFAULT_DATE_FORMAT, GMT)
+                DEFAULT_DATE_FORMAT, GMT, testSource("no-date-here.md"))
                 .format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
 
         assertEquals("2020-10-13T13:10:00Z[GMT]", publishDate);
@@ -75,7 +81,7 @@ public class ParsePublishDateTest {
     @DisplayName("Date with seconds in frontmatter")
     public void testDateTimeWithSecondsInFrontMatter() {
         String publishDate = parsePublishDate("no-date-here.md", JsonObject.of("date", "2020-10-13 13:10:45"),
-                DEFAULT_DATE_FORMAT, GMT)
+                DEFAULT_DATE_FORMAT, GMT, testSource("no-date-here.md"))
                 .format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
 
         assertEquals("2020-10-13T13:10:45Z[GMT]", publishDate);
@@ -85,7 +91,7 @@ public class ParsePublishDateTest {
     @DisplayName("Frontmatter date takes precedence over filename date")
     public void testFrontMatterDateOverridesFilename() {
         String publishDate = parsePublishDate("2004-09-07-title.md", JsonObject.of("date", "2020-10-13"),
-                DEFAULT_DATE_FORMAT, GMT)
+                DEFAULT_DATE_FORMAT, GMT, testSource("2004-09-07-title.md"))
                 .format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
 
         assertEquals("2020-10-13T00:00:00Z[GMT]", publishDate);
@@ -94,7 +100,8 @@ public class ParsePublishDateTest {
     @Test
     @DisplayName("No date anywhere returns null")
     public void testNoDateReturnsNull() {
-        ZonedDateTime result = parsePublishDate("no-date-here.md", JsonObject.of(), DEFAULT_DATE_FORMAT, GMT);
+        ZonedDateTime result = parsePublishDate("no-date-here.md", JsonObject.of(), DEFAULT_DATE_FORMAT, GMT,
+                testSource("no-date-here.md"));
         assertNull(result, "Pages with no date should return null");
     }
 
@@ -103,7 +110,8 @@ public class ParsePublishDateTest {
     public void testNullDateValueInFrontMatter() {
         // date key exists but value is null — should fall back to filename pattern or now
         JsonObject fm = new JsonObject().put("date", (String) null);
-        ZonedDateTime result = parsePublishDate("2024-05-10-post.md", fm, DEFAULT_DATE_FORMAT, GMT);
+        ZonedDateTime result = parsePublishDate("2024-05-10-post.md", fm, DEFAULT_DATE_FORMAT, GMT,
+                testSource("2024-05-10-post.md"));
 
         assertEquals("2024-05-10T00:00:00Z[GMT]", result.format(DateTimeFormatter.ISO_ZONED_DATE_TIME));
     }
@@ -112,7 +120,8 @@ public class ParsePublishDateTest {
     @DisplayName("Null date value in frontmatter with no filename date returns null")
     public void testNullDateValueNoFilenameReturnsNull() {
         JsonObject fm = new JsonObject().put("date", (String) null);
-        ZonedDateTime result = parsePublishDate("no-date-here.md", fm, DEFAULT_DATE_FORMAT, GMT);
+        ZonedDateTime result = parsePublishDate("no-date-here.md", fm, DEFAULT_DATE_FORMAT, GMT,
+                testSource("no-date-here.md"));
         assertNull(result, "Null FM date with no filename date should return null");
     }
 
@@ -120,7 +129,8 @@ public class ParsePublishDateTest {
     @DisplayName("Filename date uses configured timezone")
     public void testFilenameDateUsesTimezone() {
         ZoneId paris = ZoneId.of("Europe/Paris");
-        ZonedDateTime result = parsePublishDate("2024-06-15-post.md", JsonObject.of(), DEFAULT_DATE_FORMAT, paris);
+        ZonedDateTime result = parsePublishDate("2024-06-15-post.md", JsonObject.of(), DEFAULT_DATE_FORMAT, paris,
+                testSource("2024-06-15-post.md"));
 
         assertEquals("Europe/Paris", result.getZone().getId());
         assertEquals("2024-06-15T00:00:00+02:00[Europe/Paris]", result.format(DateTimeFormatter.ISO_ZONED_DATE_TIME));
@@ -131,7 +141,7 @@ public class ParsePublishDateTest {
     public void testFrontMatterDateUsesTimezone() {
         ZoneId tokyo = ZoneId.of("Asia/Tokyo");
         ZonedDateTime result = parsePublishDate("no-date.md", JsonObject.of("date", "2024-01-15 14:30"),
-                DEFAULT_DATE_FORMAT, tokyo);
+                DEFAULT_DATE_FORMAT, tokyo, testSource("no-date.md"));
 
         assertEquals("Asia/Tokyo", result.getZone().getId());
         assertEquals("2024-01-15T14:30:00+09:00[Asia/Tokyo]", result.format(DateTimeFormatter.ISO_ZONED_DATE_TIME));
@@ -141,7 +151,7 @@ public class ParsePublishDateTest {
     @DisplayName("Configured timezone overrides explicit offset in frontmatter")
     public void testConfiguredTimezoneOverridesExplicitOffset() {
         ZonedDateTime result = parsePublishDate("no-date.md", JsonObject.of("date", "2024-06-15 10:00 +0530"),
-                DEFAULT_DATE_FORMAT, GMT);
+                DEFAULT_DATE_FORMAT, GMT, testSource("no-date.md"));
 
         // The configured timezone (GMT) takes precedence over the offset in the date string
         assertEquals("GMT", result.getZone().getId());
@@ -151,14 +161,16 @@ public class ParsePublishDateTest {
     @DisplayName("Invalid date in frontmatter throws RoqFrontMatterReadingException")
     public void testInvalidDateInFrontMatter() {
         assertThrows(RoqFrontMatterReadingException.class,
-                () -> parsePublishDate("no-date.md", JsonObject.of("date", "not-a-date"), DEFAULT_DATE_FORMAT, GMT));
+                () -> parsePublishDate("no-date.md", JsonObject.of("date", "not-a-date"), DEFAULT_DATE_FORMAT, GMT,
+                        testSource("no-date.md")));
     }
 
     @Test
     @DisplayName("Invalid date in filename throws RoqSiteScanningException")
     public void testInvalidDateInFilename() {
         assertThrows(RoqSiteScanningException.class,
-                () -> parsePublishDate("9999-99-99-post.md", JsonObject.of(), DEFAULT_DATE_FORMAT, GMT));
+                () -> parsePublishDate("9999-99-99-post.md", JsonObject.of(), DEFAULT_DATE_FORMAT, GMT,
+                        testSource("9999-99-99-post.md")));
     }
 
 }

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqRouteHandler.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqRouteHandler.java
@@ -16,6 +16,8 @@ import jakarta.enterprise.event.Event;
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.roq.frontmatter.runtime.config.RoqSiteConfig;
+import io.quarkiverse.roq.frontmatter.runtime.devmode.RoqErrorPage;
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 import io.quarkiverse.roq.frontmatter.runtime.model.Page;
 import io.quarkiverse.roq.frontmatter.runtime.model.Site;
 import io.quarkiverse.roq.frontmatter.runtime.utils.Sites;
@@ -27,6 +29,7 @@ import io.quarkus.arc.impl.LazyValue;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.qute.runtime.TemplateProducer;
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.LocalesBuildTimeConfig;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -161,7 +164,18 @@ public class RoqRouteHandler implements Handler<RoutingContext> {
                 if (t != null) {
                     Throwable rootCause = rootCause(t);
                     LOG.errorf("Error occurred while rendering the template [%s]: %s", page.id(), rootCause.toString());
-                    rc.fail(rootCause);
+                    if (LaunchMode.current().isDevOrTest() && rootCause instanceof RoqException) {
+                        try {
+                            String html = RoqErrorPage.generatePage(rootCause);
+                            rc.response().setStatusCode(500)
+                                    .putHeader(HttpHeaders.CONTENT_TYPE, "text/html;charset=UTF-8")
+                                    .end(html);
+                        } catch (Exception e) {
+                            rc.fail(rootCause);
+                        }
+                    } else {
+                        rc.fail(rootCause);
+                    }
                 } else {
                     rc.response().setStatusCode(200).end(r);
                 }

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/devmode/RoqErrorPage.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/devmode/RoqErrorPage.java
@@ -1,0 +1,344 @@
+package io.quarkiverse.roq.frontmatter.runtime.devmode;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Generates a friendly, styled error page for Roq exceptions in dev mode.
+ * Uses reflection to read structured fields from RoqException to handle
+ * classloader boundaries.
+ */
+public class RoqErrorPage {
+
+    private static final Logger LOG = Logger.getLogger(RoqErrorPage.class);
+
+    private static final String ROQ_EXCEPTION_CLASS = "io.quarkiverse.roq.frontmatter.runtime.exception.RoqException";
+
+    private RoqErrorPage() {
+    }
+
+    public static String generatePage(Throwable exception) {
+        List<Throwable> problems;
+        Throwable[] suppressed = exception.getSuppressed();
+        if (suppressed.length == 0) {
+            problems = Collections.singletonList(exception);
+        } else {
+            problems = Arrays.asList(suppressed);
+        }
+
+        String subtitle = problems.size() == 1
+                ? "Something went wrong"
+                : problems.size() + " problems found";
+
+        StringBuilder html = new StringBuilder();
+        html.append(PAGE_HEADER);
+
+        for (int i = 0; i < problems.size(); i++) {
+            renderProblem(html, problems.get(i), i + 1, problems.size(), subtitle);
+        }
+
+        html.append(PAGE_FOOTER);
+        return html.toString();
+    }
+
+    private static void renderProblem(StringBuilder html, Throwable problem, int index, int total, String subtitle) {
+        String title = invokeStringMethod(problem, "title");
+        String displayPath = invokeStringMethod(problem, "displayPath");
+        String absolutePath = invokeStringMethod(problem, "absolutePath");
+        String detail = invokeStringMethod(problem, "detail");
+        String hint = invokeStringMethod(problem, "hint");
+        Integer line = invokeMethod(problem, "line", Integer.class);
+        Integer column = invokeMethod(problem, "column", Integer.class);
+        boolean isRoqException = title != null;
+
+        if (!isRoqException) {
+            title = problem.getClass().getSimpleName();
+            detail = problem.getMessage();
+        }
+
+        html.append("<div class=\"error-card\">\n");
+
+        if (index == 1) {
+            html.append(MASCOT_SVG);
+            html.append("<p class=\"page-title\">").append(escapeHtml(subtitle)).append("</p>\n");
+        }
+
+        if (total > 1) {
+            html.append("<div class=\"error-number\">").append(index).append(" / ").append(total).append("</div>\n");
+        }
+
+        html.append("<h2 class=\"error-title\">").append(escapeHtml(title)).append("</h2>\n");
+
+        if (displayPath != null) {
+            html.append("<div class=\"source-location\"");
+            if (absolutePath != null) {
+                html.append(" title=\"").append(escapeHtml(absolutePath)).append("\"");
+            }
+            html.append(">");
+            html.append(escapeHtml(displayPath));
+            if (line != null) {
+                html.append(":").append(line);
+                if (column != null) {
+                    html.append(":").append(column);
+                }
+            }
+            html.append("</div>\n");
+        }
+
+        if (detail != null) {
+            html.append("<div class=\"error-detail\">").append(escapeHtml(detail)).append("</div>\n");
+        }
+
+        if (hint != null) {
+            html.append("<div class=\"hint-box\">\n");
+            html.append("<span class=\"hint-label\">Hint</span>\n");
+            html.append("<span>").append(escapeHtml(hint)).append("</span>\n");
+            html.append("</div>\n");
+        }
+
+        Throwable originalCause = invokeMethod(problem, "originalCause", Throwable.class);
+        Throwable traceSource = originalCause != null ? originalCause : problem;
+        StringWriter sw = new StringWriter();
+        traceSource.printStackTrace(new PrintWriter(sw));
+        html.append("<details class=\"stacktrace\">\n");
+        html.append("<summary>Stack trace</summary>\n");
+        html.append("<pre>").append(escapeHtml(sw.toString())).append("</pre>\n");
+        html.append("</details>\n");
+
+        html.append("</div>\n");
+    }
+
+    // -- Reflection helpers (classloader-safe method invocation) ----------------
+
+    private static String invokeStringMethod(Throwable t, String methodName) {
+        Object value = invokeMethod(t, methodName, Object.class);
+        return value != null ? value.toString() : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T invokeMethod(Throwable t, String methodName, Class<T> type) {
+        try {
+            Class<?> clazz = findRoqExceptionClass(t);
+            if (clazz == null) {
+                return null;
+            }
+            Method method = clazz.getMethod(methodName);
+            return (T) method.invoke(t);
+        } catch (Exception e) {
+            LOG.debugf("Could not invoke '%s' on %s: %s", methodName, t.getClass().getName(), e.getMessage());
+            return null;
+        }
+    }
+
+    private static Class<?> findRoqExceptionClass(Throwable t) {
+        Class<?> clazz = t.getClass();
+        while (clazz != null && !clazz.getName().equals(ROQ_EXCEPTION_CLASS)) {
+            clazz = clazz.getSuperclass();
+        }
+        return clazz;
+    }
+
+    // -- HTML escaping --------------------------------------------------------
+
+    private static String escapeHtml(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    // -- Page templates -------------------------------------------------------
+
+    // @formatter:off
+    private static final String PAGE_HEADER = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Roq Error</title>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;600&family=Fira+Sans:wght@300;400;500&display=swap');
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: 'Fira Sans', system-ui, sans-serif;
+            background: linear-gradient(to bottom right in oklab, #f3f4f6, #fafafa, #e8f7fa);
+            color: #1e293b;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 3rem 1.5rem;
+        }
+        .page-title {
+            font-family: 'Fira Code', monospace;
+            font-size: 2rem;
+            font-weight: 700;
+            margin-bottom: 1.5rem;
+            text-align: center;
+            background: linear-gradient(135deg, #237f90, #35afc5, #f08240, #237f90);
+            background-size: 300% 300%;
+            -webkit-background-clip: text;
+            background-clip: text;
+            -webkit-text-fill-color: transparent;
+            animation: shimmer 12s ease-in-out infinite;
+        }
+        @keyframes shimmer {
+            0% { background-position: 0% 50%; }
+            50% { background-position: 100% 50%; }
+            100% { background-position: 0% 50%; }
+        }
+        .error-card {
+            position: relative;
+            background: white;
+            border-radius: 12px;
+            padding: 2.5rem 2.5rem 2rem;
+            max-width: 720px;
+            width: 100%;
+            margin-top: 100px;
+            margin-bottom: 1.5rem;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.06), 0 4px 12px rgba(0,0,0,0.04);
+            border-top: 3px solid #237f90;
+        }
+        .error-card .mascot {
+            position: absolute;
+            top: -92px;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 200px;
+            height: auto;
+        }
+        .error-number {
+            font-family: 'Fira Code', monospace;
+            font-size: 0.8rem;
+            color: #94a3b8;
+            margin-bottom: 0.75rem;
+            letter-spacing: 0.05em;
+        }
+        .error-title {
+            font-family: 'Fira Code', monospace;
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: #237f90;
+            margin-bottom: 1rem;
+            line-height: 1.4;
+        }
+        .source-location {
+            font-family: 'Fira Code', monospace;
+            font-size: 0.85rem;
+            color: #237f90;
+            background: #e8f7fa;
+            border: 1px solid #b8e6ef;
+            border-radius: 6px;
+            padding: 0.5rem 0.75rem;
+            margin-bottom: 1rem;
+            word-break: break-all;
+            cursor: help;
+        }
+        .error-detail {
+            font-size: 0.95rem;
+            line-height: 1.65;
+            color: #334155;
+            margin-bottom: 1rem;
+            white-space: pre-wrap;
+        }
+        .hint-box {
+            background: #fff7ed;
+            border-left: 3px solid #f08240;
+            border-radius: 0 8px 8px 0;
+            padding: 0.75rem 1rem;
+            margin-bottom: 1rem;
+            display: flex;
+            gap: 0.5rem;
+            align-items: baseline;
+        }
+        .hint-label {
+            font-family: 'Fira Code', monospace;
+            font-size: 0.75rem;
+            font-weight: 600;
+            color: #e8712c;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            flex-shrink: 0;
+        }
+        .hint-box span:last-child {
+            font-size: 0.9rem;
+            color: #9a3412;
+            line-height: 1.5;
+        }
+        .stacktrace { margin-top: 0.5rem; }
+        .stacktrace summary {
+            font-family: 'Fira Code', monospace;
+            font-size: 0.8rem;
+            color: #94a3b8;
+            cursor: pointer;
+            padding: 0.4rem 0;
+            user-select: none;
+            transition: color 0.15s;
+        }
+        .stacktrace summary:hover { color: #237f90; }
+        .stacktrace pre {
+            font-family: 'Fira Code', monospace;
+            font-size: 0.75rem;
+            line-height: 1.6;
+            background: #1e293b;
+            color: #e2e8f0;
+            padding: 1rem;
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-top: 0.5rem;
+            white-space: pre-wrap;
+            word-break: break-all;
+        }
+        .refresh-btn {
+            display: inline-block;
+            margin-top: 1.5rem;
+            font-family: 'Fira Code', monospace;
+            font-size: 0.85rem;
+            color: white;
+            background: #237f90;
+            border: none;
+            border-radius: 8px;
+            padding: 0.6rem 1.5rem;
+            cursor: pointer;
+            text-decoration: none;
+            transition: background 0.15s;
+        }
+        .refresh-btn:hover { background: #35afc5; }
+        .footer {
+            margin-top: 1.5rem;
+            font-family: 'Fira Code', monospace;
+            font-size: 0.85rem;
+            color: #237f90;
+        }
+    </style>
+</head>
+<body>
+""";
+
+    private static final String MASCOT_SVG = """
+    <svg class="mascot" version="1.1" viewBox="293 287 949 491" xmlns="http://www.w3.org/2000/svg">
+      <defs><clipPath id="outline-clip"><path d="M 766 329 C 740 329 713 329 703 330 C 693 331 676 332 666 333 C 654 334 640 336 633 337 C 626 338 614 341 607 342 C 599 344 588 347 584 349 C 579 351 572 354 568 355 C 565 357 559 360 556 363 C 552 366 546 370 543 373 C 540 376 536 382 534 385 C 532 388 529 395 527 400 C 525 405 523 414 521 420 C 519 427 517 438 516 446 C 514 453 512 466 511 476 C 509 486 507 503 506 516 C 504 528 502 548 501 561 C 500 574 499 589 498 594 L 498 604 L 484 604 C 476 604 467 605 462 606 C 458 607 451 609 448 610 C 444 611 439 614 436 615 C 432 617 427 620 424 622 C 420 625 415 629 412 633 C 408 636 404 641 402 644 C 400 647 398 653 396 656 C 395 660 394 666 393 670 C 392 675 392 681 393 685 L 393 692 L 369 692 C 349 692 344 692 341 694 C 340 694 337 697 336 698 C 335 700 334 703 334 704 C 334 705 335 708 336 710 C 337 712 339 714 341 715 C 345 717 347 717 377 717 L 409 717 L 415 722 C 418 725 423 728 426 730 C 429 731 434 733 436 734 C 439 735 443 736 444 736 C 446 737 451 737 456 736 C 461 736 467 735 472 734 L 479 732 L 485 734 C 490 736 495 736 504 737 C 514 737 517 737 524 735 C 529 734 534 733 536 732 C 539 732 542 733 546 734 C 550 735 555 736 561 737 C 568 737 572 737 577 736 C 581 735 587 733 591 731 C 594 729 599 725 602 722 L 607 717 L 774 717 L 940 717 L 943 721 C 945 723 949 726 952 728 C 955 730 961 733 965 734 C 970 736 974 736 984 736 C 993 736 997 736 1003 734 L 1011 732 L 1018 734 C 1024 736 1027 736 1038 736 C 1048 736 1052 736 1057 734 C 1060 733 1064 732 1065 732 C 1067 732 1070 733 1074 734 C 1077 735 1083 736 1087 737 C 1092 737 1097 737 1101 736 C 1105 735 1111 732 1115 731 C 1119 729 1124 725 1127 722 L 1133 717 L 1162 717 C 1187 717 1192 717 1195 715 C 1197 714 1199 712 1200 711 C 1202 708 1202 706 1202 703 C 1201 701 1200 698 1199 697 C 1199 696 1197 695 1196 694 L 1195 694 L 1195 693 C 1194 693 1194 693 1194 693 C 1192 692 1185 692 1169 692 L 1146 692 L 1147 684 C 1147 679 1147 674 1146 668 C 1145 663 1142 656 1139 650 C 1136 643 1133 639 1127 633 C 1123 629 1117 624 1114 621 C 1110 619 1104 616 1100 614 C 1097 613 1089 610 1083 609 C 1078 607 1070 606 1066 605 C 1062 604 1054 604 1049 604 L 1040 604 L 1040 601 C 1039 599 1039 594 1039 590 C 1038 585 1037 570 1035 556 C 1034 542 1032 520 1030 507 C 1028 494 1026 477 1024 468 C 1023 459 1020 444 1018 435 C 1016 426 1014 414 1012 410 C 1011 405 1008 396 1005 390 C 1001 383 998 378 994 374 C 990 370 985 365 982 363 C 979 361 973 358 970 356 C 966 354 959 351 955 350 C 951 348 942 345 934 344 C 927 342 914 339 906 338 C 897 336 881 334 872 333 C 862 332 844 331 832 330 C 820 329 790 329 766 329 z"/></clipPath></defs>
+      <g><path id="body" style="fill:#d3c6a7" clip-path="url(#outline-clip)" d="M 744 327 C 729 328 707 329 696 330 C 685 330 667 332 657 333 C 647 334 634 336 630 337 C 625 337 614 340 606 341 C 599 343 588 346 584 348 C 579 350 572 353 568 354 C 565 356 560 359 556 362 C 554 363 551 365 548 368 C 547 369 546 370 545 370 C 545 371 544 372 543 373 C 543 373 542 373 542 373 C 538 377 534 384 532 387 C 531 388 531 390 530 391 C 530 391 530 391 530 392 C 530 392 530 392 530 392 C 528 395 526 398 526 401 C 524 405 522 414 520 420 C 518 427 516 438 515 446 C 513 453 511 466 510 476 C 508 486 506 502 505 512 C 504 521 502 541 501 556 C 499 571 498 587 497 593 L 497 602 L 497 603 L 488 603 C 483 603 476 603 471 604 C 466 605 459 606 454 607 C 450 608 443 611 438 613 C 434 615 428 619 424 621 C 421 623 416 627 413 629 C 410 632 406 637 403 642 C 400 646 397 652 396 655 C 395 658 393 664 392 669 C 392 674 391 680 392 684 L 392 691 L 369 691 C 357 691 345 691 343 692 C 342 692 342 692 342 692 C 342 692 342 692 342 692 L 341 692 L 340 693 L 340 693 C 339 694 337 695 337 696 C 335 698 334 701 333 702 C 333 705 333 707 335 710 C 336 712 338 714 340 716 L 342 717 L 343 717 C 347 718 353 718 377 718 L 409 718 L 410 718 L 415 723 C 418 726 423 730 427 732 C 431 733 438 736 441 737 C 445 737 451 738 456 738 C 461 737 468 736 472 735 L 478 733 L 478 733 C 478 733 479 733 479 733 L 486 735 C 490 737 496 737 504 738 C 505 738 506 738 506 738 C 507 738 507 738 508 738 C 515 738 518 738 524 736 C 529 735 535 734 538 734 C 540 734 546 735 550 736 C 554 737 559 738 564 738 C 568 738 574 737 578 736 C 581 736 587 734 591 732 C 594 730 599 727 602 724 L 608 718 L 773 718 L 939 718 L 945 724 C 948 727 954 730 957 732 C 959 733 961 733 963 734 C 963 734 963 734 963 734 C 963 734 963 734 963 734 C 966 735 968 736 971 737 C 976 738 981 738 987 738 C 993 738 999 737 1004 735 L 1011 733 L 1018 735 C 1024 737 1027 737 1037 737 C 1045 737 1050 737 1054 736 C 1058 735 1062 734 1064 733 C 1066 733 1069 734 1073 735 C 1077 736 1083 737 1087 738 C 1092 738 1097 738 1101 737 C 1105 736 1111 734 1115 732 C 1118 730 1124 726 1127 723 L 1133 718 L 1162 718 C 1184 718 1192 718 1194 717 C 1196 716 1199 714 1200 713 C 1202 711 1202 709 1202 706 C 1203 704 1203 703 1202 702 C 1202 699 1202 698 1200 696 C 1199 695 1196 693 1194 692 C 1192 691 1185 691 1169 691 L 1147 691 L 1148 684 C 1148 679 1148 674 1147 668 C 1146 663 1143 656 1141 650 C 1140 649 1139 647 1138 646 C 1138 646 1138 646 1138 646 C 1138 646 1138 646 1138 646 C 1136 643 1134 640 1132 637 C 1132 637 1131 636 1131 636 C 1131 636 1131 636 1131 636 C 1130 635 1130 635 1129 634 C 1126 630 1120 625 1116 622 C 1113 620 1106 616 1102 614 C 1100 613 1097 612 1094 611 C 1093 611 1092 610 1092 610 C 1091 610 1089 610 1089 609 C 1087 609 1085 608 1084 608 C 1078 606 1070 605 1065 604 C 1060 603 1053 603 1049 603 C 1042 603 1041 603 1041 601 C 1040 600 1039 587 1038 574 C 1037 561 1035 540 1033 528 C 1032 516 1029 494 1027 480 C 1025 465 1022 445 1020 436 C 1018 426 1015 414 1013 410 C 1013 408 1011 405 1010 402 C 1010 400 1009 398 1009 397 C 1009 396 1008 395 1007 394 C 1007 393 1006 391 1006 390 C 1002 382 1000 379 995 374 C 995 373 994 373 994 372 C 993 371 991 370 990 368 C 983 362 980 360 972 356 C 970 355 967 354 964 353 C 964 353 964 353 964 352 C 964 352 964 352 964 352 C 961 351 957 349 956 349 C 952 347 943 345 937 343 C 931 341 919 339 911 338 C 903 336 889 334 880 333 C 871 332 857 331 850 330 C 843 329 822 329 804 328 C 786 327 759 327 744 327 z "/><path id="outline" style="fill:#0E0E0C" d="M 766 329 C 740 329 713 329 703 330 C 693 331 676 332 666 333 C 654 334 640 336 633 337 C 626 338 614 341 607 342 C 599 344 588 347 584 349 C 579 351 572 354 568 355 C 565 357 559 360 556 363 C 552 366 546 370 543 373 C 540 376 536 382 534 385 C 532 388 529 395 527 400 C 525 405 523 414 521 420 C 519 427 517 438 516 446 C 514 453 512 466 511 476 C 509 486 507 503 506 516 C 504 528 502 548 501 561 C 500 574 499 589 498 594 L 498 604 L 484 604 C 476 604 467 605 462 606 C 458 607 451 609 448 610 C 444 611 439 614 436 615 C 432 617 427 620 424 622 C 420 625 415 629 412 633 C 408 636 404 641 402 644 C 400 647 398 653 396 656 C 395 660 394 666 393 670 C 392 675 392 681 393 685 L 393 692 L 369 692 C 349 692 344 692 341 694 C 340 694 337 697 336 698 C 335 700 334 703 334 704 C 334 705 335 708 336 710 C 337 712 339 714 341 715 C 345 717 347 717 377 717 L 409 717 L 415 722 C 418 725 423 728 426 730 C 429 731 434 733 436 734 C 439 735 443 736 444 736 C 446 737 451 737 456 736 C 461 736 467 735 472 734 L 479 732 L 485 734 C 490 736 495 736 504 737 C 514 737 517 737 524 735 C 529 734 534 733 536 732 C 539 732 542 733 546 734 C 550 735 555 736 561 737 C 568 737 572 737 577 736 C 581 735 587 733 591 731 C 594 729 599 725 602 722 L 607 717 L 774 717 L 940 717 L 943 721 C 945 723 949 726 952 728 C 955 730 961 733 965 734 C 970 736 974 736 984 736 C 993 736 997 736 1003 734 L 1011 732 L 1018 734 C 1024 736 1027 736 1038 736 C 1048 736 1052 736 1057 734 C 1060 733 1064 732 1065 732 C 1067 732 1070 733 1074 734 C 1077 735 1083 736 1087 737 C 1092 737 1097 737 1101 736 C 1105 735 1111 732 1115 731 C 1119 729 1124 725 1127 722 L 1133 717 L 1162 717 C 1187 717 1192 717 1195 715 C 1197 714 1199 712 1200 711 C 1202 708 1202 706 1202 703 C 1201 701 1200 698 1199 697 C 1199 696 1197 695 1196 694 L 1195 694 L 1195 693 C 1194 693 1194 693 1194 693 C 1192 692 1185 692 1169 692 L 1146 692 L 1147 684 C 1147 679 1147 674 1146 668 C 1145 663 1142 656 1139 650 C 1136 643 1133 639 1127 633 C 1123 629 1117 624 1114 621 C 1110 619 1104 616 1100 614 C 1097 613 1089 610 1083 609 C 1078 607 1070 606 1066 605 C 1062 604 1054 604 1049 604 L 1040 604 L 1040 601 C 1039 599 1039 594 1039 590 C 1038 585 1037 570 1035 556 C 1034 542 1032 520 1030 507 C 1028 494 1026 477 1024 468 C 1023 459 1020 444 1018 435 C 1016 426 1014 414 1012 410 C 1011 405 1008 396 1005 390 C 1001 383 998 378 994 374 C 990 370 985 365 982 363 C 979 361 973 358 970 356 C 966 354 959 351 955 350 C 951 348 942 345 934 344 C 927 342 914 339 906 338 C 897 336 881 334 872 333 C 862 332 844 331 832 330 C 820 329 790 329 766 329 z M 787 352 C 804 353 823 353 829 354 C 835 355 846 356 854 357 L 869 358 C 869 358 869 358 869 358 L 879 367 C 885 372 891 377 893 379 C 895 382 896 384 897 392 C 898 398 900 403 901 405 C 901 406 904 409 908 412 C 911 414 913 417 914 419 C 914 420 914 422 913 423 C 912 424 907 430 902 435 C 897 440 891 446 890 448 C 888 452 888 453 889 454 C 889 455 891 455 892 455 C 894 454 898 452 901 450 C 905 447 911 442 916 439 C 922 435 926 433 928 433 C 930 433 932 434 936 439 C 939 442 942 445 943 446 C 944 446 951 448 959 449 C 967 451 975 453 978 453 C 980 454 984 456 986 458 C 988 459 990 461 991 462 C 991 463 992 466 993 470 C 994 474 996 488 998 503 C 1000 517 1002 530 1002 530 C 1002 530 1002 531 1002 531 C 1002 531 1001 531 1001 531 C 1000 531 996 529 990 527 C 985 525 975 522 968 520 C 961 519 948 515 938 513 C 928 511 914 508 906 507 C 898 505 884 503 875 502 C 866 501 851 499 842 498 C 831 497 809 497 785 496 C 760 496 739 496 727 497 C 716 498 700 499 691 500 C 682 501 667 503 659 505 C 650 506 638 508 632 510 C 626 511 616 513 611 515 C 605 516 596 519 590 521 C 584 523 579 524 578 524 C 578 523 578 516 579 507 C 580 499 581 480 583 466 C 584 452 586 432 588 422 C 589 412 591 399 592 394 C 593 389 595 383 596 381 C 597 379 600 377 602 376 C 604 374 609 372 614 370 C 619 369 629 366 637 364 C 645 362 658 360 666 359 C 675 358 689 356 698 356 C 706 355 723 354 734 353 C 747 352 768 352 787 352 z M 893 363 C 894 363 899 364 906 365 C 912 366 924 369 931 371 C 938 372 948 376 952 377 C 956 379 961 382 964 384 C 966 386 970 390 972 393 C 974 396 977 403 978 407 C 980 411 982 419 983 424 C 984 429 985 436 986 439 C 986 444 986 445 984 445 C 983 445 978 444 972 442 C 966 440 958 438 954 437 C 949 435 946 434 944 432 C 942 430 939 426 937 423 C 935 419 931 414 926 410 C 922 407 917 403 917 402 C 916 400 915 396 914 391 C 913 387 913 383 912 382 C 912 381 908 376 902 372 C 897 367 893 364 893 363 L 893 363 z M 772 513 C 780 513 790 513 796 514 C 802 515 809 516 813 517 C 816 517 821 519 824 521 C 826 522 830 524 831 526 C 831 527 833 534 835 542 C 837 549 842 576 848 602 C 854 628 859 653 860 659 C 861 665 862 672 862 674 C 862 677 861 680 861 682 C 859 684 858 685 854 686 C 851 687 843 689 834 689 C 826 690 806 690 790 690 C 774 690 758 689 754 689 C 751 689 747 688 746 687 C 744 686 742 684 740 683 C 739 682 737 678 736 675 C 734 673 732 667 731 662 C 730 654 730 648 730 589 C 730 526 730 524 731 522 C 733 522 736 520 739 519 C 741 518 747 516 752 516 C 756 515 765 514 772 513 z M 647 548 C 655 548 665 550 670 551 C 674 551 680 553 683 555 C 687 556 690 558 691 560 C 691 562 692 566 692 571 C 692 579 692 579 690 579 C 688 578 684 578 680 577 C 677 576 668 576 660 576 C 653 576 643 577 638 577 C 632 578 624 580 619 582 C 614 584 607 586 603 588 C 599 590 594 594 591 597 C 588 599 585 603 584 604 C 584 606 583 608 583 609 C 583 609 585 612 586 614 C 589 616 591 617 593 617 C 595 617 602 615 608 613 C 615 610 623 607 627 606 C 631 605 639 604 643 603 C 648 602 658 602 669 602 C 679 602 687 603 688 603 C 688 604 686 619 684 638 C 682 656 680 676 679 682 L 679 692 L 646 692 L 615 692 C 614 692 614 692 614 692 C 614 692 614 692 614 691 L 612 685 C 611 681 609 674 608 671 C 606 667 603 661 600 657 C 598 653 592 647 588 642 C 584 638 578 632 575 630 C 572 628 565 624 561 622 C 557 620 553 618 553 618 C 553 617 554 607 555 593 C 557 576 558 569 559 567 C 560 565 562 562 565 561 C 567 559 573 557 578 555 C 583 553 591 551 596 551 C 600 550 611 549 619 548 C 627 547 638 547 647 548 z M 899 548 C 908 548 920 548 928 548 C 935 549 945 549 949 550 C 953 551 960 552 965 554 C 969 555 976 557 979 559 C 983 560 987 563 989 564 C 991 566 993 569 994 570 C 994 572 996 577 996 582 C 997 587 998 597 998 603 L 998 613 L 989 619 C 984 621 977 625 974 627 C 972 629 966 634 961 639 C 956 644 950 650 947 654 C 945 657 941 663 939 667 C 937 672 935 679 934 683 L 933 692 C 933 692 932 692 932 692 L 907 692 C 893 692 881 692 881 691 C 881 691 881 688 881 684 C 881 680 880 673 879 667 C 879 662 875 646 871 632 C 868 618 865 606 865 605 C 865 603 867 603 875 602 C 880 602 893 602 903 602 C 918 603 923 603 931 605 C 936 607 945 610 952 612 C 958 614 964 616 966 617 C 969 617 971 616 974 615 C 975 614 977 612 978 611 C 978 609 978 607 978 605 C 977 604 975 600 972 598 C 970 596 965 592 962 590 C 958 588 951 585 946 583 C 941 582 932 579 927 578 C 920 577 914 577 898 577 C 881 577 876 577 868 579 C 864 580 859 580 859 580 C 858 580 858 575 857 570 C 857 563 857 561 858 559 C 859 557 861 555 863 554 C 865 554 870 552 875 551 C 880 550 891 548 899 548 z M 1057 627 C 1061 627 1064 628 1067 628 C 1071 629 1077 630 1080 631 C 1083 632 1089 634 1093 636 C 1097 638 1102 641 1106 644 C 1109 648 1113 652 1114 655 C 1116 658 1118 664 1118 668 C 1119 674 1119 678 1118 684 C 1117 690 1116 695 1114 699 C 1111 704 1109 706 1106 708 C 1101 711 1099 712 1093 712 C 1087 712 1084 712 1083 711 C 1082 710 1083 707 1085 698 C 1086 692 1087 683 1088 678 C 1088 672 1088 668 1087 666 C 1086 664 1085 663 1084 663 C 1084 662 1082 662 1082 663 C 1081 663 1080 665 1079 667 C 1078 669 1075 676 1073 682 C 1071 688 1068 696 1066 698 C 1065 701 1063 704 1061 706 C 1059 708 1055 710 1051 711 C 1048 712 1042 713 1039 713 C 1035 713 1030 712 1028 712 C 1025 711 1022 710 1022 709 C 1021 708 1021 706 1021 704 C 1021 702 1022 693 1024 685 C 1025 676 1026 668 1026 667 C 1026 665 1025 663 1024 662 C 1022 661 1022 661 1019 662 C 1018 663 1015 666 1013 669 C 1012 672 1008 679 1006 686 C 1004 692 1001 700 999 703 C 998 706 996 709 995 710 C 993 711 990 711 986 711 C 983 711 979 710 976 710 C 974 709 972 707 970 706 C 969 705 967 701 966 699 C 966 696 965 690 965 685 C 965 680 966 675 967 671 C 968 668 970 663 972 661 C 974 658 977 654 979 652 C 982 649 987 646 990 643 C 994 641 1000 638 1004 636 C 1007 634 1015 632 1020 630 C 1027 628 1032 628 1044 627 C 1049 627 1053 627 1057 627 z M 493 628 C 512 628 514 628 523 630 C 529 632 537 635 542 637 C 548 640 554 643 557 645 C 559 647 564 650 566 653 C 569 655 573 660 576 663 C 578 667 581 672 582 677 C 584 683 585 687 585 693 C 585 698 584 702 583 704 C 582 706 580 708 577 710 C 574 711 570 712 565 713 C 560 713 557 713 554 711 L 549 710 C 549 709 548 709 548 708 L 542 694 C 539 686 535 677 534 674 C 532 671 530 667 528 666 C 526 664 524 662 524 662 C 523 662 521 663 520 664 C 519 666 519 666 521 675 C 522 680 524 688 525 693 C 525 698 526 703 526 705 C 526 707 525 709 525 710 C 524 710 521 711 518 712 C 515 712 510 713 507 713 C 504 713 499 712 495 711 C 491 709 487 707 485 706 C 483 704 480 701 479 698 C 477 695 474 687 471 679 C 468 672 465 665 464 664 C 463 663 462 662 461 662 C 461 662 459 663 458 665 C 457 667 457 668 458 679 C 459 685 460 695 461 700 C 463 709 463 709 461 711 C 460 711 457 712 454 712 C 451 712 447 711 444 710 C 442 709 438 706 436 703 C 434 701 431 696 430 693 C 429 690 427 685 427 683 C 426 680 426 673 426 668 C 427 659 427 657 429 652 C 431 649 434 645 436 643 C 438 641 443 638 447 636 C 451 634 459 631 464 630 C 471 628 475 628 493 628 z "/></g>
+    </svg>
+""";
+
+    private static final String PAGE_FOOTER = """
+    <button class="refresh-btn" onclick="location.reload()">Refresh</button>
+    <p class="footer">Roq Dev Mode</p>
+</body>
+</html>
+""";
+    // @formatter:on
+}

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/devmode/RoqErrorPageSetup.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/devmode/RoqErrorPageSetup.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.roq.frontmatter.runtime.devmode;
+
+import io.quarkus.dev.ErrorPageGenerators;
+import io.quarkus.dev.spi.HotReplacementContext;
+import io.quarkus.dev.spi.HotReplacementSetup;
+
+/**
+ * Registers Roq's custom error page generator for all RoqException subclasses
+ * in dev mode. Discovered via META-INF/services/io.quarkus.dev.spi.HotReplacementSetup.
+ */
+public class RoqErrorPageSetup implements HotReplacementSetup {
+
+    private static final String[] ROQ_EXCEPTION_CLASSES = {
+            "io.quarkiverse.roq.frontmatter.runtime.exception.RoqException",
+            "io.quarkiverse.roq.frontmatter.runtime.exception.RoqStaticFileException",
+            "io.quarkiverse.roq.frontmatter.deployment.exception.RoqLayoutNotFoundException",
+            "io.quarkiverse.roq.frontmatter.deployment.exception.RoqFrontMatterReadingException",
+            "io.quarkiverse.roq.frontmatter.deployment.exception.RoqPathConflictException",
+            "io.quarkiverse.roq.frontmatter.deployment.exception.RoqTemplateLinkException",
+            "io.quarkiverse.roq.frontmatter.deployment.exception.RoqSiteIndexNotFoundException",
+            "io.quarkiverse.roq.frontmatter.deployment.exception.RoqSiteScanningException",
+            "io.quarkiverse.roq.frontmatter.deployment.exception.RoqPluginException",
+            "io.quarkiverse.roq.frontmatter.deployment.exception.RoqThemeConfigurationException",
+    };
+
+    @Override
+    public void setupHotDeployment(HotReplacementContext context) {
+        for (String className : ROQ_EXCEPTION_CLASSES) {
+            ErrorPageGenerators.register(className, RoqErrorPage::generatePage);
+        }
+    }
+}

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/exception/RoqException.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/exception/RoqException.java
@@ -1,0 +1,179 @@
+package io.quarkiverse.roq.frontmatter.runtime.exception;
+
+import io.quarkiverse.roq.frontmatter.runtime.model.TemplateSource;
+
+/**
+ * Base exception for Roq errors carrying structured information
+ * for rendering friendly error pages.
+ */
+public class RoqException extends RuntimeException {
+
+    private final String title;
+    private final String sourceFilePath;
+    private final TemplateSource source;
+    private final String detail;
+    private final String hint;
+    private final Integer line;
+    private final Integer column;
+    private final Throwable originalCause;
+
+    protected RoqException(Builder builder) {
+        // Do NOT pass cause to super: Quarkus ErrorPageGenerators uses getRootCause()
+        // to match exception class names. If we set a cause, the root cause becomes
+        // the wrapped exception (e.g. DateTimeParseException) and our generator is
+        // never called. We store it separately for display in the error page.
+        super(builder.buildMessage());
+        this.title = builder.title;
+        this.sourceFilePath = builder.sourceFilePath;
+        this.source = builder.source;
+        this.detail = builder.detail;
+        this.hint = builder.hint;
+        this.line = builder.line;
+        this.column = builder.column;
+        this.originalCause = builder.cause;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public String sourceFilePath() {
+        return sourceFilePath;
+    }
+
+    /**
+     * The template source associated with this error, if available.
+     */
+    public TemplateSource source() {
+        return source;
+    }
+
+    public String detail() {
+        return detail;
+    }
+
+    public String hint() {
+        return hint;
+    }
+
+    public Integer line() {
+        return line;
+    }
+
+    public Integer column() {
+        return column;
+    }
+
+    /**
+     * Returns the original cause (stored separately to keep this exception as the root cause
+     * for Quarkus ErrorPageGenerators matching).
+     */
+    public Throwable originalCause() {
+        return originalCause;
+    }
+
+    /**
+     * Returns the best available relative path for display.
+     * Prefers {@code source.file().relativePath()} when a source is set,
+     * falls back to {@code sourceFilePath}.
+     */
+    public String displayPath() {
+        if (source != null && source.file() != null) {
+            return source.file().relativePath();
+        }
+        return sourceFilePath;
+    }
+
+    /**
+     * Returns the full absolute path when available (for tooltips).
+     * Returns null if no absolute path can be determined.
+     */
+    public String absolutePath() {
+        if (source != null && source.file() != null) {
+            return source.file().absolutePath();
+        }
+        return null;
+    }
+
+    public static Builder builder(String title) {
+        return new Builder(title);
+    }
+
+    public static class Builder {
+        private final String title;
+        private String sourceFilePath;
+        private TemplateSource source;
+        private String detail;
+        private String hint;
+        private Integer line;
+        private Integer column;
+        private Throwable cause;
+
+        private Builder(String title) {
+            this.title = title;
+        }
+
+        public Builder sourceFilePath(String sourceFilePath) {
+            this.sourceFilePath = sourceFilePath;
+            return this;
+        }
+
+        /**
+         * Set the template source for this error. When set, the source's
+         * file paths are used for display (relative) and tooltip (absolute).
+         */
+        public Builder source(TemplateSource source) {
+            this.source = source;
+            return this;
+        }
+
+        public Builder detail(String detail) {
+            this.detail = detail;
+            return this;
+        }
+
+        public Builder hint(String hint) {
+            this.hint = hint;
+            return this;
+        }
+
+        public Builder line(Integer line) {
+            this.line = line;
+            return this;
+        }
+
+        public Builder column(Integer column) {
+            this.column = column;
+            return this;
+        }
+
+        public Builder cause(Throwable cause) {
+            this.cause = cause;
+            return this;
+        }
+
+        private String buildMessage() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(title);
+            String path = source != null && source.file() != null ? source.file().relativePath() : sourceFilePath;
+            if (path != null) {
+                sb.append(" [").append(path);
+                if (line != null) {
+                    sb.append(":").append(line);
+                    if (column != null) {
+                        sb.append(":").append(column);
+                    }
+                }
+                sb.append("]");
+            }
+            if (detail != null) {
+                sb.append(": ").append(detail);
+            }
+            if (hint != null) {
+                sb.append(" (").append(hint).append(")");
+            }
+            return sb.toString();
+        }
+
+    }
+}

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/exception/RoqStaticFileException.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/exception/RoqStaticFileException.java
@@ -1,13 +1,8 @@
 package io.quarkiverse.roq.frontmatter.runtime.exception;
 
-public class RoqStaticFileException extends RuntimeException {
+public class RoqStaticFileException extends RoqException {
 
-    public RoqStaticFileException(String message) {
-        super(message);
+    public RoqStaticFileException(RoqException.Builder builder) {
+        super(builder);
     }
-
-    public RoqStaticFileException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/Page.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/Page.java
@@ -23,6 +23,7 @@ import jakarta.enterprise.inject.Vetoed;
 
 import org.jboss.logging.Logger;
 
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 import io.quarkiverse.roq.frontmatter.runtime.exception.RoqStaticFileException;
 import io.quarkiverse.roq.frontmatter.runtime.utils.SoftLazyValue;
 import io.quarkus.arc.Arc;
@@ -245,9 +246,10 @@ public class Page {
      */
     public List<String> files() {
         if (source().usePublicFiles()) {
-            throw new RoqStaticFileException(
-                    "Can't list attached files. Convert page '%s' to a directory (with an index) to allow attaching files."
-                            .formatted(this.sourcePath()));
+            throw new RoqStaticFileException(RoqException.builder("Cannot list attached files")
+                    .source(this.source().template())
+                    .detail("This page is not a directory page, so it cannot have attached files.")
+                    .hint("Convert the page to a directory with an index file to allow attaching files."));
         }
         return source().files().names();
     }
@@ -259,9 +261,10 @@ public class Page {
      */
     public boolean fileExists(Object name) {
         if (source().usePublicFiles()) {
-            throw new RoqStaticFileException(
-                    "Can't find file '%s' attached to the page. Convert page '%s' to a directory (with an index) to allow attaching files."
-                            .formatted(name, this.sourcePath()));
+            throw new RoqStaticFileException(RoqException.builder("Cannot find attached file")
+                    .source(this.source().template())
+                    .detail("Cannot check for file '%s' because this page is not a directory page.".formatted(name))
+                    .hint("Convert the page to a directory with an index file to allow attaching files."));
         }
         var f = normaliseName(name, source().files().slugified());
         return source().fileExists(f);
@@ -276,15 +279,14 @@ public class Page {
      */
     public RoqUrl file(Object name) {
         if (!source().isIndex()) {
-            throw new RoqStaticFileException(
-                    "Only page directories with an index can have attached files. Then add '%s' to the page directory to fix this error."
-                            .formatted(name, this.sourcePath()));
+            throw new RoqStaticFileException(RoqException.builder("Not a directory page")
+                    .source(this.source().template())
+                    .detail("Cannot attach file '%s' to this page.".formatted(name))
+                    .hint("Only directory pages with an index can have attached files. Move the page into a directory with an index file."));
         }
         final Path path = Path.of(this.sourcePath());
         final String dir = path.getParent() == null ? "/" : toUnixPath(path.getParent().toString());
-        return resolveFile(this, name,
-                "Page '" + this.sourcePath() + "': can't find '%s' in  '" + dir + "' which has no attached static file.",
-                "Page '" + this.sourcePath() + "': file '%s' not found in '" + dir + "' directory (found: %s).");
+        return resolveFile(this, name, "the '%s' directory".formatted(dir));
     }
 
     /**

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/utils/Pages.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/utils/Pages.java
@@ -5,6 +5,7 @@ import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.IMG;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.PICTURE;
 import static io.quarkiverse.roq.frontmatter.runtime.model.PageFiles.slugifyFile;
 
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 import io.quarkiverse.roq.frontmatter.runtime.exception.RoqStaticFileException;
 import io.quarkiverse.roq.frontmatter.runtime.model.Page;
 import io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl;
@@ -14,20 +15,24 @@ public final class Pages {
     private Pages() {
     }
 
-    public static RoqUrl resolveFile(Page page, Object name, String missingResourceMessage,
-            String notFoundMessage) {
+    public static RoqUrl resolveFile(Page page, Object name, String fileContext) {
         if (name == null) {
             return null;
         }
         if (page.source().hasNoFiles()) {
-            throw new RoqStaticFileException(missingResourceMessage.formatted(name));
+            throw new RoqStaticFileException(RoqException.builder("File not found")
+                    .source(page.source().template())
+                    .detail("'%s' not found in %s (directory is empty).".formatted(name, fileContext))
+                    .hint("Add the file to the page directory or check the file name."));
         }
         final String f = normaliseName(name, page.source().files().slugified());
         if (page.source().fileExists(f)) {
             return page.url().resolve(f);
         } else {
-            throw new RoqStaticFileException(notFoundMessage.formatted(name,
-                    String.join(", ", page.source().files().names())));
+            throw new RoqStaticFileException(RoqException.builder("File not found")
+                    .source(page.source().template())
+                    .detail("'%s' not found in %s.".formatted(name, fileContext))
+                    .hint("Available files: %s".formatted(String.join(", ", page.source().files().names()))));
         }
     }
 
@@ -42,8 +47,7 @@ public final class Pages {
     }
 
     public static RoqUrl resolvePublicFile(Page page, Object name) {
-        return resolveFile(page, name, "File '%s' not found in public dir (public dir is empty).",
-                "File '%s' not found in public dir (found: %s).");
+        return resolveFile(page, name, "the public directory");
     }
 
     public static String getImgFromData(JsonObject data) {

--- a/roq-frontmatter/runtime/src/main/resources/META-INF/services/io.quarkus.dev.spi.HotReplacementSetup
+++ b/roq-frontmatter/runtime/src/main/resources/META-INF/services/io.quarkus.dev.spi.HotReplacementSetup
@@ -1,0 +1,1 @@
+io.quarkiverse.roq.frontmatter.runtime.devmode.RoqErrorPageSetup

--- a/roq-plugin/sitemap/deployment/src/main/java/io/quarkiverse/roq/plugin/sitemap/deployment/RoqPluginSitemapProcessor.java
+++ b/roq-plugin/sitemap/deployment/src/main/java/io/quarkiverse/roq/plugin/sitemap/deployment/RoqPluginSitemapProcessor.java
@@ -17,6 +17,7 @@ import org.jboss.logging.Logger;
 import io.quarkiverse.roq.frontmatter.deployment.exception.RoqPluginException;
 import io.quarkiverse.roq.frontmatter.deployment.items.data.RoqFrontMatterDataModificationBuildItem;
 import io.quarkiverse.roq.frontmatter.runtime.config.RoqSiteConfig;
+import io.quarkiverse.roq.frontmatter.runtime.exception.RoqException;
 import io.quarkiverse.roq.plugin.sitemap.runtime.RoqPluginSitemapTemplateExtension;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -71,7 +72,10 @@ public class RoqPluginSitemapProcessor {
                         LOGGER.warnf(e, "Error while reading git last commit date for file: %s", source.path());
                     } else {
                         throw new RoqPluginException(
-                                "Error while reading git last commit date for file: %s".formatted(source.path()), e);
+                                RoqException.builder("Sitemap plugin error")
+                                        .sourceFilePath(source.path().toString())
+                                        .detail("Error while reading git last commit date")
+                                        .cause(e));
                     }
                 }
             }

--- a/roq/integration-tests/src/test/java/io/quarkiverse/roq/RoqErrorsTest.java
+++ b/roq/integration-tests/src/test/java/io/quarkiverse/roq/RoqErrorsTest.java
@@ -13,44 +13,44 @@ public class RoqErrorsTest extends AbstractRoqTest {
     @Test
     public void testErrorFilePage() {
         RestAssured.when().get("/posts/error-file").then().statusCode(500).log().ifValidationFails().body(containsString(
-                "RoqStaticFileException: Only page directories with an index can have attached files. Then add 'not-found.pdf' to the page directory to fix this error."));
+                "Cannot attach file &#39;not-found.pdf&#39; to this page."));
     }
 
     @Test
     public void testErrorImagePage() {
         RestAssured.when().get("/posts/error-image").then().statusCode(500).log().ifValidationFails().body(containsString(
-                "RoqStaticFileException: File 'images/not-found.png' not found in public dir"));
+                "&#39;images/not-found.png&#39; not found in the public directory"));
     }
 
     @Test
     public void testErrorImagePageDir() {
         RestAssured.when().get("/posts/error-image-dir").then().statusCode(500).log().ifValidationFails().body(containsString(
-                "File 'images/not-found.png' not found in public dir"));
+                "&#39;images/not-found.png&#39; not found in the public directory"));
     }
 
     @Test
     public void testErrorFilePageDir() {
         RestAssured.when().get("/posts/error-file-dir").then().statusCode(500).log().ifValidationFails().body(containsString(
-                "Page 'posts/error-file-dir/index.md': can't find 'not-found.pdf' in  'posts/error-file-dir' which has no attached static file."));
+                "&#39;not-found.pdf&#39; not found in"));
     }
 
     @Test
     public void testErrorFilePageDirNotFound() {
         RestAssured.when().get("/posts/error-image-not-found").then().statusCode(500).log().ifValidationFails()
                 .body(containsString(
-                        " Page 'posts/error-image-not-found/index.md': file 'not-found.png' not found in 'posts/error-image-not-found' directory (found: hello.png)."));
+                        "&#39;not-found.png&#39; not found in"));
     }
 
     @Test
     public void testErrorImageSite() {
         RestAssured.when().get("/error-image-site").then().statusCode(500).log().ifValidationFails().body(containsString(
-                "RoqStaticFileException: File 'images/not-found.png' not found in public dir"));
+                "&#39;images/not-found.png&#39; not found in the public directory"));
     }
 
     @Test
     public void testErrorStaticFileSite() {
         RestAssured.when().get("/error-static-file").then().statusCode(500).log().ifValidationFails()
-                .body(containsString("RoqStaticFileException: File 'not-found.pdf' not found in public dir"));
+                .body(containsString("&#39;not-found.pdf&#39; not found in the public directory"));
     }
 
 }


### PR DESCRIPTION
## Summary
- Introduce `RoqException` base class with structured fields (title, source file, detail, hint, line/column) and a Builder pattern for all Roq exceptions
- Add branded HTML error page renderer (`RoqErrorPage`) with Roq mascot, teal/orange theme, shimmer animation, and refresh button
- Register custom error pages via `ErrorPageGenerators` SPI for build-time errors, and intercept `RoqException` in `RoqRouteHandler` for runtime template rendering errors
- Detect multiple site index pages and throw a clear error (fixes #652)