### PR TITLE
Convert Roq CLI to Quarkus Picocli application

### DIFF
--- a/.github/workflows/hooks/post-prepare-release.sh
+++ b/.github/workflows/hooks/post-prepare-release.sh
@@ -2,4 +2,6 @@
 
 set -e
 
-sed -i "s/:999-SNAPSHOT@/:${CURRENT_VERSION}@/g" jbang-catalog.json
+sed -i "s|quarkus-roq-cli/[^/]*/quarkus-roq-cli-[^-]*-runner|quarkus-roq-cli/${CURRENT_VERSION}/quarkus-roq-cli-${CURRENT_VERSION}-runner|g" jbang-catalog.json
+git add jbang-catalog.json
+git commit -m "Update jbang-catalog.json for ${CURRENT_VERSION}"

--- a/blog/content/marketplace.html
+++ b/blog/content/marketplace.html
@@ -2,4 +2,5 @@
 title: Plugins & Themes
 description: Browse plugins and themes for your Roq site
 layout: marketplace
+aliases: [/docs/plugins, /docs/themes]
 ---

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -3,7 +3,7 @@
   "aliases": {
     "roq": {
       "description": "Roq CLI - static site generator",
-      "script-ref": "https://repo1.maven.org/maven2/io/quarkiverse/roq/quarkus-roq-cli/2.1.0.CR1/quarkus-roq-cli-2.1.0.CR1-fatjar.jar"
+      "script-ref": "https://repo1.maven.org/maven2/io/quarkiverse/roq/quarkus-roq-cli/2.1.0.CR1/quarkus-roq-cli-2.1.0.CR1-runner.jar"
     }
   },
   "templates": {}

--- a/roq-cli/pom.xml
+++ b/roq-cli/pom.xml
@@ -13,8 +13,6 @@
     <description>Command line interface for Roq static site generator</description>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
         <vertx.version>5.0.10</vertx.version>
     </properties>
 
@@ -32,6 +30,10 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-picocli</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-cli-common</artifactId>
@@ -60,38 +62,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.0</version>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>build</goal>
                         </goals>
                         <configuration>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>io.quarkiverse.roq.cli.RoqMain</mainClass>
-                                </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/sisu/javax.inject.Named</resource>
-                                </transformer>
-                            </transformers>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                            <shadedClassifierName>fatjar</shadedClassifierName>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <skipOriginalJarRename>true</skipOriginalJarRename>
                         </configuration>
                     </execution>
                 </executions>

--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqMain.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqMain.java
@@ -7,14 +7,23 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import jakarta.inject.Inject;
+
 import io.quarkus.cli.common.OutputOptionMixin;
 import io.quarkus.cli.common.OutputProvider;
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.QuarkusApplication;
+import io.quarkus.runtime.annotations.QuarkusMain;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
+@QuarkusMain
 @Command(name = "roq", mixinStandardHelpOptions = true, subcommands = { StartCommand.class, ServeCommand.class,
         CreateCommand.class, AddCommand.class, UpdateCommand.class, GenerateCommand.class, BlogCommand.class })
-public class RoqMain implements Callable<Integer>, OutputProvider {
+public class RoqMain implements QuarkusApplication, Callable<Integer>, OutputProvider {
+
+    @Inject
+    CommandLine.IFactory factory;
 
     @CommandLine.Mixin(name = "output")
     OutputOptionMixin output;
@@ -27,10 +36,14 @@ public class RoqMain implements Callable<Integer>, OutputProvider {
         return output;
     }
 
-    public static void main(String[] args) {
-        System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
-        int exitCode = new CommandLine(new RoqMain()).execute(args);
-        System.exit(exitCode);
+    public static void main(String... args) {
+        Quarkus.run(RoqMain.class, args);
+    }
+
+    @Override
+    public int run(String... args) throws Exception {
+        CommandLine cmd = factory == null ? new CommandLine(this) : new CommandLine(this, factory);
+        return cmd.execute(args);
     }
 
     @Override
@@ -39,7 +52,8 @@ public class RoqMain implements Callable<Integer>, OutputProvider {
             List<String> args = new ArrayList<>();
             args.add("start");
             args.addAll(unmatched);
-            return new CommandLine(this).execute(args.toArray(new String[0]));
+            CommandLine cmd = factory == null ? new CommandLine(this) : new CommandLine(this, factory);
+            return cmd.execute(args.toArray(new String[0]));
         }
         new CommandLine(this).usage(System.out);
         return CommandLine.ExitCode.OK;

--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqProjectCreator.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqProjectCreator.java
@@ -96,7 +96,8 @@ public class RoqProjectCreator {
         }
 
         // Add default theme when no theme extension is specified
-        if (allExtensions.stream().noneMatch(e -> e.contains("roq-theme-"))) {
+        if ((extensions == null || extensions.stream().noneMatch(e -> e.trim().startsWith("theme:")))
+                && allExtensions.stream().noneMatch(e -> e.contains("roq-theme-"))) {
             allExtensions.add(withVersion(ROQ_PREFIX + "theme-default"));
         }
 

--- a/roq-cli/src/main/resources/application.properties
+++ b/roq-cli/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+quarkus.log.level=WARN
+quarkus.log.category."io.quarkus.config".level=ERROR
+quarkus.banner.enabled=false
+quarkus.package.jar.type=uber-jar
+quarkus.config.sources.system-only=true
+quarkus.arc.detect-unused-false-positives=false
+quarkus.native.resources.includes=quarkus.properties
+quarkus.native.additional-build-args=--initialize-at-run-time=org.apache.maven.wagon.shared.http.AbstractHttpClientWagon
+quarkus.native.enable-https-url-handler=true


### PR DESCRIPTION
## Summary
- Replace maven-shade-plugin fatjar (42MB) with Quarkus uber-jar build (27MB) using quarkus-picocli
- RoqMain now uses @QuarkusMain and QuarkusApplication with injected CommandLine.IFactory
- Add application.properties with logging/banner/config settings matching Quarkus CLI
- Fix `theme:base` not preventing default theme addition in project creator
- Fix post-prepare-release hook: correct sed pattern and add git commit
- Update jbang-catalog.json classifier from fatjar to runner
- Add /docs/plugins and /docs/themes redirects to marketplace page