### PR TITLE
fix: Handle null paginator in blog.html theme layout

### DIFF
--- a/blog/content/docs/releases.adoc
+++ b/blog/content/docs/releases.adoc
@@ -103,6 +103,11 @@ Give it a try, it is enabled on this site. If you want this for your site:
 | ⚠ Wrap with `{#if page.date}...{/if}`
 
 | Theme users
+| `index.html` layout for blog listing
+| New `blog.html` layout (with pagination support); `index.html` now delegates to it
+| ⚠ If using `layout: blog` without pagination (`paginate: false`), add `paginate: posts`; if you have a custom `blog.html` override, use `{#if page.paginator and page.paginator.isFirst}` instead of `{#if page.paginator.isFirst}`
+
+| Theme users
 | SCSS (`app.scss`)
 | CSS with https://tailwindcss.com/[TailwindCSS]
 | ⚠ Migrate custom styles

--- a/roq-theme/default/runtime/src/main/resources/templates/theme-layouts/roq-default/blog.html
+++ b/roq-theme/default/runtime/src/main/resources/templates/theme-layouts/roq-default/blog.html
@@ -16,7 +16,7 @@ featured: 2
 <div class="blog-list">
 
   {! Featured posts on first page !}
-  {#if page.paginator.isFirst}
+  {#if page.paginator and page.paginator.isFirst}
   <div class="blog-featured-grid">
     {#for post in posts.featured(page.data.featured)}
     {#roq/postCard post /}
@@ -26,7 +26,7 @@ featured: 2
 
   {! Post grid: skip featured on first page !}
   <div class="blog-grid">
-    {#if page.paginator.isFirst}
+    {#if page.paginator and page.paginator.isFirst}
     {#for post in posts.rest(page.data.featured)}
     {#roq/postCard post /}
     {/for}


### PR DESCRIPTION
Fixes #857

Add null check for page.paginator in blog.html, following the same pattern as pagination.html. Also add migration note in releases.adoc.

[repro-null-paginator-2.1.zip](https://github.com/user-attachments/files/27090450/repro-null-paginator-2.1.zip)
[repro-null-paginator-dev.zip](https://github.com/user-attachments/files/27090452/repro-null-paginator-dev.zip)
