### PR TITLE
Bump deprecated actions to Node.js 24 versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"           # action.yml at the repo root
+      - "/.github/workflows"
+    schedule:
+      interval: "weekly"

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
     # Step 1: Set up Java
     - name: Set up Java
       if: ${{ inputs.setup-java == 'true' }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.java-distribution }}
@@ -138,11 +138,11 @@ runs:
     # Step 5: Setup GitHub Pages
     - name: Setup Pages
       if: ${{ inputs.github-pages == 'true' }}
-      uses: actions/configure-pages@v5
+      uses: actions/configure-pages@v6
 
     # Step 6: Upload Artifact to GitHub Pages
     - name: Upload Artifact
       if: ${{ inputs.github-pages == 'true' }}
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v5
       with:
         path: ${{ env.SITE_DIR }}${{ inputs.artifact-path }}


### PR DESCRIPTION
## Summary

GitHub Actions has [deprecated Node.js 20](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Workflows that consume this composite action currently surface warnings like:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20: `actions/configure-pages@v5`, `actions/setup-java@v4`, `actions/upload-artifact@v4`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## Changes

- `actions/setup-java@v4` → `@v5` (Node 24)
- `actions/configure-pages@v5` → `@v6` (Node 24)
- `actions/upload-pages-artifact@v3` → `@v5` (Node 24)

I scanned the release notes for breaking changes and nothing that should impact the action.

- `setup-java@v5` only requires runner v2.327.1+, already provided by `ubuntu-latest`.
- `configure-pages@v5`/`@v6` breaking changes are scoped to Next.js >= 13.3.0 users; the Roq action does not pass `static_site_generator`.
- `upload-pages-artifact@v5` is a Node-bump-only release; the `path` input is unchanged.

Also added `github-actions` to `.github/dependabot.yml` so the actions stay current automatically. Both the repo root (`action.yml`) and `.github/workflows` are tracked.


Thanks to Claude for the help on getting this update out of the way :) 