### PR TITLE
Fix page.content attribute propagation and add RSS contentLimit option

### DIFF
--- a/blog/content/docs/basics.adoc
+++ b/blog/content/docs/basics.adoc
@@ -561,10 +561,20 @@ Then create a `content/rss.xml` file with:
 
 [source,html]
 ----
-{#include fm/rss.html}
+{#include fm/rss.html /}
 ----
 
 Roq will generate a valid RSS feed from your blog posts FrontMatter data.
+
+By default, `<content:encoded>` contains the post description. Use the `contentLimit` parameter to include richer content:
+
+[source,html]
+----
+\{#include fm/rss.html contentLimit=0 /}  <1>
+\{#include fm/rss.html contentLimit=150 /}  <2>
+----
+<1> Full rendered content
+<2> Content abstract limited to 150 words
 
 [[llmstxt]]
 === LLMs.txt

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,10 +1,12 @@
 {
-  "catalogs": {},
   "aliases": {
     "roq": {
+      "script-ref": "https://repo1.maven.org/maven2/io/quarkiverse/roq/quarkus-roq-cli/2.1.0/quarkus-roq-cli-2.1.0-runner.jar",
       "description": "Roq CLI - static site generator",
-      "script-ref": "https://repo1.maven.org/maven2/io/quarkiverse/roq/quarkus-roq-cli/2.1.0/quarkus-roq-cli-2.1.0-runner.jar"
+      "runtime-options": [
+        "--add-opens",
+        "java.base/java.lang=ALL-UNNAMED"
+      ]
     }
-  },
-  "templates": {}
+  }
 }

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterBasicTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterBasicTest.java
@@ -124,4 +124,34 @@ public class RoqFrontMatterBasicTest {
                 .body("html.body.article.span.find { it.@class == 'literal' }.text()", equalTo("{=not-alt-syntax}"));
     }
 
+    @Test
+    @DisplayName("RSS default mode uses description in content:encoded")
+    public void testRssDefault() {
+        String body = RestAssured.when().get("/rss.xml").then().statusCode(200).log().ifValidationFails()
+                .extract().body().asString();
+        assertTrue(body.contains("<title><![CDATA[New Post]]></title>"), "Should contain post title");
+        assertTrue(body.contains("A short description of the new post"), "Should contain post description");
+        assertTrue(body.contains("Keep reading"), "Should contain keep reading link");
+    }
+
+    @Test
+    @DisplayName("RSS full mode includes rendered page content")
+    public void testRssFull() {
+        String body = RestAssured.when().get("/rss-full.xml").then().statusCode(200).log().ifValidationFails()
+                .extract().body().asString();
+        assertTrue(body.contains("New post with html"), "Should contain full rendered content");
+        assertTrue(body.contains("This is a new post."), "Should contain post paragraph");
+        assertTrue(body.contains("Keep reading"), "Should contain keep reading link");
+    }
+
+    @Test
+    @DisplayName("RSS limit mode includes word-limited content abstract")
+    public void testRssLimit() {
+        String body = RestAssured.when().get("/rss-limit.xml").then().statusCode(200).log().ifValidationFails()
+                .extract().body().asString();
+        assertTrue(body.contains("content:encoded"), "Should contain content:encoded element");
+        assertTrue(body.contains("..."), "Should contain truncation marker from word limit");
+        assertTrue(body.contains("Keep reading"), "Should contain keep reading link");
+    }
+
 }

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterSourceFileTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterSourceFileTest.java
@@ -119,8 +119,8 @@ public class RoqFrontMatterSourceFileTest {
     @DisplayName("Site page count")
     public void testSitePageCount() {
         RestAssured.when().get("/").then().statusCode(200).log().ifValidationFails()
-                .body("html.body.span.find { it.@class == 'page-count' }.text()",
-                        greaterThanOrEqualTo("2"));
+                .body("html.body.span.find { it.@class == 'page-count' }.text().toInteger()",
+                        greaterThanOrEqualTo(2));
     }
 
     @Test
@@ -135,7 +135,7 @@ public class RoqFrontMatterSourceFileTest {
     @DisplayName("All pages count includes documents")
     public void testAllPagesCount() {
         RestAssured.when().get("/").then().statusCode(200).log().ifValidationFails()
-                .body("html.body.span.find { it.@class == 'all-pages-count' }.text()",
-                        greaterThanOrEqualTo("5"));
+                .body("html.body.span.find { it.@class == 'all-pages-count' }.text().toInteger()",
+                        greaterThanOrEqualTo(5));
     }
 }

--- a/roq-frontmatter/deployment/src/test/resources/basic-site/content/posts/2024-10-09-new-post.html
+++ b/roq-frontmatter/deployment/src/test/resources/basic-site/content/posts/2024-10-09-new-post.html
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: New Post
+description: A short description of the new post
 ---
 
 <h1>New post with html</h1>

--- a/roq-frontmatter/deployment/src/test/resources/basic-site/content/rss-full.xml
+++ b/roq-frontmatter/deployment/src/test/resources/basic-site/content/rss-full.xml
@@ -1,0 +1,1 @@
+{#include fm/rss.html contentLimit=0 /}

--- a/roq-frontmatter/deployment/src/test/resources/basic-site/content/rss-limit.xml
+++ b/roq-frontmatter/deployment/src/test/resources/basic-site/content/rss-limit.xml
@@ -1,0 +1,1 @@
+{#include fm/rss.html contentLimit=3 /}

--- a/roq-frontmatter/deployment/src/test/resources/basic-site/content/rss.xml
+++ b/roq-frontmatter/deployment/src/test/resources/basic-site/content/rss.xml
@@ -1,0 +1,1 @@
+{#include fm/rss.html /}

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqQuteEngineObserver.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqQuteEngineObserver.java
@@ -40,8 +40,14 @@ public class RoqQuteEngineObserver {
         builder.addTemplateInstanceInitializer(templateInstance -> {
             final String templateId = templateInstance.getTemplate().getId();
             templateInstance.setAttribute(TEMPLATE_ID, templateId);
-            if (templatePathMapping.containsKey(templateId)) {
-                final SourceFile sourceFile = templatePathMapping.get(templateId);
+            SourceFile sourceFile = templatePathMapping.get(templateId);
+            if (sourceFile == null) {
+                int fragmentSep = templateId.lastIndexOf('$');
+                if (fragmentSep > 0) {
+                    sourceFile = templatePathMapping.get(templateId.substring(0, fragmentSep));
+                }
+            }
+            if (sourceFile != null) {
                 templateInstance.setAttribute(SOURCE_PATH, sourceFile.absolutePath());
                 templateInstance.setAttribute(SOURCE_ROOT_PATH, sourceFile.siteDirPath());
             }

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqRouteHandler.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqRouteHandler.java
@@ -153,12 +153,7 @@ public class RoqRouteHandler implements Handler<RoutingContext> {
                 }
             }
 
-            instance.data("page", page);
-            instance.data("site", site.get());
-            instance.setAttribute(RoqTemplateAttributes.SITE_URL, site.get().url().absolute());
-            instance.setAttribute(RoqTemplateAttributes.SITE_PATH, site.get().url().relative());
-            instance.setAttribute(RoqTemplateAttributes.PAGE_URL, page.url().absolute());
-            instance.setAttribute(RoqTemplateAttributes.PAGE_PATH, page.url().relative());
+            RoqTemplateAttributes.setPageData(instance, page, site.get());
             instance.setAttribute(TemplateInstance.LOCALE, getLocale(page, rc));
             instance.renderAsync().whenComplete((r, t) -> {
                 if (t != null) {

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplateAttributes.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplateAttributes.java
@@ -1,5 +1,9 @@
 package io.quarkiverse.roq.frontmatter.runtime;
 
+import io.quarkiverse.roq.frontmatter.runtime.model.Page;
+import io.quarkiverse.roq.frontmatter.runtime.model.Site;
+import io.quarkus.qute.TemplateInstance;
+
 public record RoqTemplateAttributes(String sourceRootPath,
         String sourcePath,
         String siteUrl,
@@ -14,5 +18,16 @@ public record RoqTemplateAttributes(String sourceRootPath,
     public static final String PAGE_URL = "pageUrl";
     public static final String SITE_PATH = "sitePath";
     public static final String SITE_URL = "siteUrl";
+
+    public static void setPageData(TemplateInstance instance, Page page, Site site) {
+        instance.data("page", page);
+        instance.data("site", site);
+        instance.setAttribute(SOURCE_PATH, page.source().template().file().absolutePath());
+        instance.setAttribute(SOURCE_ROOT_PATH, page.source().template().file().siteDirPath());
+        instance.setAttribute(SITE_URL, site.url().absolute());
+        instance.setAttribute(SITE_PATH, site.url().relative());
+        instance.setAttribute(PAGE_URL, page.url().absolute());
+        instance.setAttribute(PAGE_PATH, page.url().relative());
+    }
 
 }

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/Page.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/Page.java
@@ -14,7 +14,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -23,12 +22,14 @@ import jakarta.enterprise.inject.Vetoed;
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.roq.exception.RoqException;
+import io.quarkiverse.roq.frontmatter.runtime.RoqTemplateAttributes;
 import io.quarkiverse.roq.frontmatter.runtime.exception.RoqStaticFileException;
 import io.quarkiverse.roq.frontmatter.runtime.utils.SoftLazyValue;
 import io.quarkus.arc.Arc;
 import io.quarkus.qute.Engine;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateData;
+import io.quarkus.qute.TemplateInstance;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -115,11 +116,10 @@ public class Page {
             if (template == null) {
                 return "";
             }
-            // Use the fragment for pages with a layout, or the full template otherwise
             final Template contentTemplate = template.getFragment(ROQ_PAGE_CONTENT_FRAGMENT);
-            return (contentTemplate != null ? contentTemplate : template).render(Map.of(
-                    "page", this,
-                    "site", site()));
+            final TemplateInstance instance = (contentTemplate != null ? contentTemplate : template).instance();
+            RoqTemplateAttributes.setPageData(instance, this, site());
+            return instance.render();
 
         } catch (Exception e) {
             LOG.warnf(e, "Failed to render page content for page: '%s'", sourcePath());

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/Site.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/Site.java
@@ -20,6 +20,7 @@ import jakarta.enterprise.inject.Vetoed;
 
 import org.jboss.logging.Logger;
 
+import io.quarkiverse.roq.exception.RoqException;
 import io.quarkiverse.roq.frontmatter.runtime.exception.RoqStaticFileException;
 import io.quarkiverse.tools.stringpaths.StringPaths;
 import io.quarkus.arc.impl.LazyValue;
@@ -134,7 +135,26 @@ public final class Site {
         if (fileExists(StringPaths.join("static/assets/images", path))) {
             return file(StringPaths.join("static/assets/images", path));
         }
-        return file(StringPaths.join(imagesDir, path));
+        String resolvedPath = StringPaths.join(imagesDir, path);
+        if (page.source().fileExists(resolvedPath)) {
+            return page.url().resolve(resolvedPath);
+        }
+        List<String> imageFiles = page.source().files().names().stream()
+                .filter(f -> f.startsWith(imagesDir))
+                .map(f -> f.substring(imagesDir.length()))
+                .toList();
+        RoqException.Builder error = RoqException.builder("Image not found")
+                .detail("'%s' not found in the '%s' directory (resolved to '%s').".formatted(name, imagesDir, resolvedPath));
+        if (page.source().template() != null) {
+            error.sourceInfo(page.source().template().file().toSourceInfo());
+        }
+        if (imageFiles.isEmpty()) {
+            error.hint("The '%s' directory is empty. Add the image to your public/%s directory.".formatted(imagesDir,
+                    imagesDir));
+        } else {
+            error.hint("Available images: %s".formatted(String.join(", ", imageFiles)));
+        }
+        throw new RoqStaticFileException(error);
     }
 
     /**

--- a/roq-frontmatter/runtime/src/main/resources/templates/fm/rss.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/fm/rss.html
@@ -1,7 +1,8 @@
 {@java.lang.String collectionName}
+{@java.lang.Integer contentLimit}
 {@io.quarkiverse.roq.frontmatter.runtime.model.Site site}
 {@io.quarkiverse.roq.frontmatter.runtime.model.NormalPage page}
-{#let name=(collectionName ?: 'posts')}
+{#let name=(collectionName ?: 'posts') cl=contentLimit.or(-1)}
 <rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
   <channel>
     <title><![CDATA[ {site.title} ]]></title>
@@ -18,10 +19,17 @@
         <guid isPermaLink="false">{post.url.absolute}</guid>
         <pubDate>{post.date.rfc822}</pubDate>
         <description><![CDATA[{post.description}]]></description>
+        {#if cl >= 0}
+        {#if cl == 0}
+        <content:encoded><![CDATA[{post.content}<div style="margin-top: 50px; font-style: italic;"><strong><a href="{post.url.absolute}">Keep reading</a>.</strong></div><br /> <br />]]></content:encoded>
+        {#else}
+        <content:encoded><![CDATA[<p>{post.contentAbstract(contentLimit)}</p><div style="margin-top: 50px; font-style: italic;"><strong><a href="{post.url.absolute}">Keep reading</a>.</strong></div><br /> <br />]]></content:encoded>
+        {/if}
+        {#else}
         <content:encoded><![CDATA[<p>{post.description}</p><div style="margin-top: 50px; font-style: italic;"><strong><a href="{post.url.absolute}">Keep reading</a>.</strong></div><br /> <br />]]></content:encoded>
+        {/if}
       </item>
     {/for}
     {/if}
   </channel>
 </rss>
-

--- a/roq-plugin/asciidoc-jruby/integration-tests/src/main/resources/content/content-test.html
+++ b/roq-plugin/asciidoc-jruby/integration-tests/src/main/resources/content/content-test.html
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Content Test
+link: /content-test
+---
+
+<div class="content-result">{site.page('guides/my-doc.adoc').content}</div>

--- a/roq-plugin/asciidoc-jruby/integration-tests/src/test/java/io/quarkiverse/roq/RoqAsciidocJTest.java
+++ b/roq-plugin/asciidoc-jruby/integration-tests/src/test/java/io/quarkiverse/roq/RoqAsciidocJTest.java
@@ -56,4 +56,12 @@ public class RoqAsciidocJTest {
     public void testErrorAboveSite() {
         RestAssured.when().get("/guides/include-error-above-site/").then().statusCode(500).log().ifValidationFails();
     }
+
+    @Test
+    public void testPageContentWithIncludes() {
+        final String body = RestAssured.when().get("/content-test").then().statusCode(200).log().ifValidationFails().extract()
+                .asString();
+        assertThat(body).contains("content-result");
+        assertThat(body).contains("Roughly 15 minutes");
+    }
 }

--- a/roq-plugin/asciidoc/integration-tests/src/main/resources/content/content-test.html
+++ b/roq-plugin/asciidoc/integration-tests/src/main/resources/content/content-test.html
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Content Test
+link: /content-test
+---
+
+<div class="content-result">{site.page('guides/my-doc.adoc').content}</div>

--- a/roq-plugin/asciidoc/integration-tests/src/test/java/io/quarkiverse/roq/RoqAsciidocTest.java
+++ b/roq-plugin/asciidoc/integration-tests/src/test/java/io/quarkiverse/roq/RoqAsciidocTest.java
@@ -33,4 +33,11 @@ public class RoqAsciidocTest {
         RestAssured.when().get("/guides/include-error/").then().statusCode(500).log().ifValidationFails();
     }
 
+    @Test
+    public void testPageContentWithIncludes() {
+        final String body = RestAssured.when().get("/content-test").then().statusCode(200).log().ifValidationFails().extract()
+                .asString();
+        assertThat(body).contains("content-result");
+        assertThat(body).contains("Roughly 15 minutes");
+    }
 }

--- a/roq/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/roq/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -51,6 +51,8 @@ Create `content/rss.xml`:
 
 Add `{#rss site /}` to your root layout `<head>` to include the RSS feed link.
 
+Use `contentLimit` to control `<content:encoded>`: omit for description only (default), `contentLimit=0` for full rendered content, `contentLimit=N` for a word-limited content abstract (e.g. `{#include fm/rss.html contentLimit=150 /}`).
+
 ### LLMs.txt
 
 Generate `/llms.txt` and `/llms-full.txt` for AI discoverability. Create `content/llms.qute.txt`:

--- a/roq/integration-tests/src/test/java/io/quarkiverse/roq/RoqErrorsTest.java
+++ b/roq/integration-tests/src/test/java/io/quarkiverse/roq/RoqErrorsTest.java
@@ -18,14 +18,17 @@ public class RoqErrorsTest extends AbstractRoqTest {
 
     @Test
     public void testErrorImagePage() {
-        RestAssured.when().get("/posts/error-image").then().statusCode(500).log().ifValidationFails().body(containsString(
-                "&#39;images/not-found.png&#39; not found in the public directory"));
+        RestAssured.when().get("/posts/error-image").then().statusCode(500).log().ifValidationFails()
+                .body(containsString("&#39;not-found.png&#39; not found in the &#39;images/&#39; directory"))
+                .body(containsString("Available images:"))
+                .body(containsString("hello.png"));
     }
 
     @Test
     public void testErrorImagePageDir() {
-        RestAssured.when().get("/posts/error-image-dir").then().statusCode(500).log().ifValidationFails().body(containsString(
-                "&#39;images/not-found.png&#39; not found in the public directory"));
+        RestAssured.when().get("/posts/error-image-dir").then().statusCode(500).log().ifValidationFails()
+                .body(containsString("&#39;not-found.png&#39; not found in the &#39;images/&#39; directory"))
+                .body(containsString("Available images:"));
     }
 
     @Test
@@ -43,8 +46,10 @@ public class RoqErrorsTest extends AbstractRoqTest {
 
     @Test
     public void testErrorImageSite() {
-        RestAssured.when().get("/error-image-site").then().statusCode(500).log().ifValidationFails().body(containsString(
-                "&#39;images/not-found.png&#39; not found in the public directory"));
+        RestAssured.when().get("/error-image-site").then().statusCode(500).log().ifValidationFails()
+                .body(containsString("&#39;not-found.png&#39; not found in the &#39;images/&#39; directory"))
+                .body(containsString("Available images:"))
+                .body(containsString("hello.png"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Fix AsciiDoc includes breaking when rendered via `page.content` by propagating `SOURCE_PATH`/`SOURCE_ROOT_PATH` attributes through fragment templates (extract shared `RoqTemplateAttributes.setPageData()` helper)
- Add `contentLimit` parameter to `fm/rss.html` template: omit for description-only (default), `0` for full rendered content, or `N` for word-limited content abstract in `<content:encoded>`
- Add integration tests for all three RSS modes and for AsciiDoc page content with includes