### PR TITLE
Add Roq 2.1 release blog post series

### DIFF
--- a/blog/content/docs/advanced.adoc
+++ b/blog/content/docs/advanced.adoc
@@ -502,16 +502,10 @@ In this case the RestAssured port will automatically use the Quarkus dynamic tes
 
 == Updating Roq
 
-Make sure your https://quarkus.io/guides/cli-tooling[Quarkus cli] is up-to-date:
+Run the update command from your project directory:
 [source,shell]
 ----
-$ curl -Ls https://sh.jbang.dev | bash -s - app install --fresh --force quarkus@quarkusio
-----
-
-Then run the update command:
-[source,shell]
-----
-$ quarkus update
+$ roq update
 ----
 
 This will update the Quarkus version and extensions (including Roq) and make sure they are compatible together.

--- a/blog/content/index.html
+++ b/blog/content/index.html
@@ -85,7 +85,7 @@ layout: home
   {#roq/featureCard icon="fa-box-open" title="Web Bundler & mvnpm" highlighted=true link="/marketplace/#webs" link-text="Browse web extensions"}
     Use any npm package as a Maven dependency through mvnpm. CSS, JS, and web assets bundled automatically via esbuild. No Node.js required.
   {/}
-  {#roq/featureCard icon="fa-pen-to-square" title="Live Editor" highlighted=true link="/posts/set-it-in-roq-the-editor-that-change-the-game/" link-text="About the editor"}
+  {#roq/featureCard icon="fa-pen-to-square" title="Live Editor" highlighted=true link=site.page('posts/2026-02-02-set-it-in-roq-the-editor-that-change-the-game/index.md').url link-text="About the editor"}
     Edit your content directly in the browser with a built-in WYSIWYG editor. Preview changes instantly in dev mode.
   {/}
 </div>

--- a/blog/content/posts/2026-02-02-set-it-in-roq-the-editor-that-change-the-game/index.md
+++ b/blog/content/posts/2026-02-02-set-it-in-roq-the-editor-that-change-the-game/index.md
@@ -1,9 +1,10 @@
 ---
-title: "Set It in Roq: The Editor that change the game!"
+title: "Set It in Roq: The Editor that changes the game!"
 image: https://images.unsplash.com/photo-1594643469650-dd506331ff7a?q=80&w=2940&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
 tags: guide, cool-stuff
 description: Roq introduces a TipTap-powered editor with Markdown support, transforming it from a static site generator into a lightweight, developer-friendly CMS. Create, edit, and preview content seamlessly within the Quarkus dev experience.
-date: 2026-02-02 00:00:00 +0100
+date: 2026-05-04 10:00:00 +0200
+series: roq-2.1
 ---
 Roq started as a solid foundation for building modern apps and static sites. But now, it’s leveling up in a big way. With the introduction of a **TipTap-powered Editor with Markdown support**, Roq is no longer just an SSG tool, it’s stepping into **CMS territory**.
 
@@ -21,10 +22,10 @@ Until now, writers had to:
 Now, with Roq’s built-in editor:
 
 - **Native integration**: all integrated in Quarkus dev experience.
-- **Rich Text Editor with Markdown support**: write your content in a notion like editor, render beautifully.
+- **Rich Text Editor with Markdown support**: write your content in a Notion-like editor, render beautifully.
 - **Preview article**: directly from the editor or using a new tab.
 
-This makes Roq feel less like a static site generator and more like a **developer-friendly CMS**, closer to the flexibility of WordPress — but without the heavyness.
+This makes Roq feel less like a static site generator and more like a **developer-friendly CMS**, closer to the flexibility of WordPress but without the heaviness.
 
 ## Key Features
 
@@ -40,7 +41,6 @@ The editor is natively integrated into Roq `2.1`.
 ```
 roq create my-blog
 ```
-
 
 Start it
 

--- a/blog/content/posts/2026-04-09-gfm-alert-blocks/index.md
+++ b/blog/content/posts/2026-04-09-gfm-alert-blocks/index.md
@@ -3,7 +3,8 @@ title: "GFM Alert Blocks: Styled Callouts in Your Markdown"
 image: https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=800
 tags: markdown, features, gfm
 description: Roq supports GitHub Flavored Markdown alert blocks with icons and themed colors. Learn how to use NOTE, TIP, IMPORTANT, WARNING, and CAUTION blocks, and how to add custom alert types.
-date: 2026-04-09 00:00:00 +0100
+date: 2026-05-04 11:00:00 +0200
+series: roq-2.1
 ---
 
 Roq now supports **GitHub Flavored Markdown (GFM) alert blocks** (also known as admonition blocks) — the styled callouts you see on GitHub READMEs and issues, complete with icons and color themes:

--- a/blog/content/posts/2026-05-04-roq-2-1-is-here.md
+++ b/blog/content/posts/2026-05-04-roq-2-1-is-here.md
@@ -40,7 +40,7 @@ cd my-blog
 roq
 ```
 
-That's it. The CLI handles project creation, dev mode, static generation, plugin management, and updates. It's built as a Quarkus Picocli application and distributed via JBang.
+That's it. The CLI handles project creation, dev mode, static generation, plugin management, and updates. It's built as a Quarkus Picocli application and distributed via [JBang]({=site.page('docs/getting-started.html').url}).
 
 ## LLMs.txt
 

--- a/blog/content/posts/2026-05-04-roq-2-1-is-here.md
+++ b/blog/content/posts/2026-05-04-roq-2-1-is-here.md
@@ -1,0 +1,72 @@
+---
+title: "Roq 2.1 is here!"
+image: https://images.unsplash.com/photo-1470596914251-afb0b4510279?q=80&w=1740&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
+description: Roq 2.1 brings a standalone CLI, LLMs.txt generation, dynamic pages from data, custom error pages, and much more. This post kicks off a series covering all the new features.
+author: ia3andy
+tags: release, cool-stuff
+series: roq-2.1
+date: 2026-05-01 10:00:00 +0200
+---
+
+Hello fellow Roqers,
+
+Roq 2.1 is officially out, and it's packed with features that make content creation smoother, the developer experience richer, and the tooling more powerful than ever.
+
+This release is big enough that we're covering it as a **series of posts**. We already published posts about the [built-in editor]({=site.page('posts/2026-02-02-set-it-in-roq-the-editor-that-change-the-game/index.md').url}) and [GFM alert blocks]({=site.page('posts/2026-04-09-gfm-alert-blocks/index.md').url}), and this post gives you the full picture of everything else that landed.
+
+## The highlights
+
+Here's what's new in Roq 2.1:
+
+- **[Built-in Content Editor]({=site.page('posts/2026-02-02-set-it-in-roq-the-editor-that-change-the-game/index.md').url})** with rich text, Markdown support, and image upload
+- **[GFM Alert Blocks]({=site.page('posts/2026-04-09-gfm-alert-blocks/index.md').url})** (NOTE, TIP, WARNING, CAUTION, IMPORTANT) with icons and themed colors
+- **Standalone Roq CLI** powered by Quarkus Picocli
+- **LLMs.txt generation** for AI discoverability
+- **Custom error pages** with source info and hints in dev mode
+- **Default theme with TailwindCSS** and zero configuration
+- **Raclette link checker** integration in roq-testing
+- **RSS content modes** (full content or word-limited abstracts)
+- **Dynamic pages from data** collections
+- **Qute alternative expression syntax** support
+- **Simplified layout resolution** with `theme-layout` support
+
+## The Roq CLI
+
+Roq now ships as a standalone CLI tool, no Maven or Gradle knowledge required:
+
+```bash
+roq create my-blog
+cd my-blog
+roq
+```
+
+That's it. The CLI handles project creation, dev mode, static generation, plugin management, and updates. It's built as a Quarkus Picocli application and distributed via JBang.
+
+## LLMs.txt
+
+Roq can auto-generate `/llms.txt` and `/llms-full.txt` following the [llms.txt specification](https://llmstxt.org/). AI systems like ChatGPT, Claude, and Perplexity use these files to understand your site's structure and content.
+
+## Dynamic pages from data
+
+You can now generate pages dynamically from data collections, perfect for catalogs, team pages, or any content driven by structured data files.
+
+## Developer experience
+
+Dev mode got a lot of love in this release:
+
+- **Custom error pages** with source file location, detailed hints, and available alternatives when something goes wrong
+- **Centralized filesystem watcher** for reliable live reload
+- **Simplified layout resolution** with the new `theme-layout` key for explicit theme layout targeting
+
+## What's coming next in this series
+
+Upcoming posts will dive deeper into:
+
+- The Roq CLI
+- LLMs.txt and AI discoverability
+- Dynamic pages from data
+- The new default theme and TailwindCSS integration
+
+Ready to try it? Check out the [Getting Started]({=site.page('docs/getting-started.html').url}) guide, or if you're already on Roq, see [how to update]({=site.page('docs/advanced.adoc').url}#updating-roq).
+
+Stay tuned and happy Roqing!


### PR DESCRIPTION
## Summary

- New overview post for Roq 2.1 covering CLI, LLMs.txt, dynamic pages, error pages, and more
- Group editor and GFM alert posts into the `roq-2.1` series with updated dates
- Fix typos in editor post (title grammar, heaviness, Notion-like)
- Use `site.page()` for cross-post links instead of hardcoded slugs
- Update "Updating Roq" docs to use `roq update` CLI command