### PR TITLE
refactor: add roq dev as alias for roq start CLI command (#890)

### DIFF
--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/StartCommand.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/StartCommand.java
@@ -8,7 +8,7 @@ import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
-@Command(name = "start", mixinStandardHelpOptions = true, description = "Start the Roq site in dev mode")
+@Command(name = "start", aliases = { "dev" }, mixinStandardHelpOptions = true, description = "Start the Roq site in dev mode")
 public class StartCommand extends BuildToolDelegatingCommand {
 
     @Option(names = { "-p",


### PR DESCRIPTION
Add oq dev as alias for oq start CLI command.
Closes #890 