### PR TITLE
Add medium-zoom for image zoom support

### DIFF
--- a/blog/pom.xml
+++ b/blog/pom.xml
@@ -16,7 +16,6 @@
         <quarkus-roq.version>999-SNAPSHOT</quarkus-roq.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <surefire-plugin.version>3.5.5</surefire-plugin.version>
         <mvnpm.medium-zoom.version>1.1.0</mvnpm.medium-zoom.version>
         <mvnpm.highlightjs.version>11.11.1</mvnpm.highlightjs.version>
     </properties>

--- a/blog/pom.xml
+++ b/blog/pom.xml
@@ -86,11 +86,6 @@
             <version>1.6.3</version>
         </dependency>-->
         <dependency>
-            <groupId>io.quarkiverse.chappie</groupId>
-            <artifactId>quarkus-chappie</artifactId>
-            <version>1.6.3</version>
-        </dependency>
-        <dependency>
             <groupId>org.mvnpm</groupId>
             <artifactId>highlight.js</artifactId>
             <version>${mvnpm.highlightjs.version}</version>

--- a/blog/pom.xml
+++ b/blog/pom.xml
@@ -16,6 +16,9 @@
         <quarkus-roq.version>999-SNAPSHOT</quarkus-roq.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
+        <surefire-plugin.version>3.5.5</surefire-plugin.version>
+        <mvnpm.medium-zoom.version>1.1.0</mvnpm.medium-zoom.version>
+        <mvnpm.highlightjs.version>11.11.1</mvnpm.highlightjs.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -84,9 +87,20 @@
             <version>1.6.3</version>
         </dependency>-->
         <dependency>
+            <groupId>io.quarkiverse.chappie</groupId>
+            <artifactId>quarkus-chappie</artifactId>
+            <version>1.6.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.mvnpm</groupId>
             <artifactId>highlight.js</artifactId>
-            <version>11.11.1</version>
+            <version>${mvnpm.highlightjs.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mvnpm</groupId>
+            <artifactId>medium-zoom</artifactId>
+            <version>${mvnpm.medium-zoom.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/blog/web/_medium-zoom.css
+++ b/blog/web/_medium-zoom.css
@@ -1,0 +1,11 @@
+/*
+ * medium-zoom sets the overlay/opened-image z-index inline (998/999), which is
+ * lower than some positioned page elements (e.g. the TIP admonition box).
+ */
+.medium-zoom-overlay {
+  z-index: 2147483646 !important;
+}
+
+.medium-zoom-image--opened {
+  z-index: 2147483647 !important;
+}

--- a/blog/web/main.js
+++ b/blog/web/main.js
@@ -1,5 +1,12 @@
 import hljs from 'highlight.js';
 import 'highlight.js/styles/github.css';
 import './_hljs-dark.css';
+import './_medium-zoom.css';
+import mediumZoom from 'medium-zoom';
 
 hljs.highlightAll();
+
+mediumZoom('.content-prose img, .asciidoc-prose img', {
+  background: 'rgba(0, 0, 0, 0.85)',
+  margin: 24,
+});


### PR DESCRIPTION
# Changes

This pull request adds support for image zooming and updates how syntax highlighting dependencies are managed in the project. The main changes include introducing the `medium-zoom` library for image zoom functionality, updating dependency management in `pom.xml`, and applying the new zoom effect to all images in the main JavaScript entry point.

Dependency management improvements:

* Added `medium-zoom` and `highlight.js` version properties to the Maven `pom.xml` properties section for better maintainability.
* Updated the `highlight.js` dependency to use the defined property for its version and set its scope to `provided`. Added the `medium-zoom` dependency with `provided` scope.

Frontend enhancements:

* Imported `medium-zoom` in `web/main.js` and initialized it to enable zooming on all images.

# Video

https://github.com/user-attachments/assets/8a2e33de-d43a-45a2-b23f-f2fa37a73875
