### PR TITLE
Disable editor auto-sync file name by default

### DIFF
--- a/roq-editor/runtime/src/main/java/io/quarkiverse/roq/editor/runtime/devui/RoqEditorConfig.java
+++ b/roq-editor/runtime/src/main/java/io/quarkiverse/roq/editor/runtime/devui/RoqEditorConfig.java
@@ -70,7 +70,7 @@ public interface RoqEditorConfig {
          * If enabled, Editor will suggest file path sync when it differs from content.
          */
         @JsonProperty("enabled")
-        @WithDefault("true")
+        @WithDefault("false")
         boolean enabled();
 
     }


### PR DESCRIPTION
## Summary
- Change the default value of `editor.suggestedPath.enabled` from `true` to `false`
- Users can still opt-in by setting `editor.suggestedPath.enabled=true` in their configuration