### PR TITLE
Add AI content generation to the Roq Editor

### DIFF
--- a/blog/content/posts/2026-02-02-set-it-in-roq-the-editor-that-change-the-game/index.md
+++ b/blog/content/posts/2026-02-02-set-it-in-roq-the-editor-that-change-the-game/index.md
@@ -48,4 +48,4 @@ Start it
 roq
 ```
 
-🚀 Hit `a` (like Admin) to Open [The Roq Editor.](http://localhost:8080/q/dev-ui/quarkus-roq-editor/roq-editor)
+🚀 Hit `m` (like Manage) to Open [The Roq Editor.](http://localhost:8080/q/dev-ui/quarkus-roq-editor/roq-editor)

--- a/blog/includes/configs/quarkus-roq-editor.adoc
+++ b/blog/includes/configs/quarkus-roq-editor.adoc
@@ -110,7 +110,7 @@ Environment variable: `+++EDITOR_SUGGESTED_PATH_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|`+++false+++`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-enabled]] [.property-path]##link:#quarkus-roq-editor_editor-sync-enabled[`+++editor.sync.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -131,7 +131,7 @@ Environment variable: `+++EDITOR_SYNC_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|`+++false+++`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-auto-sync-enabled]] [.property-path]##link:#quarkus-roq-editor_editor-sync-auto-sync-enabled[`+++editor.sync.auto-sync.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -237,6 +237,27 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`+++Update content via Roq Editor+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-ai-context]] [.property-path]##link:#quarkus-roq-editor_editor-ai-context[`+++editor.ai.context+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++editor.ai.context+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Custom context to include in every AI content generation request. Use this to set the tone, topic, or style for your blog. For example: "This is a tech blog about Quarkus. Write in a friendly, concise tone."
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++EDITOR_AI_CONTEXT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++EDITOR_AI_CONTEXT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
 
 |===
 

--- a/blog/includes/configs/quarkus-roq-editor_editor.adoc
+++ b/blog/includes/configs/quarkus-roq-editor_editor.adoc
@@ -110,7 +110,7 @@ Environment variable: `+++EDITOR_SUGGESTED_PATH_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|`+++false+++`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-enabled]] [.property-path]##link:#quarkus-roq-editor_editor-sync-enabled[`+++editor.sync.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -131,7 +131,7 @@ Environment variable: `+++EDITOR_SYNC_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|`+++false+++`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-auto-sync-enabled]] [.property-path]##link:#quarkus-roq-editor_editor-sync-auto-sync-enabled[`+++editor.sync.auto-sync.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -237,6 +237,27 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`+++Update content via Roq Editor+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-ai-context]] [.property-path]##link:#quarkus-roq-editor_editor-ai-context[`+++editor.ai.context+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++editor.ai.context+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Custom context to include in every AI content generation request. Use this to set the tone, topic, or style for your blog. For example: "This is a tech blog about Quarkus. Write in a friendly, concise tone."
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++EDITOR_AI_CONTEXT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++EDITOR_AI_CONTEXT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
 
 |===
 

--- a/blog/pom.xml
+++ b/blog/pom.xml
@@ -79,6 +79,11 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.chappie</groupId>
+            <artifactId>quarkus-chappie</artifactId>
+            <version>1.6.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.mvnpm</groupId>
             <artifactId>highlight.js</artifactId>
             <version>11.11.1</version>

--- a/docs/modules/ROOT/pages/_includes/quarkus-roq-editor.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-roq-editor.adoc
@@ -110,7 +110,7 @@ Environment variable: `+++EDITOR_SUGGESTED_PATH_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|`+++false+++`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-enabled]] [.property-path]##link:#quarkus-roq-editor_editor-sync-enabled[`+++editor.sync.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -131,7 +131,7 @@ Environment variable: `+++EDITOR_SYNC_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|`+++false+++`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-auto-sync-enabled]] [.property-path]##link:#quarkus-roq-editor_editor-sync-auto-sync-enabled[`+++editor.sync.auto-sync.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -237,6 +237,27 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`+++Update content via Roq Editor+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-ai-context]] [.property-path]##link:#quarkus-roq-editor_editor-ai-context[`+++editor.ai.context+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++editor.ai.context+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Custom context to include in every AI content generation request. Use this to set the tone, topic, or style for your blog. For example: "This is a tech blog about Quarkus. Write in a friendly, concise tone."
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++EDITOR_AI_CONTEXT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++EDITOR_AI_CONTEXT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
 
 |===
 

--- a/docs/modules/ROOT/pages/_includes/quarkus-roq-editor_editor.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-roq-editor_editor.adoc
@@ -110,7 +110,7 @@ Environment variable: `+++EDITOR_SUGGESTED_PATH_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|`+++false+++`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-enabled]] [.property-path]##link:#quarkus-roq-editor_editor-sync-enabled[`+++editor.sync.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -131,7 +131,7 @@ Environment variable: `+++EDITOR_SYNC_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|`+++false+++`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-auto-sync-enabled]] [.property-path]##link:#quarkus-roq-editor_editor-sync-auto-sync-enabled[`+++editor.sync.auto-sync.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -237,6 +237,27 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`+++Update content via Roq Editor+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-ai-context]] [.property-path]##link:#quarkus-roq-editor_editor-ai-context[`+++editor.ai.context+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++editor.ai.context+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Custom context to include in every AI content generation request. Use this to set the tone, topic, or style for your blog. For example: "This is a tech blog about Quarkus. Write in a friendly, concise tone."
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++EDITOR_AI_CONTEXT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++EDITOR_AI_CONTEXT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
 
 |===
 

--- a/roq-editor/deployment/src/main/java/io/quarkiverse/roq/editor/deployment/RoqEditorProcessor.java
+++ b/roq-editor/deployment/src/main/java/io/quarkiverse/roq/editor/deployment/RoqEditorProcessor.java
@@ -15,6 +15,8 @@ import io.quarkiverse.roq.editor.runtime.devui.RoqEditorJsonRPCService;
 import io.quarkiverse.roq.frontmatter.deployment.items.scan.RoqFrontMatterQuteMarkupBuildItem;
 import io.quarkiverse.roq.frontmatter.runtime.config.RoqSiteConfig;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Produce;
@@ -75,7 +77,7 @@ public class RoqEditorProcessor {
                 : c.getOptionalValue("quarkus.http.port", String.class).orElse("8080");
 
         String protocol = isInsecureDisabled ? "https" : "http";
-        context.reset(new ConsoleCommand('a', "Open the Roq Editor in a browser (Admin)", null,
+        context.reset(new ConsoleCommand('m', "Open the Roq Editor in a browser (Manage content)", null,
                 () -> IdeHelper.openBrowser(rp, np, protocol, "/q/dev-ui/quarkus-roq-editor/roq-editor", host, port)));
     }
 
@@ -88,16 +90,19 @@ public class RoqEditorProcessor {
     CardPageBuildItem create(
             RoqEditorConfig config,
             CurateOutcomeBuildItem bi,
+            Capabilities capabilities,
             List<RoqFrontMatterQuteMarkupBuildItem> markupList) {
         CardPageBuildItem pageBuildItem = new CardPageBuildItem();
         pageBuildItem.addPage(Page.webComponentPageBuilder()
                 .title("Roq Editor")
                 .componentLink("qwc-roq-editor.js")
                 .icon("font-awesome-solid:pencil"));
+        final boolean assistantIsAvailable = capabilities.isPresent(Capability.ASSISTANT);
         List<String> markups = new ArrayList<>(markupList.stream().map(RoqFrontMatterQuteMarkupBuildItem::name).toList());
         markups.add("html");
         pageBuildItem.addBuildTimeData("markups", markups);
         pageBuildItem.addBuildTimeData("config", config);
+        pageBuildItem.addBuildTimeData("assistantIsAvailable", assistantIsAvailable);
         return pageBuildItem;
     }
 

--- a/roq-editor/deployment/src/main/resources/dev-ui/components/ai-prompt-widget.js
+++ b/roq-editor/deployment/src/main/resources/dev-ui/components/ai-prompt-widget.js
@@ -1,0 +1,136 @@
+import { LitElement, html, css } from 'lit';
+import '@vaadin/icon';
+import '@vaadin/progress-bar';
+
+export class AiPromptWidget extends LitElement {
+
+    static properties = {
+        _loading: { state: true },
+        _error: { state: true },
+    };
+
+    static styles = css`
+        :host {
+            position: absolute;
+            z-index: 1000;
+            background: var(--lumo-base-color);
+            border: 1px solid var(--lumo-primary-color-50pct);
+            border-radius: var(--lumo-border-radius-m);
+            box-shadow: var(--lumo-box-shadow-s);
+            padding: var(--lumo-space-xs) var(--lumo-space-s);
+            display: flex;
+            flex-direction: column;
+            gap: var(--lumo-space-xs);
+            min-width: 500px;
+        }
+        :host([error]) {
+            border-color: var(--lumo-error-color-50pct);
+        }
+        .row {
+            display: flex;
+            align-items: center;
+            gap: var(--lumo-space-s);
+        }
+        .icon {
+            color: var(--lumo-secondary-text-color);
+            flex-shrink: 0;
+        }
+        .icon[error] {
+            color: var(--lumo-error-color);
+        }
+        input {
+            flex: 1;
+            border: none;
+            outline: none;
+            font: inherit;
+            font-size: var(--lumo-font-size-s);
+            background: transparent;
+            color: var(--lumo-body-text-color);
+            padding: var(--lumo-space-xs) 0;
+        }
+        input:disabled {
+            opacity: 0.6;
+        }
+        .hint {
+            font-size: var(--lumo-font-size-xxs);
+            color: var(--lumo-tertiary-text-color);
+            white-space: nowrap;
+        }
+        .close {
+            cursor: pointer;
+            color: var(--lumo-tertiary-text-color);
+            flex-shrink: 0;
+            font-size: var(--lumo-font-size-xs);
+        }
+        vaadin-progress-bar {
+            width: 100%;
+            margin: 0;
+        }
+    `;
+
+    constructor() {
+        super();
+        this._loading = false;
+        this._error = false;
+    }
+
+    firstUpdated() {
+        this.shadowRoot.querySelector('input')?.focus();
+    }
+
+    render() {
+        return html`
+            <div class="row">
+                <vaadin-icon class="icon" ?error="${this._error}"
+                    icon="${this._error ? 'font-awesome-solid:triangle-exclamation' : 'font-awesome-solid:robot'}">
+                </vaadin-icon>
+                <input
+                    type="text"
+                    placeholder="Describe what to generate..."
+                    ?disabled="${this._loading}"
+                    @keydown="${this._onKeyDown}"
+                />
+                <span class="hint">${this._error ? 'Retry ↵' : 'Enter ↵'}</span>
+                <vaadin-icon class="close" icon="lumo:cross" @click="${this._close}"></vaadin-icon>
+            </div>
+            ${this._loading ? html`<vaadin-progress-bar indeterminate></vaadin-progress-bar>` : ''}
+        `;
+    }
+
+    _onKeyDown(e) {
+        if (e.key === 'Enter' && e.target.value.trim()) {
+            this._generate(e.target.value.trim());
+        } else if (e.key === 'Escape') {
+            this._close();
+        }
+    }
+
+    async _generate(prompt) {
+        this._loading = true;
+        this._error = false;
+        this.dispatchEvent(new CustomEvent('generate', {
+            detail: { prompt },
+            bubbles: true, composed: true
+        }));
+    }
+
+    showError() {
+        this._loading = false;
+        this._error = true;
+        this.toggleAttribute('error', true);
+        this.updateComplete.then(() => {
+            this.shadowRoot.querySelector('input')?.focus();
+        });
+    }
+
+    close() {
+        this.remove();
+    }
+
+    _close() {
+        this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+        this.remove();
+    }
+}
+
+customElements.define('qwc-ai-prompt', AiPromptWidget);

--- a/roq-editor/deployment/src/main/resources/dev-ui/components/visual-editor/extensions/slash-command.js
+++ b/roq-editor/deployment/src/main/resources/dev-ui/components/visual-editor/extensions/slash-command.js
@@ -76,7 +76,7 @@ const getBlockTypes = (options) => [
     },
     {
         label: 'Image',
-        icon: '🏞️',
+        icon: '🖼️',
         command: ({ editor, range }) => {
             const pagePath = options.getPagePath ? options.getPagePath() : '';
 
@@ -85,39 +85,54 @@ const getBlockTypes = (options) => [
                     editor.chain().focus().deleteRange(range).setParagraph().setImage({ src, title, alt }).run();
                 }
             });
-        }
-    },
-    {
-        label: 'Code Block',
-        icon: '{}',
-        command: ({ editor, range }) => {
-            editor.chain().focus().deleteRange(range).toggleCodeBlock().run();
-        }
-    },
-    {
-        label: 'Raw Block',
-        icon: '</>',
-        command: ({ editor, range }) => {
-            editor.chain().focus().deleteRange(range).insertContent({ type: 'rawBlock' }).run();
-        }
-    },
-    {
-        label: 'Table',
-        icon: '▦',
-        command: ({ editor, range }) => {
-            editor.chain().focus().deleteRange(range).insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
-        }
     }
+  },
+  {
+    label: 'Code Block',
+    icon: '{}',
+    command: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).toggleCodeBlock().run();
+    }
+  },
+  {
+    label: 'Raw Block',
+    icon: '</>',
+    command: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).insertContent({ type: 'rawBlock' }).run();
+    }
+  },
+  {
+    label: 'Table',
+    icon: '▦',
+    command: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
+    }
+  }
 ];
+
+const AI_COMMAND = {
+    label: 'AI',
+    icon: '✨',
+    description: 'Generate content with AI',
+    isAiCommand: true,
+    command: ({ editor, range }) => {
+        editor.chain().focus().deleteRange(range).run();
+        editor.view.dom.dispatchEvent(new CustomEvent('generate-ai-content', {
+            bubbles: true, composed: true,
+            detail: { editor }
+        }));
+    }
+};
 
 /**
  * Create the SlashCommand extension
  */
 export const SlashCommand = Extension.create({
-    name: 'slashCommand',
+  name: 'slashCommand',
 
     addOptions() {
         return {
+            assistantIsAvailable: false,
             suggestion: {
                 char: '/',
                 startOfLine: true,
@@ -131,134 +146,141 @@ export const SlashCommand = Extension.create({
     },
 
 
-    addCommands() {
-        return {
-            openSlashMenu:
-                (pos) =>
-                    ({editor, chain}) => {
-                        if (pos == null) {
-                            return false;
-                        }
-                        const $root = editor.$pos(pos);
+  addCommands() {
+    return {
+      openSlashMenu:
+        (pos) =>
+          ({ editor, chain }) => {
+            if (pos == null) {
+              return false;
+            }
+            const $root = editor.$pos(pos);
 
-                        if ($root.node.type.name !== 'doc') return false
+            if ($root.node.type.name !== 'doc') return false
 
-                        const $from = $root.firstChild;
-                        if(!$from.node.isTextblock)  return false;
-                        console.log($from.textContent);
-                        const hasContent = $from.textContent?.length > 0;
-                        if(hasContent){
-                            return chain()
-                                .focus()
-                                .insertContentAt($from.to, [
-                                {
-                                    type: 'paragraph',
-                                    content: [
-                                        {
-                                            type: 'text',
-                                            text: '/',
-                                        },
-                                    ],
-                                }], { updateSelection:true })
-                                .run();
-                        }
+            const $from = $root.firstChild;
+            if (!$from.node.isTextblock) return false;
+            console.log($from.textContent);
+            const hasContent = $from.textContent?.length > 0;
+            if (hasContent) {
+              return chain()
+                .focus()
+                .insertContentAt($from.to, [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        type: 'text',
+                        text: '/',
+                      },
+                    ],
+                  }], { updateSelection: true })
+                .run();
+            }
 
-                        return chain()
-                            .focus()
-                            .insertContentAt($from.pos, '/', { updateSelection:true })
-                            .run()
-                    },
+            return chain()
+              .focus()
+              .insertContentAt($from.pos, '/', { updateSelection: true })
+              .run()
+          },
 
-        }
-    },
+    }
+  },
 
 
     addProseMirrorPlugins() {
         const blockTypes = getBlockTypes(this.options);
+        const { assistantIsAvailable } = this.options;
+
         return [
             Suggestion({
                 editor: this.editor,
                 ...this.options.suggestion,
-                items: ({query}) => {
-                    return blockTypes.filter(item =>
-                        item.label.toLowerCase().includes(query.toLowerCase())
+                items: ({ query }) => {
+                    const lowerQuery = query.toLowerCase();
+                    const items = blockTypes.filter(item =>
+                        item.label.toLowerCase().includes(lowerQuery)
                     );
+                    if (assistantIsAvailable && 'ai'.includes(lowerQuery)) {
+                        items.push(AI_COMMAND);
+                    }
+                    return items;
                 },
-                render: () => {
-                    let component;
-                    let popup;
+        render: () => {
+          let component;
+          let popup;
 
-                    const updatePosition = (clientRect) => {
-                        if (popup && clientRect) {
-                            const rect = clientRect();
-                            if (rect) {
-                                popup.style.left = `${rect.left}px`;
-                                popup.style.top = `${rect.bottom + 4}px`;
-                            }
-                        }
-                    };
+          const updatePosition = (clientRect) => {
+            if (popup && clientRect) {
+              const rect = clientRect();
+              if (rect) {
+                popup.style.left = `${rect.left}px`;
+                popup.style.top = `${rect.bottom + 4}px`;
+              }
+            }
+          };
 
-                    const renderPopup = (props) => {
-                        const template = html`
+          const renderPopup = (props) => {
+            const template = html`
                           <qwc-slash-menu
                             .items="${props.items}"
                             .query="${props.query}"
                             @item-selected="${(e) => {
-                              const item = e.detail.item;
-                              if (item && item.command) {
-                                props.command(item);
-                              }
-                            }}"
+                const item = e.detail.item;
+                if (item && item.command) {
+                  props.command(item);
+                }
+              }}"
                           ></qwc-slash-menu>
                         `;
-                        render(template, popup);
-                        component = popup.querySelector('qwc-slash-menu');
-                    };
+            render(template, popup);
+            component = popup.querySelector('qwc-slash-menu');
+          };
 
-                    return {
-                        onStart: (props) => {
-                            // Create popup container
-                            popup = document.createElement('div');
-                            popup.style.position = 'absolute';
-                            popup.style.zIndex = '1000';
-                            document.body.appendChild(popup);
+          return {
+            onStart: (props) => {
+              // Create popup container
+              popup = document.createElement('div');
+              popup.style.position = 'absolute';
+              popup.style.zIndex = '1000';
+              document.body.appendChild(popup);
 
-                            // Render the slash menu using Lit template
-                            renderPopup(props);
-                            updatePosition(props.clientRect);
-                        },
+              // Render the slash menu using Lit template
+              renderPopup(props);
+              updatePosition(props.clientRect);
+            },
 
-                        onUpdate: (props) => {
-                            renderPopup(props);
-                            updatePosition(props.clientRect);
-                        },
+            onUpdate: (props) => {
+              renderPopup(props);
+              updatePosition(props.clientRect);
+            },
 
-                        onKeyDown: (props) => {
-                            if (props.event.key === 'Escape') {
-                                if (popup) {
-                                    popup.remove();
-                                    popup = null;
-                                }
-                                return true;
-                            }
+            onKeyDown: (props) => {
+              if (props.event.key === 'Escape') {
+                if (popup) {
+                  popup.remove();
+                  popup = null;
+                }
+                return true;
+              }
 
-                            if (component) {
-                                return component.onKeyDown(props.event);
-                            }
+              if (component) {
+                return component.onKeyDown(props.event);
+              }
 
-                            return false;
-                        },
+              return false;
+            },
 
-                        onExit: () => {
-                            if (popup) {
-                                popup.remove();
-                                popup = null;
-                            }
-                            component = null;
-                        },
-                    };
-                },
-            }),
-        ];
-    },
+            onExit: () => {
+              if (popup) {
+                popup.remove();
+                popup = null;
+              }
+              component = null;
+            },
+          };
+        },
+      }),
+    ];
+  },
 });

--- a/roq-editor/deployment/src/main/resources/dev-ui/components/visual-editor/extensions/slash-menu.js
+++ b/roq-editor/deployment/src/main/resources/dev-ui/components/visual-editor/extensions/slash-menu.js
@@ -63,6 +63,15 @@ export class SlashMenu extends LitElement {
             font-weight: 600;
             color: var(--lumo-secondary-text-color);
         }
+        .item-content {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+        }
+        .item-description {
+            font-size: var(--lumo-font-size-xs);
+            color: var(--lumo-secondary-text-color);
+        }
         .slash-menu-empty {
             padding: var(--lumo-space-m);
             text-align: center;
@@ -86,9 +95,12 @@ export class SlashMenu extends LitElement {
             `;
         }
 
+        const hasAiCommand = this.items.some(item => item.isAiCommand);
+        const menuLabel = hasAiCommand && this.items.length === 1 ? 'AI Assistant' : 'Style';
+        
         return html`
             <div class="slash-menu">
-                <div class="slash-menu-label">Style</div>
+                <div class="slash-menu-label">${menuLabel}</div>
                 <vaadin-list-box
                     .selected="${this.selectedIndex}"
                     @selected-changed="${this._onSelectedChanged}"
@@ -99,7 +111,10 @@ export class SlashMenu extends LitElement {
                             @mouseenter="${() => this._hoverItem(index)}"
                         >
                             <span class="item-icon">${item.icon}</span>
-                            <span>${item.label}</span>
+                            <div class="item-content">
+                                <span>${item.label}</span>
+                                ${item.description ? html`<span class="item-description">${item.description}</span>` : ''}
+                            </div>
                         </vaadin-item>
                     `)}
                 </vaadin-list-box>

--- a/roq-editor/deployment/src/main/resources/dev-ui/components/visual-editor/visual-editor.js
+++ b/roq-editor/deployment/src/main/resources/dev-ui/components/visual-editor/visual-editor.js
@@ -2,6 +2,7 @@ import '@qomponent/qui-code-block';
 import '@vaadin/button';
 import '@vaadin/icon';
 import {css, html} from 'lit';
+import {assistantIsAvailable} from 'build-time-data';
 import {
     BubbleMenu,
     Placeholder,
@@ -403,6 +404,7 @@ export class RoqVisualEditor extends BaseEditor {
             }),
             SlashCommand.configure({
                 getPagePath: () => this.page?.path || '',
+                assistantIsAvailable: assistantIsAvailable,
             }),
             Placeholder.configure({
                 placeholder: "Write some text, or type '/' for blocks & commands",

--- a/roq-editor/deployment/src/main/resources/dev-ui/qwc-roq-editor.js
+++ b/roq-editor/deployment/src/main/resources/dev-ui/qwc-roq-editor.js
@@ -9,6 +9,7 @@ import './components/simple-editor.js';
 import './components/loading-dialog.js';
 import './components/sync-status-bar.js';
 import './components/sync-controls.js';
+import './components/ai-prompt-widget.js';
 import {showPrompt} from './components/prompt-dialog.js';
 import {showConfirm} from './components/confirm-dialog.js';
 import {showNotification} from './components/notification-toast.js';
@@ -263,6 +264,7 @@ export class QwcRoqEditor extends LitElement {
                 .content="${this._fileContent}"
                 @save-content="${this._onSaveContent}"
                 @page-sync-path="${this._onPageSyncPath}"
+                @generate-ai-content="${this._onGenerateAiContent}"
               >
               </qwc-visual-editor>
             `;
@@ -498,6 +500,49 @@ export class QwcRoqEditor extends LitElement {
                 this._posts.push(c);
             });
             this._loadingContent = false;
+        });
+    }
+
+    _onGenerateAiContent(e) {
+        const { editor } = e.detail;
+        if (!editor || editor.isDestroyed) return;
+
+        const coords = editor.view.coordsAtPos(editor.view.state.selection.from);
+
+        const widget = document.createElement('qwc-ai-prompt');
+        widget.style.left = `${coords.left}px`;
+        widget.style.top = `${coords.bottom + 4}px`;
+        document.body.appendChild(widget);
+
+        widget.addEventListener('close', () => editor.commands.focus());
+
+        widget.addEventListener('generate', async (e) => {
+            const { prompt } = e.detail;
+            try {
+                const pos = editor.state.selection.from;
+                const textBefore = editor.state.doc.textBetween(0, pos, '\n');
+                const textAfter = editor.state.doc.textBetween(pos, editor.state.doc.content.size, '\n');
+                const trimBefore = textBefore.length > 2000 ? '...' + textBefore.slice(-2000) : textBefore;
+                const trimAfter = textAfter.length > 1000 ? textAfter.slice(0, 1000) + '...' : textAfter;
+                const context = `Article content before cursor:\n${trimBefore}\n\n---CURSOR IS HERE---\n\n`
+                    + (trimAfter.trim() ? `Article content after cursor:\n${trimAfter}` : '(end of article)');
+                const response = await this.jsonRpc.generateContent({ message: prompt, context });
+                const raw = response.result;
+
+                let markdown;
+                try {
+                    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+                    markdown = parsed.body || parsed.answer || parsed.markdown || parsed.content || raw;
+                } catch (err) {
+                    markdown = raw;
+                }
+
+                editor.chain().focus().insertContent(markdown, { contentType: 'markdown' }).run();
+                widget.close();
+            } catch (error) {
+                console.error('Error generating content:', error);
+                widget.showError();
+            }
         });
     }
 

--- a/roq-editor/deployment/src/test/java/io/quarkiverse/roq/editor/deployment/git/GitSyncServiceTest.java
+++ b/roq-editor/deployment/src/test/java/io/quarkiverse/roq/editor/deployment/git/GitSyncServiceTest.java
@@ -720,6 +720,11 @@ class GitSyncServiceTest {
                     }
                 };
             }
+
+            @Override
+            public AiConfig ai() {
+                return Optional::empty;
+            }
         };
     }
 }

--- a/roq-editor/runtime/pom.xml
+++ b/roq-editor/runtime/pom.xml
@@ -37,6 +37,10 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-assistant-dev</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/roq-editor/runtime/src/main/java/io/quarkiverse/roq/editor/runtime/devui/RoqEditorConfig.java
+++ b/roq-editor/runtime/src/main/java/io/quarkiverse/roq/editor/runtime/devui/RoqEditorConfig.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.roq.editor.runtime.devui;
 
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -149,6 +152,24 @@ public interface RoqEditorConfig {
             @WithDefault("Update content via Roq Editor")
             String template();
         }
+    }
+
+    /**
+     * AI content generation configuration
+     */
+    @JsonIgnore
+    AiConfig ai();
+
+    interface AiConfig {
+
+        /**
+         * Custom context to include in every AI content generation request.
+         * Use this to set the tone, topic, or style for your blog.
+         * For example: "This is a tech blog about Quarkus. Write in a friendly, concise tone."
+         */
+        @JsonProperty("context")
+        Optional<String> context();
+
     }
 
 }

--- a/roq-editor/runtime/src/main/java/io/quarkiverse/roq/editor/runtime/devui/RoqEditorJsonRPCService.java
+++ b/roq-editor/runtime/src/main/java/io/quarkiverse/roq/editor/runtime/devui/RoqEditorJsonRPCService.java
@@ -12,6 +12,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -29,7 +32,11 @@ import io.quarkiverse.roq.frontmatter.runtime.model.Page;
 import io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl;
 import io.quarkiverse.roq.frontmatter.runtime.model.Site;
 import io.quarkiverse.tools.stringpaths.StringPaths;
+import io.quarkus.assistant.runtime.dev.Assistant;
 import io.smallrye.common.annotation.Blocking;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
 
 @ApplicationScoped
 public class RoqEditorJsonRPCService {
@@ -41,11 +48,32 @@ public class RoqEditorJsonRPCService {
             "markdown", "md",
             "html", "html");
 
+    private static final String SYSTEM_MESSAGE = "IGNORE ALL PREVIOUS INSTRUCTIONS about Quarkus, Java, and programming. "
+            + "You are a blog content writer, NOT a programming assistant. "
+            + "{{customContext}}"
+            + "Generate blog post body content in Markdown based on the user's request. "
+            + "The article context shows content around the cursor position. "
+            + "Generate content that fits naturally at the cursor position. "
+            + "STRICT RESPONSE FORMAT: You MUST return a JSON object with EXACTLY one field named \"body\". "
+            + "The \"body\" field MUST contain the generated Markdown content as a string. "
+            + "Do NOT add any other fields. Do NOT use \"title\", \"date\", \"description\", \"content\", or \"answer\" fields. "
+            + "ONLY {\"body\": \"your markdown here\"}. "
+            + "Example: {\"body\": \"## My Heading\\n\\nSome paragraph text.\\n\\nMore content here.\"}";
+
     @Inject
     private Site site;
 
     @Inject
     private RoqSiteConfig config;
+
+    @Inject
+    private RoqEditorConfig editorConfig;
+
+    @Inject
+    private Optional<Assistant> assistant;
+
+    @Inject
+    private Vertx vertx;
 
     @Blocking
     public List<PageSource> getPosts() {
@@ -428,6 +456,71 @@ public class RoqEditorJsonRPCService {
         public boolean isError() {
             return errorMessage != null && !errorMessage.isEmpty();
         }
+    }
+
+    public CompletionStage<String> generateContent(String message, String context) {
+        if (assistant.isEmpty()) {
+            return CompletableFuture.failedStage(new RuntimeException("Assistant is not available"));
+        }
+        String baseUrl = getAssistantBaseUrl();
+        if (baseUrl == null) {
+            return CompletableFuture.failedStage(new RuntimeException("Assistant server is not running"));
+        }
+
+        String customContext = editorConfig.ai().context().orElse(null);
+
+        // Use variables for user-provided content (article context) to avoid prompt injection
+        JsonObject variables = new JsonObject()
+                .put("customContext", customContext != null && !customContext.isBlank()
+                        ? "Writing guidelines: " + customContext + ". "
+                        : "");
+
+        String userMessage = message;
+        if (context != null && !context.isBlank()) {
+            String trimmedContext = context.length() > 4000 ? context.substring(0, 4000) + "\n...(truncated)" : context;
+            userMessage += "\n\nArticle context:\n" + trimmedContext;
+        }
+
+        JsonObject payload = new JsonObject()
+                .put("genericInput", new JsonObject()
+                        .put("programmingLanguage", "Java")
+                        .put("programmingLanguageVersion", System.getProperty("java.version"))
+                        .put("quarkusVersion", "n/a")
+                        .put("systemmessageTemplate", SYSTEM_MESSAGE)
+                        .put("usermessageTemplate", userMessage)
+                        .put("variables", variables))
+                .put("responseSchemaPrompt", "");
+
+        var uri = java.net.URI.create(baseUrl + "/api/assist");
+        CompletableFuture<String> future = new CompletableFuture<>();
+        WebClient.create(vertx)
+                .post(uri.getPort(), uri.getHost(), uri.getPath())
+                .putHeader("Content-Type", "application/json")
+                .putHeader("Accept", "application/json")
+                .sendJsonObject(payload, ar -> {
+                    if (ar.failed()) {
+                        future.completeExceptionally(new RuntimeException("Assistant request failed", ar.cause()));
+                    } else if (ar.result().statusCode() != 200) {
+                        LOG.errorf("Assistant returned HTTP %d: %s", ar.result().statusCode(), ar.result().bodyAsString());
+                        future.completeExceptionally(
+                                new RuntimeException("Assistant returned HTTP " + ar.result().statusCode()));
+                    } else {
+                        future.complete(ar.result().bodyAsString());
+                    }
+                });
+        return future;
+    }
+
+    // Workaround: ChappieAssistant.getBaseUrl() is not on the Assistant interface, use reflection until it is
+    private String getAssistantBaseUrl() {
+        try {
+            var a = assistant.get();
+            var method = a.getClass().getMethod("getBaseUrl");
+            return (String) method.invoke(a);
+        } catch (Exception e) {
+            LOG.debug("Could not get assistant base URL", e);
+        }
+        return null;
     }
 
 }


### PR DESCRIPTION
## Summary

<img width="395" height="213" alt="Kapture 2026-05-19 at 20 54 34" src="https://github.com/user-attachments/assets/8b4d032d-bc37-4840-a0a2-a2e917cfa873" />


- Add AI slash command (`/ai`) in the visual editor, available when `quarkus-chappie` is present
- Inline AI prompt widget with loading indicator and error handling (retry on error, Escape to close)
- Direct integration with chappie-server for provider-agnostic content generation (works with Ollama, OpenAI, Podman AI)
- Article context (content around cursor position) sent with AI requests for contextual generation
- New `editor.ai.context` config property for custom writing instructions (tone, topic, style)
- Change editor console key from `a` to `m` (Manage content) to avoid conflict with chappie's `a` key
- Update chappie dependency to 1.6.3

Based on the original work by @edewit in #746.

Related chappie issues filed during development:
- quarkiverse/quarkus-chappie#208 (Ollama dev service)
- quarkiverse/quarkus-chappie#209 (stale server processes)
- quarkiverse/quarkus-chappie#210 (simple mode for AssistBuilder)
- quarkusio/quarkus#54317 (duplicate console key warning)