### PR TITLE
Fix roq generate and improve Gradle support in CLI

### DIFF
--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/CreateCommand.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/CreateCommand.java
@@ -81,6 +81,13 @@ public class CreateCommand implements Callable<Integer> {
                 output.info("");
                 output.info("  \u276F cd " + name);
                 output.info("  \u276F roq start");
+                if (buildTool == BuildTool.GRADLE || buildTool == BuildTool.GRADLE_KOTLIN_DSL) {
+                    output.info("");
+                    output.info("\u26A0\uFE0F  Gradle requires extra setup:");
+                    output.info("  1. Add the native plugin to your build file:");
+                    output.info("     id 'io.mvnpm.gradle.plugin.native-java-plugin' version '1.0.0' (or newer)");
+                    output.info("  2. Create src/main/java/ with at least one .java file (e.g. package-info.java)");
+                }
                 output.info("");
                 return CommandLine.ExitCode.OK;
             } else {

--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/GenerateCommand.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/GenerateCommand.java
@@ -11,13 +11,24 @@ import picocli.CommandLine.Command;
 public class GenerateCommand extends BuildToolDelegatingCommand {
 
     private static final Map<BuildTool, String> ACTION_MAPPING = Map.of(
-            BuildTool.MAVEN, "package quarkus:run -DskipTests",
-            BuildTool.GRADLE, "build quarkusRun -x test",
-            BuildTool.GRADLE_KOTLIN_DSL, "build quarkusRun -x test");
+            BuildTool.MAVEN, "package",
+            BuildTool.GRADLE, "build",
+            BuildTool.GRADLE_KOTLIN_DSL, "build");
 
     @Override
     public void prepareMaven(BuildToolContext context) {
-        // Skip resources:resources, already part of the package lifecycle
+        // Skip resources:resources (already part of the package lifecycle)
+        // and add the quarkus:run goal with -DskipTests
+        context.getParams().add("quarkus:run");
+        context.getParams().add("-DskipTests");
+    }
+
+    @Override
+    public void prepareGradle(BuildToolContext context) {
+        super.prepareGradle(context);
+        context.getParams().add("quarkusRun");
+        context.getParams().add("-x");
+        context.getParams().add("test");
     }
 
     @Override

--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqProjectCreator.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqProjectCreator.java
@@ -5,10 +5,11 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.apache.commons.io.FileUtils;
 
 import io.quarkus.devtools.commands.CreateProject;
 import io.quarkus.devtools.commands.CreateProjectHelper;
@@ -140,8 +141,8 @@ public class RoqProjectCreator {
             }
         }
 
-        // Remove src/ (not needed for a Roq site)
-        deleteDir(projectDir.resolve("src"));
+        // Remove src/ if it has no files (not needed for a Roq site, but Gradle needs src/main/java with sources)
+        deleteDirIfNoFiles(projectDir.resolve("src"));
 
         // Replace the default Quarkus README with a Roq-specific one
         copyBaseResource("README.md");
@@ -200,17 +201,16 @@ public class RoqProjectCreator {
         return ROQ_PREFIX + value;
     }
 
-    private static void deleteDir(Path dir) throws IOException {
-        if (Files.exists(dir)) {
-            try (var stream = Files.walk(dir)) {
-                stream.sorted(Comparator.reverseOrder())
-                        .forEach(p -> {
-                            try {
-                                Files.delete(p);
-                            } catch (IOException ignored) {
-                            }
-                        });
+    private static void deleteDirIfNoFiles(Path dir) throws IOException {
+        if (!Files.isDirectory(dir)) {
+            return;
+        }
+        try (var stream = Files.find(dir, Integer.MAX_VALUE, (p, a) -> a.isRegularFile())) {
+            if (stream.findAny().isPresent()) {
+                return;
             }
         }
+        FileUtils.deleteDirectory(dir.toFile());
     }
+
 }


### PR DESCRIPTION
## Summary
- Fix `roq generate` which was broken because `BuildToolDelegatingCommand.prepareAction()` receives the action as a single argument. Multi-word actions like `"package quarkus:run -DskipTests"` were parsed as one goal prefix. Split into primary goal + extra args via `prepareMaven()`/`prepareGradle()`.
- Show Gradle-specific setup instructions after `roq create --gradle` (native plugin + source file requirement).
- Only delete `src/` during project creation when it contains no files (preserving user sources for Gradle compatibility).