### PR TITLE
Editor: add image browse to frontmatter image field

### DIFF
--- a/roq-editor/deployment/src/main/resources/dev-ui/components/image-dialog.js
+++ b/roq-editor/deployment/src/main/resources/dev-ui/components/image-dialog.js
@@ -28,7 +28,8 @@ export class ImageDialog extends LitElement {
         _loadingImages: { state: true },
         _uploading: { state: true },
         _uploadError: { state: true },
-        _pagePath: { state: true }
+        _pagePath: { state: true },
+        _mode: { state: true }
     };
 
     static styles = css`
@@ -59,16 +60,18 @@ export class ImageDialog extends LitElement {
         this._uploading = false;
         this._uploadError = null;
         this._pagePath = '';
+        this._mode = 'content';
     }
 
-    show(defaultValues = {}, pagePath = '') {
+    show(defaultValues = {}, pagePath = '', options = {}) {
         return new Promise((resolve) => {
             // Cache jsonRpc reference when dialog opens
             if (!cachedJsonRpc) {
                 const editor = document.querySelector('qwc-roq-editor');
                 cachedJsonRpc = editor?.jsonRpc || null;
             }
-            
+
+            this._mode = options.mode || 'content';
             this._values = {
                 src: defaultValues.src || '',
                 alt: defaultValues.alt || '',
@@ -96,8 +99,8 @@ export class ImageDialog extends LitElement {
                         ${this._showPicker ? 'Select Image' : 'Add Image'}
                     </h2>
                 `, [this._showPicker])}
-                ${dialogRenderer(() => this._showPicker ? this._renderPicker() : this._renderForm(), 
-                    [this._values, this._showPicker, this._pageImages, this._publicImages, this._loadingImages, this._uploading, this._uploadError])}
+                ${dialogRenderer(() => this._showPicker ? this._renderPicker() : this._renderForm(),
+                    [this._values, this._showPicker, this._pageImages, this._publicImages, this._loadingImages, this._uploading, this._uploadError, this._mode])}
                 ${dialogFooterRenderer(() => html`
                     ${this._showPicker ? html`
                         <vaadin-button theme="tertiary" @click=${() => this._showPicker = false}>
@@ -141,16 +144,18 @@ export class ImageDialog extends LitElement {
                         Browse
                     </vaadin-button>
                 </div>
-                <vaadin-text-field
-                    label="Alternate text"
-                    .value=${this._values.alt}
-                    @value-changed=${(e) => this._updateValue('alt', e.detail.value)}
-                ></vaadin-text-field>
-                <vaadin-text-field
-                    label="Title"
-                    .value=${this._values.title}
-                    @value-changed=${(e) => this._updateValue('title', e.detail.value)}
-                ></vaadin-text-field>
+                ${this._mode !== 'frontmatter' ? html`
+                    <vaadin-text-field
+                        label="Alternate text"
+                        .value=${this._values.alt}
+                        @value-changed=${(e) => this._updateValue('alt', e.detail.value)}
+                    ></vaadin-text-field>
+                    <vaadin-text-field
+                        label="Title"
+                        .value=${this._values.title}
+                        @value-changed=${(e) => this._updateValue('title', e.detail.value)}
+                    ></vaadin-text-field>
+                ` : ''}
             </vaadin-vertical-layout>
         `;
     }
@@ -204,8 +209,9 @@ export class ImageDialog extends LitElement {
     }
 
     _onImageSelected(e) {
-        const { image } = e.detail;
-        this._values = { ...this._values, src: image.path };
+        const { image, location } = e.detail;
+        const src = location === 'page' ? image.name : image.path;
+        this._values = { ...this._values, src };
         this._showPicker = false;
     }
 
@@ -274,10 +280,10 @@ customElements.define('qwc-image-dialog', ImageDialog);
 
 let dialogInstance = null;
 
-export function showImageDialog(defaultValues = {}, pagePath = '') {
+export function showImageDialog(defaultValues = {}, pagePath = '', options = {}) {
     if (!dialogInstance) {
         dialogInstance = document.createElement('qwc-image-dialog');
         document.body.appendChild(dialogInstance);
     }
-    return dialogInstance.show(defaultValues, pagePath);
+    return dialogInstance.show(defaultValues, pagePath, options);
 }

--- a/roq-editor/deployment/src/main/resources/dev-ui/components/visual-editor/frontmatter-panel.js
+++ b/roq-editor/deployment/src/main/resources/dev-ui/components/visual-editor/frontmatter-panel.js
@@ -5,6 +5,7 @@ import '@vaadin/button';
 import '@vaadin/icon';
 import '@vaadin/date-time-picker';
 import { parseAndFormatDate } from '../../utils/frontmatter.js';
+import { showImageDialog } from '../image-dialog.js';
 
 export class FrontmatterPanel extends LitElement {
     
@@ -12,6 +13,7 @@ export class FrontmatterPanel extends LitElement {
         frontmatter: { type: Object },
         date: { type: String },  // Initial date from file path (used as fallback if not in frontmatter)
         dateFormat: { type: String },  // Date format from server config (e.g., "yyyy-MM-dd[ HH:mm][:ss][ Z]")
+        pagePath: { type: String },
         _fields: { state: true }
     };
 
@@ -52,12 +54,36 @@ export class FrontmatterPanel extends LitElement {
         .field-group {
             margin-bottom: var(--lumo-space-m);
         }
+        .field-header {
+            display: flex;
+            align-items: center;
+            margin-bottom: var(--lumo-space-xs);
+        }
         .field-label {
-            display: block;
             font-size: var(--lumo-font-size-s);
             font-weight: 500;
             color: var(--lumo-body-text-color);
-            margin-bottom: var(--lumo-space-xs);
+            flex: 1;
+        }
+        .field-header .delete-icon {
+            cursor: pointer;
+            color: var(--lumo-contrast-30pct);
+            font-size: var(--lumo-font-size-xs);
+            opacity: 0;
+            transition: opacity 0.15s;
+        }
+        .field-group:hover .delete-icon {
+            opacity: 1;
+        }
+        .field-header .delete-icon:hover {
+            color: var(--lumo-error-color);
+        }
+        .suffix-icon {
+            cursor: pointer;
+            color: var(--lumo-contrast-50pct);
+        }
+        .suffix-icon:hover {
+            color: var(--lumo-contrast-80pct);
         }
         vaadin-text-field,
         vaadin-text-area {
@@ -134,6 +160,7 @@ export class FrontmatterPanel extends LitElement {
         this.frontmatter = {};
         this.date = '';  // Initial date from file path (used as fallback if not in frontmatter)
         this.dateFormat = 'yyyy-MM-dd';  // Default date format, will be overridden by server config
+        this.pagePath = '';
         this._fields = {};
         this._fieldTypes = {}; // Store field types: { fieldName: 'textarea' | 'text' | 'number' | 'boolean' | 'array' }
         this._newFieldKey = '';
@@ -226,11 +253,22 @@ export class FrontmatterPanel extends LitElement {
         `;
     }
 
+    _renderFieldHeader(key) {
+        return html`
+            <div class="field-header">
+                <label class="field-label">${key}</label>
+                <vaadin-icon icon="font-awesome-solid:xmark" class="delete-icon"
+                    title="Remove field"
+                    @click="${() => this._removeField(key)}"></vaadin-icon>
+            </div>
+        `;
+    }
+
     _renderField(key, value) {
         if (Array.isArray(value)) {
             return html`
                 <div class="field-group">
-                    <label class="field-label">${key}</label>
+                    ${this._renderFieldHeader(key)}
                     ${value.map((item, index) => html`
                         <div class="array-item">
                             <vaadin-text-field
@@ -238,9 +276,10 @@ export class FrontmatterPanel extends LitElement {
                                 @input="${(e) => this._updateArrayItem(key, index, e.target.value)}">
                             </vaadin-text-field>
                             <vaadin-button
-                                theme="tertiary error"
-                                @click="${() => this._removeArrayItem(key, index)}">
-                                <vaadin-icon icon="font-awesome-solid:trash" slot="prefix"></vaadin-icon>
+                                theme="tertiary error icon small"
+                                @click="${() => this._removeArrayItem(key, index)}"
+                                title="Remove item">
+                                <vaadin-icon icon="font-awesome-solid:xmark"></vaadin-icon>
                             </vaadin-button>
                         </div>
                     `)}
@@ -250,65 +289,56 @@ export class FrontmatterPanel extends LitElement {
                         <vaadin-icon icon="font-awesome-solid:plus" slot="prefix"></vaadin-icon>
                         Add Item
                     </vaadin-button>
-                    <vaadin-button
-                        theme="tertiary error small"
-                        @click="${() => this._removeField(key)}"
-                        style="margin-top: var(--lumo-space-xs);">
-                        <vaadin-icon icon="font-awesome-solid:trash" slot="prefix"></vaadin-icon>
-                        Remove Field
-                    </vaadin-button>
                 </div>
             `;
         } else if (typeof value === 'object' && value !== null) {
-            // For nested objects, render as textarea with YAML-like format
             return html`
                 <div class="field-group">
-                    <label class="field-label">${key}</label>
+                    ${this._renderFieldHeader(key)}
                     <vaadin-text-area
                         value="${JSON.stringify(value, null, 2)}"
                         rows="4"
                         @input="${(e) => this._updateField(key, e.target.value, true)}">
                     </vaadin-text-area>
-                    <vaadin-button
-                        theme="tertiary error small"
-                        @click="${() => this._removeField(key)}"
-                        style="margin-top: var(--lumo-space-xs);">
-                        <vaadin-icon icon="font-awesome-solid:trash" slot="prefix"></vaadin-icon>
-                        Remove Field
-                    </vaadin-button>
                 </div>
             `;
         } else if (typeof value === 'boolean') {
-            // Boolean field - use checkbox
             return html`
                 <div class="field-group">
-                    <label class="field-label" style="display: flex; align-items: center; gap: var(--lumo-space-xs); cursor: pointer;">
-                        <input 
-                            type="checkbox"
-                            ?checked="${value}"
-                            @change="${(e) => this._updateField(key, e.target.checked)}"
-                            style="width: auto; margin: 0; cursor: pointer;">
-                        <span>${key}</span>
-                    </label>
-                    <div style="font-size: var(--lumo-font-size-xs); color: var(--lumo-contrast-60pct); margin-top: var(--lumo-space-xs); margin-left: calc(var(--lumo-space-m) + 4px);">
-                        Value: ${value ? 'true' : 'false'}
+                    <div class="field-header">
+                        <label class="field-label" style="display: flex; align-items: center; gap: var(--lumo-space-xs); cursor: pointer;">
+                            <input
+                                type="checkbox"
+                                ?checked="${value}"
+                                @change="${(e) => this._updateField(key, e.target.checked)}"
+                                style="width: auto; margin: 0; cursor: pointer;">
+                            <span>${key}</span>
+                        </label>
+                        <vaadin-icon icon="font-awesome-solid:xmark" class="delete-icon"
+                            title="Remove field"
+                            @click="${() => this._removeField(key)}"></vaadin-icon>
                     </div>
-                    <vaadin-button
-                        theme="tertiary error small"
-                        @click="${() => this._removeField(key)}"
-                        style="margin-top: var(--lumo-space-xs);">
-                        <vaadin-icon icon="font-awesome-solid:trash" slot="prefix"></vaadin-icon>
-                        Remove Field
-                    </vaadin-button>
+                </div>
+            `;
+        } else if (key === 'image') {
+            return html`
+                <div class="field-group">
+                    ${this._renderFieldHeader(key)}
+                    <vaadin-text-field
+                        value="${String(value || '')}"
+                        @input="${(e) => this._updateField(key, e.target.value)}">
+                        <vaadin-icon slot="suffix" icon="font-awesome-solid:folder-open" class="suffix-icon"
+                            title="Browse images"
+                            @click="${() => this._browseImage(key, value)}"></vaadin-icon>
+                    </vaadin-text-field>
                 </div>
             `;
         } else {
-            // String, number
             const fieldType = this._fieldTypes[key];
             const isTextarea = fieldType === 'textarea' || (typeof value === 'string' && value.length > 100);
             return html`
                 <div class="field-group">
-                    <label class="field-label">${key}</label>
+                    ${this._renderFieldHeader(key)}
                     ${isTextarea
                         ? html`
                             <vaadin-text-area
@@ -325,16 +355,19 @@ export class FrontmatterPanel extends LitElement {
                             </vaadin-text-field>
                         `
                     }
-                    <vaadin-button
-                        theme="tertiary error small"
-                        @click="${() => this._removeField(key)}"
-                        style="margin-top: var(--lumo-space-xs);">
-                        <vaadin-icon icon="font-awesome-solid:trash" slot="prefix"></vaadin-icon>
-                        Remove Field
-                    </vaadin-button>
                 </div>
             `;
         }
+    }
+
+    _browseImage(key, currentValue) {
+        showImageDialog({ src: String(currentValue || '') }, this.pagePath, { mode: 'frontmatter' }).then(({ src }) => {
+            if (src) {
+                this._fields[key] = src;
+                this._notifyChange();
+                this.requestUpdate();
+            }
+        });
     }
 
     _updateField(key, value, isJSON = false) {

--- a/roq-editor/deployment/src/main/resources/dev-ui/components/visual-editor/frontmatter-panel.js
+++ b/roq-editor/deployment/src/main/resources/dev-ui/components/visual-editor/frontmatter-panel.js
@@ -60,6 +60,7 @@ export class FrontmatterPanel extends LitElement {
             margin-bottom: var(--lumo-space-xs);
         }
         .field-label {
+            display: block;
             font-size: var(--lumo-font-size-s);
             font-weight: 500;
             color: var(--lumo-body-text-color);
@@ -88,9 +89,6 @@ export class FrontmatterPanel extends LitElement {
         vaadin-text-field,
         vaadin-text-area {
             width: 100%;
-        }
-        .array-field {
-            margin-bottom: var(--lumo-space-s);
         }
         .array-item {
             display: flex;

--- a/roq-editor/deployment/src/main/resources/dev-ui/components/visual-editor/visual-editor.js
+++ b/roq-editor/deployment/src/main/resources/dev-ui/components/visual-editor/visual-editor.js
@@ -538,6 +538,7 @@ export class RoqVisualEditor extends BaseEditor {
                 .frontmatter="${this._frontmatter}"
                 .date="${this.page.date}"
                 .dateFormat="${this.dateFormat}"
+                .pagePath="${this.page?.path || ''}"
                 @frontmatter-changed="${this._onFrontmatterChanged}"
               >
               </qwc-frontmatter-panel>


### PR DESCRIPTION
## Summary
- Add browse button (folder icon as field suffix) to the frontmatter `image` field, reusing the existing image upload/browse dialog
- Add `mode` option to the image dialog: hides alt/title fields in frontmatter mode (only the path is needed)
- Fix page image selection to use the filename instead of the full URL path
- Improve field delete buttons: small `x` icon in the label line, visible on hover only

Closes #929