### PR TITLE
Fix editor save+rename for index pages

### DIFF
--- a/roq-editor/deployment/src/main/java/io/quarkiverse/roq/editor/deployment/content/RoqEditorContentService.java
+++ b/roq-editor/deployment/src/main/java/io/quarkiverse/roq/editor/deployment/content/RoqEditorContentService.java
@@ -71,10 +71,9 @@ public class RoqEditorContentService {
         checkPath(to);
         checkReady();
         executor.submit(() -> run(() -> {
-            // Write content before rename so data is safe if rename fails
-            Files.writeString(from, content, StandardCharsets.UTF_8);
+            Files.writeString(writePath, content, StandardCharsets.UTF_8);
             doRename(from, to);
-            LOG.infof("Written and renamed %s -> %s", from, to);
+            LOG.infof("Written %s, then renamed %s -> %s", writePath, from, to);
         }));
     }
 

--- a/roq-editor/runtime/src/main/java/io/quarkiverse/roq/editor/runtime/devui/RoqEditorJsonRPCService.java
+++ b/roq-editor/runtime/src/main/java/io/quarkiverse/roq/editor/runtime/devui/RoqEditorJsonRPCService.java
@@ -147,9 +147,8 @@ public class RoqEditorJsonRPCService {
                 Path newFilePath = contentDir.resolve(suggestedPath);
                 Path from = page.source().isIndex() ? filePath.getParent() : filePath;
                 Path to = page.source().isIndex() ? newFilePath.getParent() : newFilePath;
-                Path writeTarget = page.source().isIndex() ? newFilePath : to;
                 CompletableFuture.runAsync(() -> DevConsoleManager.invoke("roq-submit-write-and-rename", Map.of(
-                        "writePath", writeTarget.toString(), "content", content,
+                        "writePath", filePath.toString(), "content", content,
                         "from", from.toString(), "to", to.toString())));
                 return WriteActionResult.success(new SaveResult(null, suggestedPath));
             }


### PR DESCRIPTION
## Summary
- Fix `Is a directory` error when saving index pages (directory-based posts) with auto-sync rename
- Write content to the current file location before renaming, so data is saved even if the rename fails
- `writePath` now points to the existing file instead of the new (post-rename) location