### PR TITLE
Add Liquid-to-Qute template converter as first step of support for converting Jekyll sites to Roq

### DIFF
--- a/migration/pom.xml
+++ b/migration/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.quarkus.tools</groupId>
+    <artifactId>liquid-to-qute-converter</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Liquid to Qute Converter</name>
+    <description>Converts Jekyll/Liquid templates to Roq/Qute templates</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.1</junit.version>
+        <assertj.version>3.24.2</assertj.version>
+        <picocli.version>4.7.5</picocli.version>
+    </properties>
+
+    <dependencies>
+        <!-- CLI framework -->
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>${picocli.version}</version>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/migration/src/main/java/io/quarkus/tools/LiquidToQuteCommand.java
+++ b/migration/src/main/java/io/quarkus/tools/LiquidToQuteCommand.java
@@ -31,7 +31,14 @@ public class LiquidToQuteCommand implements Callable<Integer> {
     @Option(names = {"-v", "--verbose"}, description = "Verbose output")
     private boolean verbose;
 
-    private final LiquidToQuteConverter converter = new LiquidToQuteConverter();
+    @Option(names = {"-e", "--extensions"}, description = "Template file extensions to process (default: .html, .htm, .liquid, .md, .markdown)", split = ",")
+    private List<String> templateExtensions = List.of(".html", ".htm", ".liquid", ".md", ".markdown");
+
+    @Option(names = {"--extension-syntax"}, description = "Use Qute extension syntax {=expr} instead of standard {expr} (default: true)",
+            defaultValue = "true", negatable = true)
+    private boolean extensionSyntax = true;
+
+    private LiquidToQuteConverter converter = new LiquidToQuteConverter();
 
     public static void main(String... args) {
         int exitCode = new CommandLine(new LiquidToQuteCommand()).execute(args);
@@ -40,6 +47,8 @@ public class LiquidToQuteCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
+        converter = new LiquidToQuteConverter(extensionSyntax);
+
         if (!Files.exists(input)) {
             System.err.println("Error: Input path '" + input + "' does not exist");
             return 1;
@@ -101,8 +110,6 @@ public class LiquidToQuteCommand implements Callable<Integer> {
     }
 
     private void convertDirectory(Path inputDir, Path outputDir) throws IOException {
-        List<String> templateExtensions = List.of(".html", ".htm", ".liquid", ".md", ".markdown");
-
         int convertedCount = 0;
         int errorCount = 0;
 

--- a/migration/src/main/java/io/quarkus/tools/LiquidToQuteCommand.java
+++ b/migration/src/main/java/io/quarkus/tools/LiquidToQuteCommand.java
@@ -1,0 +1,134 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS info.picocli:picocli:4.7.5
+
+package io.quarkus.tools;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Stream;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "liquid-to-qute", mixinStandardHelpOptions = true, version = "1.0",
+        description = "Converts Liquid templates to Qute templates for Roq")
+public class LiquidToQuteCommand implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "Input file or directory")
+    private Path input;
+
+    @Parameters(index = "1", description = "Output file or directory (optional for single files)", arity = "0..1")
+    private Path output;
+
+    @Option(names = {"-r", "--recursive"}, description = "Process directories recursively")
+    private boolean recursive;
+
+    @Option(names = {"-v", "--verbose"}, description = "Verbose output")
+    private boolean verbose;
+
+    private final LiquidToQuteConverter converter = new LiquidToQuteConverter();
+
+    public static void main(String... args) {
+        int exitCode = new CommandLine(new LiquidToQuteCommand()).execute(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        if (!Files.exists(input)) {
+            System.err.println("Error: Input path '" + input + "' does not exist");
+            return 1;
+        }
+
+        if (Files.isRegularFile(input)) {
+            return convertFile(input, getOutputPath(input)) ? 0 : 1;
+        }
+
+        if (Files.isDirectory(input)) {
+            if (output == null) {
+                System.err.println("Error: Output directory required for directory conversion");
+                return 1;
+            }
+            convertDirectory(input, output);
+            return 0;
+        }
+
+        System.err.println("Error: '" + input + "' is neither a file nor a directory");
+        return 1;
+    }
+
+    private Path getOutputPath(Path inputPath) {
+        if (output != null) {
+            return output;
+        }
+        // Default: add .qute before extension
+        String fileName = inputPath.getFileName().toString();
+        int dotIndex = fileName.lastIndexOf('.');
+        if (dotIndex > 0) {
+            String name = fileName.substring(0, dotIndex);
+            String ext = fileName.substring(dotIndex);
+            return inputPath.getParent().resolve(name + ".qute" + ext);
+        }
+        return inputPath.getParent().resolve(fileName + ".qute");
+    }
+
+    boolean convertFile(Path inputPath, Path outputPath) {
+        try {
+            String content = Files.readString(inputPath);
+            converter.clearConversions();
+
+            String converted = converter.convert(content);
+
+            Files.createDirectories(outputPath.getParent());
+            Files.writeString(outputPath, converted);
+
+            if (verbose) {
+                System.out.println("✓ Converted: " + inputPath + " -> " + outputPath);
+                System.out.println(converter.getConversionReport());
+                System.out.println();
+            }
+
+            return true;
+        } catch (IOException e) {
+            System.err.println("✗ Error converting " + inputPath + ": " + e.getMessage());
+            return false;
+        }
+    }
+
+    private void convertDirectory(Path inputDir, Path outputDir) throws IOException {
+        List<String> templateExtensions = List.of(".html", ".htm", ".liquid", ".md", ".markdown");
+
+        int convertedCount = 0;
+        int errorCount = 0;
+
+        try (Stream<Path> paths = recursive ? Files.walk(inputDir) : Files.list(inputDir)) {
+            for (Path inputPath : paths.filter(Files::isRegularFile).toList()) {
+                String fileName = inputPath.getFileName().toString();
+                boolean isTemplate = templateExtensions.stream()
+                        .anyMatch(fileName::endsWith);
+
+                if (isTemplate) {
+                    Path relativePath = inputDir.relativize(inputPath);
+                    Path outputPath = outputDir.resolve(relativePath);
+
+                    if (convertFile(inputPath, outputPath)) {
+                        convertedCount++;
+                    } else {
+                        errorCount++;
+                    }
+                }
+            }
+        }
+
+        System.out.println("\nConversion complete:");
+        System.out.println("  ✓ " + convertedCount + " files converted");
+        if (errorCount > 0) {
+            System.out.println("  ✗ " + errorCount + " files failed");
+        }
+    }
+}

--- a/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
@@ -1,0 +1,882 @@
+package io.quarkus.tools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class LiquidToQuteConverter {
+
+    private final List<String> conversionsApplied = new ArrayList<>();
+
+    String convert(String content) {
+        String original = content;
+
+        // Strip Liquid whitespace-trimming markers before any conversion
+        content = content.replaceAll("\\{%-", "{%");
+        content = content.replaceAll("-%\\}", "%}");
+
+        // Extract raw blocks before any conversion to preserve their content verbatim
+        List<String> rawBlocks = new ArrayList<>();
+        content = extractRawBlocks(content, rawBlocks);
+
+        // Convert in order of complexity
+        content = convertComments(content);
+        content = convertVariables(content);
+        content = convertFilters(content);
+        content = convertConditionals(content);
+        content = convertLoops(content);
+        content = convertIncludes(content);
+        content = convertAssignments(content);
+        content = convertCaseStatements(content);
+        content = convertLayoutTags(content);
+        content = convertSpecialTags(content);
+
+        content = convertBracketNotation(content);
+
+        // Final cleanup steps - ORDER MATTERS!
+        // Remove spaces first so ternary wrapping can match properly
+        content = removeSpacesBeforeMethods(content);
+        content = wrapTernaryBeforeMethods(content);
+
+        // Restore raw blocks with Qute verbatim delimiters
+        content = restoreRawBlocks(content, rawBlocks);
+
+        if (!content.equals(original)) {
+            conversionsApplied.add("Template converted successfully");
+        }
+
+        return content;
+    }
+
+    String getConversionReport() {
+        if (conversionsApplied.isEmpty()) {
+            return "No conversions needed";
+        }
+        return conversionsApplied.stream()
+                .map(s -> "✓ " + s)
+                .reduce((a, b) -> a + "\n" + b)
+                .orElse("");
+    }
+
+    void clearConversions() {
+        conversionsApplied.clear();
+    }
+
+    private String extractRawBlocks(String content, List<String> rawBlocks) {
+        Pattern pattern = Pattern.compile("\\{%\\s*raw\\s*%\\}(.*?)\\{%\\s*endraw\\s*%\\}", Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+        while (matcher.find()) {
+            rawBlocks.add(matcher.group(1));
+            matcher.appendReplacement(sb, "\0RAW_" + (rawBlocks.size() - 1) + "\0");
+        }
+        matcher.appendTail(sb);
+        if (!rawBlocks.isEmpty()) {
+            conversionsApplied.add("Converted raw blocks");
+        }
+        return sb.toString();
+    }
+
+    private String restoreRawBlocks(String content, List<String> rawBlocks) {
+        for (int i = 0; i < rawBlocks.size(); i++) {
+            content = content.replace("\0RAW_" + i + "\0", "{|" + rawBlocks.get(i) + "|}");
+        }
+        return content;
+    }
+
+    private String convertComments(String content) {
+        // Liquid: {% comment %}...{% endcomment %}
+        // Qute: {! ... !}
+        Pattern pattern = Pattern.compile("\\{%\\s*comment\\s*%\\}(.*?)\\{%\\s*endcomment\\s*%\\}", Pattern.DOTALL);
+        String result = pattern.matcher(content).replaceAll("{! $1 !}");
+
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted comments");
+        }
+
+        return result;
+    }
+
+    private String convertVariables(String content) {
+        // Liquid: {{ variable }}
+        // Qute (Roq alternative syntax): {=variable}
+        Pattern pattern = Pattern.compile("\\{\\{\\s*([^}]+?)\\s*\\}\\}");
+        Matcher matcher = pattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+
+        while (matcher.find()) {
+            String var = matcher.group(1).trim();
+
+            // Convert post.* to page.* (Roq uses page for all content)
+            var = var.replaceAll("\\bpost\\.", "page.");
+
+            matcher.appendReplacement(sb, "{=" + Matcher.quoteReplacement(var) + "}");
+        }
+        matcher.appendTail(sb);
+
+        String result = sb.toString();
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted variable outputs to alternative expression syntax");
+        }
+
+        return result;
+    }
+
+    private String convertFilters(String content) {
+        Pattern blockPattern = Pattern.compile("\\{=[^}]*\\}|\\{%[^%]*%\\}");
+        Matcher matcher = blockPattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+
+        while (matcher.find()) {
+            String block = matcher.group();
+            String converted = convertFiltersInBlock(block);
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(converted));
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    private String convertFiltersInBlock(String block) {
+        block = convertConcatenationFilters(block);
+        block = convertTableDrivenFilters(block);
+        block = convertDateFilter(block);
+        block = convertDefaultFilter(block);
+        block = convertTwoArgFilters(block);
+        block = convertPushFilter(block);
+        block = convertSplitFilter(block);
+        return block;
+    }
+
+    private String convertConcatenationFilters(String content) {
+        // Append filter: "text" | append: variable | append: "more" -> "text" + variable + "more"
+        Pattern appendPattern = Pattern.compile("([^|{]+?)((?:\\s*\\|\\s*append:\\s*[^|]+)+)");
+        Matcher appendMatcher = appendPattern.matcher(content);
+        StringBuilder appendSb = new StringBuilder();
+
+        while (appendMatcher.find()) {
+            String base = appendMatcher.group(1).trim();
+            String appends = appendMatcher.group(2);
+
+            Pattern appendValuePattern = Pattern.compile("\\|\\s*append:\\s*([^|]+?)(?=\\s*\\||$)");
+            Matcher appendValueMatcher = appendValuePattern.matcher(appends);
+            StringBuilder concatenation = new StringBuilder(base);
+
+            while (appendValueMatcher.find()) {
+                concatenation.append(" + ").append(appendValueMatcher.group(1).trim());
+            }
+
+            String remaining = appends.replaceAll("\\|\\s*append:\\s*[^|]+", "").trim();
+            String replacement;
+            if (!remaining.isEmpty() && remaining.startsWith("|")) {
+                replacement = "(" + concatenation + ")" + remaining;
+            } else {
+                replacement = concatenation.toString();
+            }
+
+            appendMatcher.appendReplacement(appendSb, Matcher.quoteReplacement(replacement));
+        }
+        appendMatcher.appendTail(appendSb);
+
+        String result = appendSb.toString();
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted append filter to string concatenation");
+            content = result;
+        }
+
+        // Prepend filter: path | prepend: base -> base + path
+        Pattern prependPattern = Pattern.compile("([a-zA-Z0-9_.\"']+)\\s*\\|\\s*prepend:\\s*([^|}%]+)");
+        Matcher prependMatcher = prependPattern.matcher(content);
+        StringBuilder prependSb = new StringBuilder();
+
+        while (prependMatcher.find()) {
+            String base = prependMatcher.group(1).trim();
+            String prefix = prependMatcher.group(2).trim();
+            prependMatcher.appendReplacement(prependSb, Matcher.quoteReplacement(prefix + " + " + base));
+        }
+        prependMatcher.appendTail(prependSb);
+
+        result = prependSb.toString();
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted prepend filter to string concatenation");
+            content = result;
+        }
+
+        return content;
+    }
+
+    private String convertTableDrivenFilters(String content) {
+        // Filters with a single argument: | filter: arg -> .method(arg)
+        String[][] filterWithArgMap = {
+                {"sort", "sort"},
+                {"startswith", "startsWith"},
+                {"endswith", "endsWith"},
+                {"contains", "contains"},
+                {"equals", "equals"},
+                {"map", "map"},
+                {"group_by", "groupBy"},
+                {"slice", "slice"},
+                {"add", "add"},
+                {"minus", "minus"},
+                {"times", "times"},
+                {"truncate", "truncate"},
+                {"remove_first", "removeFirst"},
+                {"where_exp", "whereExp"},
+        };
+
+        for (String[] mapping : filterWithArgMap) {
+            String liquidFilter = mapping[0];
+            String quteMethod = mapping[1];
+            Pattern fwaPattern = Pattern.compile("\\|\\s*" + liquidFilter + ":\\s*([^|}%]+)");
+            Matcher fwaMatcher = fwaPattern.matcher(content);
+            StringBuilder fwaSb = new StringBuilder();
+
+            while (fwaMatcher.find()) {
+                String arg = fwaMatcher.group(1).trim();
+                fwaMatcher.appendReplacement(fwaSb, "." + quteMethod + "(" + Matcher.quoteReplacement(arg) + ")");
+            }
+            fwaMatcher.appendTail(fwaSb);
+
+            String result = fwaSb.toString();
+            if (!result.equals(content)) {
+                conversionsApplied.add("Converted filter: " + liquidFilter + " -> " + quteMethod + "()");
+                content = result;
+            }
+        }
+
+        // No-arg filters: | filter -> .method
+        String[][] filterMap = {
+                {"upcase", "toUpperCase"},
+                {"downcase", "toLowerCase"},
+                {"capitalize", "capitalize"},
+                {"strip_html", "stripHtml"},
+                {"number_of_words", "numberOfWords"},
+                {"size", "size"},
+                {"first", "first"},
+                {"last", "last"},
+                {"join", "join"},
+                {"sort", "sort"},
+                {"reverse", "reverse"},
+                {"uniq", "distinct"},
+                {"compact", "filterNotNull"},
+                {"strip", "trim()"},
+                {"lstrip", "trimStart"},
+                {"rstrip", "trimEnd"},
+                {"escape", "escapeHtml"},
+                {"url_encode", "urlEncode"},
+                {"slugify", "slugify"}
+        };
+
+        for (String[] mapping : filterMap) {
+            String liquidFilter = mapping[0];
+            String quteFilter = mapping[1];
+            Pattern pattern = Pattern.compile("\\|\\s*" + liquidFilter + "\\b");
+            String replacement = "." + quteFilter;
+            String newContent = pattern.matcher(content).replaceAll(replacement);
+            if (!newContent.equals(content)) {
+                conversionsApplied.add("Converted filter: " + liquidFilter + " -> " + quteFilter);
+                content = newContent;
+            }
+        }
+
+        return content;
+    }
+
+    private String convertDateFilter(String content) {
+        Pattern datePattern = Pattern.compile("\\|\\s*date:\\s*[\"']([^\"']+)[\"']");
+        Matcher dateMatcher = datePattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+
+        while (dateMatcher.find()) {
+            String liquidFormat = dateMatcher.group(1);
+            String javaFormat = liquidFormat
+                    .replace("%Y", "yyyy")
+                    .replace("%m", "MM")
+                    .replace("%-m", "M")
+                    .replace("%d", "dd")
+                    .replace("%-d", "d")
+                    .replace("%e", "d")
+                    .replace("%H", "HH")
+                    .replace("%-H", "H")
+                    .replace("%k", "H")
+                    .replace("%I", "hh")
+                    .replace("%l", "h")
+                    .replace("%M", "mm")
+                    .replace("%S", "ss")
+                    .replace("%p", "a")
+                    .replace("%B", "MMMM")
+                    .replace("%b", "MMM")
+                    .replace("%A", "EEEE")
+                    .replace("%a", "EEE")
+                    .replace("%Z", "z")
+                    .replace("%z", "Z")
+                    .replace("%j", "DDD")
+                    .replace("%w", "e")
+                    .replace("%W", "ww");
+
+            if (javaFormat.matches(".*%[a-zA-Z].*")) {
+                conversionsApplied.add("WARNING: unrecognized date format specifiers in: " + liquidFormat);
+                javaFormat = javaFormat + " /* TODO: unsupported strftime specifiers */";
+            }
+
+            dateMatcher.appendReplacement(sb, ".format('" + javaFormat + "')");
+        }
+        dateMatcher.appendTail(sb);
+
+        String result = sb.toString();
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted date filters");
+            content = result;
+        }
+
+        return content;
+    }
+
+    private String convertDefaultFilter(String content) {
+        Pattern defaultPattern = Pattern.compile("\\|\\s*default:\\s*([\"'][^\"']*[\"']|\\S+)");
+        Matcher defaultMatcher = defaultPattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+
+        while (defaultMatcher.find()) {
+            String defaultVal = defaultMatcher.group(1);
+            defaultMatcher.appendReplacement(sb, " ?: " + Matcher.quoteReplacement(defaultVal));
+        }
+        defaultMatcher.appendTail(sb);
+
+        String result = sb.toString();
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted default filter");
+            content = result;
+        }
+
+        content = content.replaceAll("\\s{2,}\\?:", " ?:");
+
+        return content;
+    }
+
+    private String convertTwoArgFilters(String content) {
+        // Truncatewords: | truncatewords: 50 -> .wordLimit(50)
+        Pattern truncatePattern = Pattern.compile("\\|\\s*truncatewords:\\s*(\\d+)");
+        String result = truncatePattern.matcher(content).replaceAll(".wordLimit($1)");
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted truncate filter");
+            content = result;
+        }
+
+        // Replace_regex (must be before replace to avoid partial match)
+        Pattern replaceRegexPattern = Pattern.compile("\\|\\s*replace_regex:\\s*(['\"][^'\"]*['\"])\\s*,\\s*(['\"][^'\"]*['\"])");
+        result = replaceRegexPattern.matcher(content).replaceAll(".replaceAll($1, $2)");
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted replace_regex filter");
+            content = result;
+        }
+
+        // Replace
+        Pattern replacePattern = Pattern.compile("\\|\\s*replace:\\s*(['\"][^'\"]*['\"])\\s*,\\s*(['\"][^'\"]*['\"])");
+        result = replacePattern.matcher(content).replaceAll(".replace($1, $2)");
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted replace filter");
+            content = result;
+        }
+
+        // Where: | where: "key", "value" -> .where("key", "value")
+        Pattern wherePattern = Pattern.compile("\\|\\s*where:\\s*(['\"][^'\"]*['\"])\\s*,\\s*(['\"][^'\"]*['\"])");
+        result = wherePattern.matcher(content).replaceAll(".where($1, $2)");
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted where filter");
+            content = result;
+        }
+
+        return content;
+    }
+
+    private String convertPushFilter(String content) {
+        Pattern pushPattern = Pattern.compile("\\|\\s*push:\\s*([^}|%]+)");
+        Matcher pushMatcher = pushPattern.matcher(content);
+        StringBuilder pushSb = new StringBuilder();
+
+        while (pushMatcher.find()) {
+            String param = pushMatcher.group(1).trim();
+            pushMatcher.appendReplacement(pushSb, ".push(" + param + ")");
+        }
+        pushMatcher.appendTail(pushSb);
+
+        String result = pushSb.toString();
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted push filter");
+            content = result;
+        }
+
+        return content;
+    }
+
+    private String convertSplitFilter(String content) {
+        Pattern splitPattern = Pattern.compile("\\|\\s*split:\\s*(['\"][^'\"]*['\"])");
+        String result = splitPattern.matcher(content).replaceAll(".split($1)");
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted split filter");
+            content = result;
+        }
+
+        return content;
+    }
+
+    private String convertConditionals(String content) {
+        String original = content;
+
+        // if statements
+        content = content.replaceAll("\\{%\\s*if\\s+([^%]+?)\\s*%\\}", "{#if $1}");
+        content = content.replaceAll("\\{%\\s*elsif\\s+([^%]+?)\\s*%\\}", "{#else if $1}");
+        content = content.replaceAll("\\{%\\s*else\\s*%\\}", "{#else}");
+        content = content.replaceAll("\\{%\\s*endif\\s*%\\}", "{/if}");
+
+        // unless (negative if)
+        content = content.replaceAll("\\{%\\s*unless\\s+([^%]+?)\\s*%\\}", "{#if !($1)}");
+        content = content.replaceAll("\\{%\\s*endunless\\s*%\\}", "{/if}");
+
+        // Convert operators ONLY inside conditional blocks to avoid corrupting prose text
+        Pattern ifPattern = Pattern.compile("(\\{#(?:if|else if)\\s+)([^}]+?)(\\})");
+        Matcher ifMatcher = ifPattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+
+        while (ifMatcher.find()) {
+            String prefix = ifMatcher.group(1);
+            String condition = ifMatcher.group(2);
+            String suffix = ifMatcher.group(3);
+
+            condition = replaceOperatorsOutsideStrings(condition);
+
+            ifMatcher.appendReplacement(sb, Matcher.quoteReplacement(prefix + condition + suffix));
+        }
+        ifMatcher.appendTail(sb);
+        content = sb.toString();
+
+        if (!content.equals(original)) {
+            conversionsApplied.add("Converted conditionals");
+        }
+        return content;
+    }
+
+    private String replaceOperatorsOutsideStrings(String condition) {
+        StringBuilder result = new StringBuilder();
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        int i = 0;
+
+        while (i < condition.length()) {
+            if (!inSingleQuote && !inDoubleQuote) {
+                if (condition.charAt(i) == '"') {
+                    inDoubleQuote = true;
+                    result.append('"');
+                    i++;
+                } else if (condition.charAt(i) == '\'') {
+                    inSingleQuote = true;
+                    result.append('\'');
+                    i++;
+                } else if (matchesWord(condition, i, "and")) {
+                    result.append("&&");
+                    i += 3;
+                } else if (matchesWord(condition, i, "or")) {
+                    result.append("||");
+                    i += 2;
+                } else {
+                    result.append(condition.charAt(i));
+                    i++;
+                }
+            } else {
+                if (inDoubleQuote && condition.charAt(i) == '"') {
+                    inDoubleQuote = false;
+                } else if (inSingleQuote && condition.charAt(i) == '\'') {
+                    inSingleQuote = false;
+                }
+                result.append(condition.charAt(i));
+                i++;
+            }
+        }
+
+        return result.toString();
+    }
+
+    private static boolean matchesWord(String s, int pos, String word) {
+        if (pos + word.length() > s.length()) {
+            return false;
+        }
+        if (!s.substring(pos, pos + word.length()).equals(word)) {
+            return false;
+        }
+        if (pos > 0 && Character.isLetterOrDigit(s.charAt(pos - 1))) {
+            return false;
+        }
+        if (pos + word.length() < s.length() && Character.isLetterOrDigit(s.charAt(pos + word.length()))) {
+            return false;
+        }
+        return true;
+    }
+
+    private String convertLoops(String content) {
+        String original = content;
+
+        // Basic for loop
+        content = content.replaceAll("\\{%\\s*for\\s+(\\w+)\\s+in\\s+([^%]+?)\\s*%\\}", "{#for $1 in $2}");
+        content = content.replaceAll("\\{%\\s*endfor\\s*%\\}", "{/for}");
+
+        // Loop variables: replace forloop.* with Qute metadata derived from the actual loop variable name.
+        // We find each {#for VAR in ...} and replace forloop.* references with VAR_* in the loop body.
+        content = replaceLoopVariables(content);
+
+        // Handle limit and offset
+        Pattern limitPattern = Pattern.compile("\\{#for\\s+(\\w+)\\s+in\\s+([^}]+?)\\s+limit:(\\d+)(?:\\s+offset:(\\d+))?\\s*\\}");
+        Matcher limitMatcher = limitPattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+
+        while (limitMatcher.find()) {
+            String replacement = buildLimitedForLoop(limitMatcher);
+            limitMatcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        limitMatcher.appendTail(sb);
+        content = sb.toString();
+
+        if (!content.equals(original)) {
+            conversionsApplied.add("Converted loops");
+        }
+        return content;
+    }
+
+    private String replaceLoopVariables(String content) {
+        // Find each for loop and replace forloop.* within its body
+        Pattern forPattern = Pattern.compile("\\{#for\\s+(\\w+)\\s+in\\s+[^}]+\\}");
+        Matcher forMatcher = forPattern.matcher(content);
+
+        // Collect loop variable names and their positions
+        List<int[]> loopRanges = new ArrayList<>();
+        List<String> loopVars = new ArrayList<>();
+
+        while (forMatcher.find()) {
+            loopVars.add(forMatcher.group(1));
+            loopRanges.add(new int[] { forMatcher.end(), findMatchingEndFor(content, forMatcher.end()) });
+        }
+
+        // Process from last to first to preserve positions
+        for (int i = loopRanges.size() - 1; i >= 0; i--) {
+            String var = loopVars.get(i);
+            int start = loopRanges.get(i)[0];
+            int end = loopRanges.get(i)[1];
+            if (end <= start) {
+                continue;
+            }
+
+            String body = content.substring(start, end);
+            body = body.replaceAll("forloop\\.index0", var + "_index");
+            body = body.replaceAll("forloop\\.index", var + "_count");
+            body = body.replaceAll("forloop\\.first", var + "_count == 1");
+            body = body.replaceAll("forloop\\.last", "!" + var + "_hasNext");
+            content = content.substring(0, start) + body + content.substring(end);
+        }
+
+        return content;
+    }
+
+    private int findMatchingEndFor(String content, int startPos) {
+        int depth = 1;
+        Pattern tagPattern = Pattern.compile("\\{#for\\s|\\{/for\\}");
+        Matcher matcher = tagPattern.matcher(content);
+        matcher.region(startPos, content.length());
+
+        while (matcher.find()) {
+            if (matcher.group().startsWith("{#for")) {
+                depth++;
+            } else {
+                depth--;
+                if (depth == 0) {
+                    return matcher.start();
+                }
+            }
+        }
+        return content.length();
+    }
+
+    private static String buildLimitedForLoop(Matcher limitMatcher) {
+        String var = limitMatcher.group(1);
+        String collection = limitMatcher.group(2);
+        String limit = limitMatcher.group(3);
+        String offset = limitMatcher.group(4);
+
+        if (offset != null && !offset.equals("0")) {
+            return "{#for " + var + " in " + collection + ".skip(" + offset + ").limit(" + limit + ")}";
+        } else {
+            return "{#for " + var + " in " + collection + ".limit(" + limit + ")}";
+        }
+    }
+
+    private String convertIncludes(String content) {
+        // Liquid: {% include "file.html" %}
+        // Qute: {#include file.html /}
+        Pattern includePattern = Pattern.compile("\\{%\\s*include\\s+[\"']?([^\"'%\\s]+)[\"']?\\s*([^%]*?)\\s*%\\}");
+        Matcher includeMatcher = includePattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+
+        while (includeMatcher.find()) {
+            String file = includeMatcher.group(1);
+            String params = includeMatcher.group(2).trim();
+
+            String replacement;
+            if (!params.isEmpty()) {
+                replacement = "{#include " + file + " " + params + " /}";
+            } else {
+                replacement = "{#include " + file + " /}";
+            }
+
+            includeMatcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        includeMatcher.appendTail(sb);
+
+        String result = sb.toString();
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted includes");
+        }
+
+        return result;
+    }
+
+    private String convertAssignments(String content) {
+        String original = content;
+
+        // Convert post.* to page.* inside assign tags before converting the tags themselves
+        content = content.replaceAll("(\\{%\\s*assign\\s+\\w+\\s*=\\s*[^%]*?)\\bpost\\.", "$1page.");
+
+        // Place {/let} at the enclosing scope boundary for each assign
+        Pattern assignPattern = Pattern.compile("\\{%\\s*assign\\s+(\\w+)\\s*=\\s*([^%]+?)\\s*%\\}");
+        Matcher matcher = assignPattern.matcher(content);
+
+        List<int[]> positions = new ArrayList<>();
+        List<String> varNames = new ArrayList<>();
+        List<String> expressions = new ArrayList<>();
+
+        while (matcher.find()) {
+            positions.add(new int[] { matcher.start(), matcher.end() });
+            varNames.add(matcher.group(1));
+            expressions.add(matcher.group(2));
+        }
+
+        for (int i = positions.size() - 1; i >= 0; i--) {
+            int assignStart = positions.get(i)[0];
+            int assignEnd = positions.get(i)[1];
+            String var = varNames.get(i);
+            String expr = expressions.get(i);
+
+            int scopeEnd = findScopeBoundary(content, assignEnd);
+            content = content.substring(0, assignStart)
+                    + "{#let " + var + "=" + expr + "}"
+                    + content.substring(assignEnd, scopeEnd)
+                    + "{/let}"
+                    + content.substring(scopeEnd);
+        }
+
+        // Capture (multi-line assignment) — already block-scoped
+        content = content.replaceAll("\\{%\\s*capture\\s+(\\w+)\\s*%\\}", "{#let $1}");
+        content = content.replaceAll("\\{%\\s*endcapture\\s*%\\}", "{/let}");
+
+        if (!content.equals(original)) {
+            conversionsApplied.add("Converted assignments");
+        }
+        return content;
+    }
+
+    private int findScopeBoundary(String content, int startPos) {
+        int depth = 0;
+        Pattern tagPattern = Pattern.compile("\\{#(for|if|let)\\b|\\{#else\\b|\\{/(for|if|let)\\}");
+        Matcher matcher = tagPattern.matcher(content);
+        matcher.region(startPos, content.length());
+
+        while (matcher.find()) {
+            String match = matcher.group();
+            if (match.startsWith("{#else")) {
+                if (depth == 0) {
+                    return matcher.start();
+                }
+            } else if (match.startsWith("{#")) {
+                depth++;
+            } else {
+                if (depth == 0) {
+                    return matcher.start();
+                }
+                depth--;
+            }
+        }
+
+        return content.length();
+    }
+
+    private String convertCaseStatements(String content) {
+        Pattern caseBlockPattern = Pattern.compile(
+                "\\{%\\s*case\\s+([^%]+?)\\s*%\\}(.*?)\\{%\\s*endcase\\s*%\\}", Pattern.DOTALL);
+        Matcher matcher = caseBlockPattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+        boolean changed = false;
+
+        while (matcher.find()) {
+            changed = true;
+            String var = matcher.group(1).trim();
+            String body = matcher.group(2);
+
+            boolean[] first = { true };
+            Pattern whenPattern = Pattern.compile("\\{%\\s*when\\s+([^%]+?)\\s*%\\}");
+            Matcher whenMatcher = whenPattern.matcher(body);
+            StringBuilder bodySb = new StringBuilder();
+            while (whenMatcher.find()) {
+                String val = whenMatcher.group(1).trim();
+                String tag = first[0] ? "{#if " + var + " == " + val + "}"
+                        : "{#else if " + var + " == " + val + "}";
+                whenMatcher.appendReplacement(bodySb, Matcher.quoteReplacement(tag));
+                first[0] = false;
+            }
+            whenMatcher.appendTail(bodySb);
+
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(bodySb.toString() + "{/if}"));
+        }
+        matcher.appendTail(sb);
+
+        if (changed) {
+            conversionsApplied.add("Converted case statements to if/else if chains");
+        }
+        return sb.toString();
+    }
+
+    private String convertLayoutTags(String content) {
+        String original = content;
+
+        // Jekyll layout declaration — in Roq, layout is set via front matter, not a template tag
+        content = content.replaceAll("\\{%\\s*layout\\s+[\"']([^\"']+)[\"']\\s*%\\}",
+                "{! TODO: set layout in front matter instead: layout: $1 !}");
+
+        // {% block name %} -> {#block name}
+        content = content.replaceAll("\\{%\\s*block\\s+(\\w+)\\s*%\\}", "{#block $1}");
+        content = content.replaceAll("\\{%\\s*endblock\\s*%\\}", "{/block}");
+
+        // {% append name %} -> {#append name}
+        content = content.replaceAll("\\{%\\s*append\\s+(\\w+)\\s*%\\}", "{#append $1}");
+        content = content.replaceAll("\\{%\\s*endappend\\s*%\\}", "{/append}");
+
+        // {% prepend name %} -> {#prepend name}
+        content = content.replaceAll("\\{%\\s*prepend\\s+(\\w+)\\s*%\\}", "{#prepend $1}");
+        content = content.replaceAll("\\{%\\s*endprepend\\s*%\\}", "{/prepend}");
+
+        if (!content.equals(original)) {
+            conversionsApplied.add("Converted layout tags");
+        }
+        return content;
+    }
+
+    private String convertSpecialTags(String content) {
+        // Highlight blocks (for code syntax highlighting)
+        // Liquid: {% highlight lang %}...{% endhighlight %}
+        // Qute: <pre><code class="language-lang">...</code></pre>
+        Pattern highlightPattern = Pattern.compile("\\{%\\s*highlight\\s+(\\w+)\\s*%\\}(.*?)\\{%\\s*endhighlight\\s*%\\}", Pattern.DOTALL);
+        Matcher highlightMatcher = highlightPattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+
+        while (highlightMatcher.find()) {
+            String lang = highlightMatcher.group(1);
+            String code = highlightMatcher.group(2);
+            String replacement = "<pre><code class=\"language-" + lang + "\">" + code + "</code></pre>";
+            highlightMatcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        highlightMatcher.appendTail(sb);
+
+        String result = sb.toString();
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted special tags");
+        }
+
+        return result;
+    }
+
+    private String convertBracketNotation(String content) {
+        // Liquid: object[variable] (dynamic property access)
+        // Qute: object.get(variable)
+        Pattern pattern = Pattern.compile("([a-zA-Z0-9_.]+)\\[([a-zA-Z0-9_.]+)\\]");
+        Matcher matcher = pattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+
+        while (matcher.find()) {
+            String object = matcher.group(1);
+            String key = matcher.group(2);
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(object + ".get(" + key + ")"));
+        }
+        matcher.appendTail(sb);
+
+        String result = sb.toString();
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted bracket notation to .get()");
+        }
+
+        return result;
+    }
+
+    private String wrapTernaryBeforeMethods(String content) {
+        return transformInsideExpressions(content, this::wrapTernaryInExpression,
+                "Wrapped ternary operators before method calls");
+    }
+
+    private String wrapTernaryInExpression(String expr) {
+        Pattern pattern = Pattern.compile("([a-zA-Z0-9_\\.\\[\\]]+)\\s*\\?:\\s*([\"'][^\"']*[\"']|[a-zA-Z0-9_\\.\\[\\]]+)\\.([a-zA-Z0-9_]+)\\s*\\(");
+        Matcher matcher = pattern.matcher(expr);
+        StringBuilder sb = new StringBuilder();
+
+        while (matcher.find()) {
+            String variable = matcher.group(1);
+            String defaultVal = matcher.group(2);
+            String method = matcher.group(3);
+            String replacement = "(" + variable + " ?: " + defaultVal + ")." + method + "(";
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    private String removeSpacesBeforeMethods(String content) {
+        return transformInsideExpressions(content, this::removeSpacesInExpression,
+                "Removed spaces before method calls");
+    }
+
+    private String removeSpacesInExpression(String expr) {
+        // Match: identifier/paren/bracket/quote + whitespace + dot + identifier
+        // This handles cases like "stripHtml .wordLimit" → "stripHtml.wordLimit"
+        Pattern pattern = Pattern.compile("([a-zA-Z0-9_\\)\\]\"'])\\s+\\.([a-zA-Z0-9_]+)");
+        String result = expr;
+        String prev;
+
+        // Keep applying until no more matches (handles multiple spaces in a row)
+        do {
+            prev = result;
+            result = pattern.matcher(result).replaceAll("$1.$2");
+        } while (!result.equals(prev));
+
+        return result;
+    }
+
+    private String transformInsideExpressions(String content,
+            java.util.function.UnaryOperator<String> transform, String conversionLabel) {
+        // Match Qute expressions: {=...}, {#...}, {/...}, {!...!}
+        Pattern exprPattern = Pattern.compile("\\{[=#/!][^}]*\\}");
+        Matcher matcher = exprPattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+
+        boolean changed = false;
+        while (matcher.find()) {
+            String expr = matcher.group();
+            String transformed = transform.apply(expr);
+            if (!transformed.equals(expr)) {
+                changed = true;
+            }
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(transformed));
+        }
+        matcher.appendTail(sb);
+
+        if (changed) {
+            conversionsApplied.add(conversionLabel);
+        }
+
+        return sb.toString();
+    }
+}

--- a/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
@@ -7,7 +7,18 @@ import java.util.regex.Pattern;
 
 public class LiquidToQuteConverter {
 
+    private final boolean useExtensionSyntax;
+    private final String exprOpen;
     private final List<String> conversionsApplied = new ArrayList<>();
+
+    LiquidToQuteConverter() {
+        this(true);
+    }
+
+    LiquidToQuteConverter(boolean useExtensionSyntax) {
+        this.useExtensionSyntax = useExtensionSyntax;
+        this.exprOpen = useExtensionSyntax ? "{=" : "{";
+    }
 
     String convert(String content) {
         String original = content;
@@ -111,7 +122,7 @@ public class LiquidToQuteConverter {
             // Convert post.* to page.* (Roq uses page for all content)
             var = var.replaceAll("\\bpost\\.", "page.");
 
-            matcher.appendReplacement(sb, "{=" + Matcher.quoteReplacement(var) + "}");
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(exprOpen) + Matcher.quoteReplacement(var) + "}");
         }
         matcher.appendTail(sb);
 
@@ -124,7 +135,9 @@ public class LiquidToQuteConverter {
     }
 
     private String convertFilters(String content) {
-        Pattern blockPattern = Pattern.compile("\\{=[^}]*\\}|\\{%[^%]*%\\}");
+        Pattern blockPattern = useExtensionSyntax
+                ? Pattern.compile("\\{=[^}]*\\}|\\{%[^%]*%\\}")
+                : Pattern.compile("\\{(?![%#/!|])[^}]*\\}|\\{%[^%]*%\\}");
         Matcher matcher = blockPattern.matcher(content);
         StringBuilder sb = new StringBuilder();
 
@@ -857,8 +870,9 @@ public class LiquidToQuteConverter {
 
     private String transformInsideExpressions(String content,
             java.util.function.UnaryOperator<String> transform, String conversionLabel) {
-        // Match Qute expressions: {=...}, {#...}, {/...}, {!...!}
-        Pattern exprPattern = Pattern.compile("\\{[=#/!][^}]*\\}");
+        Pattern exprPattern = useExtensionSyntax
+                ? Pattern.compile("\\{[=#/!][^}]*\\}")
+                : Pattern.compile("\\{[^}]*\\}");
         Matcher matcher = exprPattern.matcher(content);
         StringBuilder sb = new StringBuilder();
 

--- a/migration/src/test/java/io/quarkus/tools/LiquidToQuteCommandTest.java
+++ b/migration/src/test/java/io/quarkus/tools/LiquidToQuteCommandTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.tools;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LiquidToQuteCommandTest {
+
+    @Test
+    void testFileConversion(@TempDir Path tempDir) throws IOException {
+        // Create input file
+        Path inputFile = tempDir.resolve("input.html");
+        String inputContent = "{{page.title | strip}}";
+        Files.writeString(inputFile, inputContent);
+
+        // Create output file path
+        Path outputFile = tempDir.resolve("output.html");
+
+        // Convert
+        LiquidToQuteCommand command = new LiquidToQuteCommand();
+        boolean success = command.convertFile(inputFile, outputFile);
+
+        // Verify
+        assertTrue(success, "File conversion should succeed");
+        assertTrue(Files.exists(outputFile), "Output file should exist");
+
+        String outputContent = Files.readString(outputFile);
+        String expected = "{=page.title.trim()}";
+        assertEquals(expected, outputContent, "File content should be converted");
+    }
+
+    @Test
+    void testDirectoryConversionViaCli(@TempDir Path tempDir) throws IOException {
+        Path inputDir = tempDir.resolve("_layouts");
+        Files.createDirectories(inputDir);
+        Files.writeString(inputDir.resolve("default.html"), "<html>{{ content }}</html>");
+        Files.writeString(inputDir.resolve("post.html"), "{% if page.title %}<h1>{{ page.title }}</h1>{% endif %}");
+
+        Path outputDir = tempDir.resolve("templates/layouts");
+
+        int exitCode = new picocli.CommandLine(new LiquidToQuteCommand())
+                .execute(inputDir.toString(), outputDir.toString());
+
+        assertEquals(0, exitCode, "Command should exit successfully");
+        assertTrue(Files.exists(outputDir.resolve("default.html")), "default.html should be converted");
+        assertTrue(Files.exists(outputDir.resolve("post.html")), "post.html should be converted");
+
+        String defaultContent = Files.readString(outputDir.resolve("default.html"));
+        assertEquals("<html>{=content}</html>", defaultContent);
+
+        String postContent = Files.readString(outputDir.resolve("post.html"));
+        assertEquals("{#if page.title}<h1>{=page.title}</h1>{/if}", postContent);
+    }
+}

--- a/migration/src/test/java/io/quarkus/tools/LiquidToQuteConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/LiquidToQuteConverterTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.tools;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -584,5 +585,72 @@ class LiquidToQuteConverterTest {
         String expected = "{=page.content.stripHtml.wordLimit(75)}";
         assertConverts(input, expected,
                 "Chained filters should not have spaces between method calls");
+    }
+
+    @Nested
+    class StandardSyntaxTest {
+
+        private LiquidToQuteConverter converter;
+
+        @BeforeEach
+        void setUp() {
+            converter = new LiquidToQuteConverter(false);
+        }
+
+        private void assertConverts(String input, String expected, String message) {
+            assertEquals(expected, converter.convert(input), message);
+        }
+
+        @Test
+        void testVariable() {
+            assertConverts("{{page.title}}", "{page.title}",
+                    "Standard syntax should use {expr} not {=expr}");
+        }
+
+        @Test
+        void testFilter() {
+            assertConverts("{{text | upcase}}", "{text.toUpperCase}",
+                    "Standard syntax should apply filters inside {expr}");
+        }
+
+        @Test
+        void testDefaultFilter() {
+            assertConverts("{{var | default: \"value\"}}", "{var ?: \"value\"}",
+                    "Standard syntax should convert default filter inside {expr}");
+        }
+
+        @Test
+        void testChainedFilters() {
+            assertConverts("{{page.content | strip_html | truncatewords: 75}}",
+                    "{page.content.stripHtml.wordLimit(75)}",
+                    "Standard syntax should chain filters correctly");
+        }
+
+        @Test
+        void testTernaryWrapping() {
+            assertConverts("{{post.author | default: \"\" | split: \",\"}}",
+                    "{(page.author ?: \"\").split(\",\")}",
+                    "Standard syntax should wrap ternary before method calls");
+        }
+
+        @Test
+        void testForLoop() {
+            assertConverts("{% for item in items %}{{item}}{% endfor %}",
+                    "{#for item in items}{item}{/for}",
+                    "Standard syntax for loop should use {expr} for outputs");
+        }
+
+        @Test
+        void testSpaceRemoval() {
+            assertConverts("{variable .trim()}", "{variable.trim()}",
+                    "Standard syntax should remove spaces before methods in expressions");
+        }
+
+        @Test
+        void testExtensionSyntaxDefaultConstructor() {
+            LiquidToQuteConverter ext = new LiquidToQuteConverter();
+            assertEquals("{=page.title}", ext.convert("{{page.title}}"),
+                    "Default constructor should use extension syntax");
+        }
     }
 }

--- a/migration/src/test/java/io/quarkus/tools/LiquidToQuteConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/LiquidToQuteConverterTest.java
@@ -1,0 +1,588 @@
+package io.quarkus.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LiquidToQuteConverterTest {
+
+    private LiquidToQuteConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        converter = new LiquidToQuteConverter();
+    }
+
+    private void assertConverts(String input, String expected, String message) {
+        assertEquals(expected, converter.convert(input), message);
+    }
+
+    @Test
+    void testEmptyStringSplit() {
+        String input = "{=\"\" | split: \",\"}";
+        String expected = "{=\"\".split(\",\")}";
+        assertConverts(input, expected, "Empty string split should use split method");
+    }
+
+    @Test
+    void testTernaryWithMethodCall() {
+        String input = "{=post.author ?: \"\".split(\",\")}";
+        String expected = "{=(post.author ?: \"\").split(\",\")}";
+        assertConverts(input, expected, "Ternary before method call should be wrapped in parentheses");
+    }
+
+    @Test
+    void testTernaryWithTrim() {
+        String input = "{=page.author ?: \"\".trim()}";
+        String expected = "{=(page.author ?: \"\").trim()}";
+        assertConverts(input, expected, "Ternary with trim should be wrapped");
+    }
+
+    @Test
+    void testSpaceBeforeMethod() {
+        String input = "{=variable .trim()}";
+        String expected = "{=variable.trim()}";
+        assertConverts(input, expected, "Space before method should be removed");
+    }
+
+    @Test
+    void testStripFilter() {
+        String input = "{{text | strip}}";
+        String expected = "{=text.trim()}";
+        assertConverts(input, expected, "Strip filter should convert to trim()");
+    }
+
+    @Test
+    void testDefaultFilter() {
+        String input = "{{var | default: \"value\"}}";
+        String expected = "{=var ?: \"value\"}";
+        assertConverts(input, expected, "Default filter should convert to ternary");
+    }
+
+    @Test
+    void testSplitFilter() {
+        String input = "{{text | split: \",\"}}";
+        String expected = "{=text.split(\",\")}";
+        assertConverts(input, expected, "Split filter should convert to method call");
+    }
+
+    @Test
+    void testComplexTernaryWithSplit() {
+        String input = "{{post.author | default: \"\" | split: \",\"}}";
+        // After variable conversion: post.author -> page.author
+        // After default filter: page.author ?: ""
+        // After split filter: page.author ?: "".split(",")
+        // After space removal: page.author ?: "".split(",")
+        // After ternary wrapping: (page.author ?: "").split(",")
+        String expected = "{=(page.author ?: \"\").split(\",\")}";
+        assertConverts(input, expected, "Complex ternary with split should be properly wrapped");
+    }
+
+    @Test
+    void testVariableConversion() {
+        String input = "{{page.title}}";
+        String expected = "{=page.title}";
+        assertConverts(input, expected, "Variable output should use alternative syntax");
+    }
+
+    @Test
+    void testPostToPageConversion() {
+        String input = "{{post.title}}";
+        String expected = "{=page.title}";
+        assertConverts(input, expected, "post.* should convert to page.*");
+    }
+
+    @Test
+    void testIfStatement() {
+        String input = "{% if condition %}content{% endif %}";
+        String expected = "{#if condition}content{/if}";
+        assertConverts(input, expected, "If statement should convert");
+    }
+
+    @Test
+    void testForLoop() {
+        String input = "{% for item in items %}{{item}}{% endfor %}";
+        String expected = "{#for item in items}{=item}{/for}";
+        assertConverts(input, expected, "For loop should convert");
+    }
+
+    @Test
+    void testComment() {
+        String input = "{% comment %}This is a comment{% endcomment %}";
+        String expected = "{! This is a comment !}";
+        assertConverts(input, expected, "Comment should convert");
+    }
+
+    @Test
+    void testDateFilter() {
+        String input = "{{page.date | date: \"%Y-%m-%d\"}}";
+        String expected = "{=page.date.format('yyyy-MM-dd')}";
+        assertConverts(input, expected, "Date filter should convert format");
+    }
+
+    @Test
+    void testUpcase() {
+        String input = "{{text | upcase}}";
+        String expected = "{=text.toUpperCase}";
+        assertConverts(input, expected, "Upcase filter should convert");
+    }
+
+    @Test
+    void testDowncase() {
+        String input = "{{text | downcase}}";
+        String expected = "{=text.toLowerCase}";
+        assertConverts(input, expected, "Downcase filter should convert");
+    }
+
+    @Test
+    void testMultipleFilters() {
+        String input = "{{text | strip | upcase}}";
+        String expected = "{=text.trim().toUpperCase}";
+        assertConverts(input, expected, "Multiple filters should chain");
+    }
+
+    @Test
+    void testAssignment() {
+        String input = "{% assign myvar = \"value\" %}";
+        String expected = "{#let myvar=\"value\"}{/let}";
+        assertConverts(input, expected, "Assignment should convert");
+    }
+
+    @Test
+    void testInclude() {
+        String input = "{% include \"header.html\" %}";
+        String expected = "{#include header.html /}";
+        assertConverts(input, expected, "Include should convert");
+    }
+
+    @Test
+    void testRawBlock() {
+        String input = "{% raw %}{{not processed}}{% endraw %}";
+        String expected = "{|{{not processed}}|}";
+        assertConverts(input, expected, "Raw block content should be preserved verbatim");
+    }
+
+    @Test
+    void testUnless() {
+        String input = "{% unless condition %}content{% endunless %}";
+        String expected = "{#if !(condition)}content{/if}";
+        assertConverts(input, expected, "Unless should convert to negated if");
+    }
+
+    @Test
+    void testAndOperator() {
+        String input = "{#if a and b}";
+        String expected = "{#if a && b}";
+        assertConverts(input, expected, "And operator should convert");
+    }
+
+    @Test
+    void testOrOperator() {
+        String input = "{#if a or b}";
+        String expected = "{#if a || b}";
+        assertConverts(input, expected, "Or operator should convert");
+    }
+
+    @Test
+    void testRealWorldAuthorExample() {
+        // This is the actual pattern from _layouts/author.html that was causing issues
+        // Note: post.author is converted to page.author by the converter
+        String input = "{{post.author | default: \"\" | split: \",\"}}";
+        String expected = "{=(page.author ?: \"\").split(\",\")}";
+        assertConverts(input, expected, "Real-world author pattern should convert correctly");
+    }
+
+    @Test
+    void testMultipleTernariesInSameExpression() {
+        String input = "{=a ?: \"\".trim()} and {=b ?: \"\".split(\",\")}";
+        String expected = "{=(a ?: \"\").trim()} and {=(b ?: \"\").split(\",\")}";
+        assertConverts(input, expected, "Multiple ternaries should all be wrapped");
+    }
+
+    @Test
+    void testTernaryWithoutMethodCall() {
+        String input = "{=var ?: \"default\"}";
+        String expected = "{=var ?: \"default\"}";
+        assertConverts(input, expected, "Ternary without method call should not be wrapped");
+    }
+
+    @Test
+    void testAppendFilter() {
+        String input = "{{\"hello\" | append: \" world\"}}";
+        String expected = "{=\"hello\" + \" world\"}";
+        assertConverts(input, expected, "Append filter should convert to concatenation");
+    }
+
+    @Test
+    void testMultipleAppends() {
+        String input = "{{\"a\" | append: \"b\" | append: \"c\"}}";
+        String expected = "{=\"a\" + \"b\" + \"c\"}";
+        assertConverts(input, expected, "Multiple appends should chain");
+    }
+
+    @Test
+    void testReplaceFilter() {
+        String input = "{{text | replace: 'old', 'new'}}";
+        String expected = "{=text.replace('old', 'new')}";
+        assertConverts(input, expected, "Replace filter should convert");
+    }
+
+    @Test
+    void testWhereFilter() {
+        String input = "{{array | where: \"key\", \"value\"}}";
+        String expected = "{=array.where(\"key\", \"value\")}";
+        assertConverts(input, expected, "Where filter should convert");
+    }
+
+    @Test
+    void testCaseStatement() {
+        String input = "{% case var %}{% when val1 %}a{% endcase %}";
+        String expected = "{#if var == val1}a{/if}";
+        assertConverts(input, expected, "Case statement should convert to if");
+    }
+
+    @Test
+    void testElsif() {
+        String input = "{% if a %}1{% elsif b %}2{% else %}3{% endif %}";
+        String expected = "{#if a}1{#else if b}2{#else}3{/if}";
+        assertConverts(input, expected, "Elsif should convert");
+    }
+
+    @Test
+    void testCapture() {
+        String input = "{% capture myvar %}content{% endcapture %}";
+        String expected = "{#let myvar}content{/let}";
+        assertConverts(input, expected, "Capture should convert");
+    }
+
+    @Test
+    void testAssignWithEmptyStringSplit() {
+        String input = "{% assign authors_clean = \"\" | split: \"\" %}";
+        String expected = "{#let authors_clean=\"\".split(\"\")}{/let}";
+        assertConverts(input, expected, "Empty string split in assignment should produce valid Qute");
+    }
+
+    @Test
+    void testFilterNotConvertedOutsideBlocks() {
+        String input = "\"\" | split: \"\"";
+        String expected = "\"\" | split: \"\"";
+        assertConverts(input, expected,
+                "Filters outside expression blocks should not be converted");
+    }
+
+    @Test
+    void testAssignWithPushFilter() {
+        String input = "{% assign authors_clean = authors_clean | push: a_trimmed %}";
+        String expected = "{#let authors_clean=authors_clean.push(a_trimmed)}{/let}";
+        assertConverts(input, expected, "Assignment with push filter should convert correctly");
+    }
+
+    @Test
+    void testAndOrInProseNotCorrupted() {
+        String input = "<p>This is information or data and more text</p>\n" +
+                       "{% if a and b %}yes{% endif %}";
+        String expected = "<p>This is information or data and more text</p>\n" +
+                         "{#if a && b}yes{/if}";
+        assertConverts(input, expected,
+                "and/or in prose text should not be converted, only inside conditionals");
+    }
+
+    @Test
+    void testAuthorFileLines36to38() {
+        String input = "      {% comment %} Build multi-author list for this post {% endcomment %}\n" +
+                       "      {% assign authors_raw = post.author | default: \"\" | split: \",\" %}\n" +
+                       "      {% assign authors_clean = \"\" | split: \"\" %}";
+
+        String expected = "      {!  Build multi-author list for this post  !}\n" +
+                         "      {#let authors_raw=(page.author ?: \"\").split(\",\")}\n" +
+                         "      {#let authors_clean=\"\".split(\"\")}{/let}{/let}";
+
+        assertConverts(input, expected, "Author file lines 36-38 should convert without {?:} errors");
+    }
+
+    @Test
+    void testWhitespaceTrimmingTags() {
+        // Liquid: {%- if ... -%} and {% endif -%} (whitespace trimming)
+        String input = "{%- if condition -%}content{%- endif -%}";
+        String expected = "{#if condition}content{/if}";
+        assertConverts(input, expected,
+                "Whitespace-trimming tags should be handled like normal tags");
+    }
+
+    @Test
+    void testWhitespaceTrimmingEndFor() {
+        String input = "{% for item in items %}{=item}{% endfor -%}";
+        String expected = "{#for item in items}{=item}{/for}";
+        assertConverts(input, expected,
+                "endfor with whitespace trimming should convert");
+    }
+
+    @Test
+    void testReplaceRegexFilter() {
+        String input = "{{page.url | replace_regex: '^/version/([^/]+)/.*', '\\1'}}";
+        String expected = "{=page.url.replaceAll('^/version/([^/]+)/.*', '\\1')}";
+        assertConverts(input, expected,
+                "replace_regex filter should convert to .replaceAll() method call");
+    }
+
+    @Test
+    void testStartsWithFilter() {
+        String input = "{% assign versioned = page.url | startswith: '/version/' %}";
+        String expected = "{#let versioned=page.url.startsWith('/version/')}{/let}";
+        assertConverts(input, expected,
+                "startswith filter should convert to .startsWith() method call");
+    }
+
+    @Test
+    void testEndsWithFilter() {
+        String input = "{{title | endswith: 'Quarkus'}}";
+        String expected = "{=title.endsWith('Quarkus')}";
+        assertConverts(input, expected,
+                "endswith filter should convert to .endsWith() method call");
+    }
+
+    @Test
+    void testSortFilterWithArgument() {
+        String input = "{% assign authors = site.data.authors | sort: name %}";
+        String expected = "{#let authors=site.data.authors.sort(name)}{/let}";
+        assertConverts(input, expected,
+                "Sort filter with argument should convert to method call with argument");
+    }
+
+    @Test
+    void testPrependFilter() {
+        // Liquid: {{ path | prepend: site.baseurl }}
+        // Qute: site.baseurl + path (prepend = concatenate before)
+        String input = "{{paginator.next_page_path | prepend: site.baseurl}}";
+        String expected = "{=site.baseurl + paginator.next_page_path}";
+        assertConverts(input, expected,
+                "Prepend filter should convert to string concatenation");
+    }
+
+    @Test
+    void testDynamicBracketNotation() {
+        String input = "{% assign author = site.data.authors[author_key] %}";
+        String expected = "{#let author=site.data.authors.get(author_key)}{/let}";
+        assertConverts(input, expected,
+                "Dynamic bracket notation should be converted to .get() method call");
+    }
+
+    @Test
+    void testDynamicBracketNotationInVariable() {
+        String input = "{{ site.data.authors[key].name }}";
+        String expected = "{=site.data.authors.get(key).name}";
+        assertConverts(input, expected,
+                "Bracket notation followed by property access should convert correctly");
+    }
+
+    // --- Loop variable tests ---
+
+    @Test
+    void testForLoopIndexWithNamedVar() {
+        String input = "{% for post in posts %}{{forloop.index0}} {{forloop.index}}{% endfor %}";
+        String expected = "{#for post in posts}{=post_index} {=post_count}{/for}";
+        assertConverts(input, expected,
+                "forloop.index0/index should use the loop variable name");
+    }
+
+    @Test
+    void testForLoopFirstUsesCount() {
+        String input = "{% for item in items %}{% if forloop.first %}first{% endif %}{% endfor %}";
+        String expected = "{#for item in items}{#if item_count == 1}first{/if}{/for}";
+        assertConverts(input, expected,
+                "forloop.first should convert to var_count == 1");
+    }
+
+    @Test
+    void testForLoopLastUsesHasNext() {
+        String input = "{% for entry in entries %}{% if forloop.last %}last{% endif %}{% endfor %}";
+        String expected = "{#for entry in entries}{#if !entry_hasNext}last{/if}{/for}";
+        assertConverts(input, expected,
+                "forloop.last should convert to !var_hasNext");
+    }
+
+    @Test
+    void testNestedForLoopsUseDifferentVarNames() {
+        String input = "{% for cat in categories %}{% for post in cat.posts %}{{forloop.index}}{% endfor %}{% endfor %}";
+        String expected = "{#for cat in categories}{#for post in cat.posts}{=post_count}{/for}{/for}";
+        assertConverts(input, expected,
+                "Nested loops should use their own variable name for metadata");
+    }
+
+    @Test
+    void testForLoopWithLimitAndOffset() {
+        String input = "{% for item in items limit:3 offset:2 %}{{item}}{% endfor %}";
+        String expected = "{#for item in items.skip(2).limit(3)}{=item}{/for}";
+        assertConverts(input, expected,
+                "Loop with limit and offset should convert to .skip().limit()");
+    }
+
+    // --- Layout tag tests ---
+
+    @Test
+    void testLayoutInheritance() {
+        String input = "{% layout \"default\" %}";
+        String expected = "{! TODO: set layout in front matter instead: layout: default !}";
+        assertConverts(input, expected, "Layout tag should emit front matter TODO");
+    }
+
+    @Test
+    void testBlockTags() {
+        String input = "{% block content %}body{% endblock %}";
+        String expected = "{#block content}body{/block}";
+        assertConverts(input, expected, "Block tags should convert");
+    }
+
+    // --- Highlight block tests ---
+
+    @Test
+    void testHighlightBlock() {
+        String input = "{% highlight java %}System.out.println();{% endhighlight %}";
+        String expected = "<pre><code class=\"language-java\">System.out.println();</code></pre>";
+        assertConverts(input, expected, "Highlight blocks should convert to pre/code");
+    }
+
+    // --- Full pipeline and/or tests ---
+
+    @Test
+    void testFullPipelineAndOrInConditional() {
+        String input = "{% if a and b or c %}yes{% endif %}";
+        String expected = "{#if a && b || c}yes{/if}";
+        assertConverts(input, expected,
+                "and/or in raw Liquid conditionals should convert through the full pipeline");
+    }
+
+    // --- Prose safety tests ---
+
+    @Test
+    void testSpaceBeforeMethodPreservedInProse() {
+        String input = "<p>See docs .method for details</p>";
+        String expected = "<p>See docs .method for details</p>";
+        assertConverts(input, expected,
+                "Spaces before dot-words in prose should not be removed");
+    }
+
+    @Test
+    void testSpaceBeforeMethodRemovedInExpression() {
+        String input = "{=variable .trim()}";
+        String expected = "{=variable.trim()}";
+        assertConverts(input, expected,
+                "Spaces before method calls inside expressions should be removed");
+    }
+
+    // --- No-change reporting tests ---
+
+    @Test
+    void testNoChangeReportsNoConversions() {
+        String input = "<p>Plain HTML with no Liquid</p>";
+        converter.convert(input);
+        assertEquals("No conversions needed", converter.getConversionReport(),
+                "Content with no Liquid should report no conversions");
+    }
+
+    // --- Regression tests for bug fixes ---
+
+    @Test
+    void testAndOrInsideStringNotCorrupted() {
+        String input = "{% if label == \"and\" %}yes{% endif %}";
+        String expected = "{#if label == \"and\"}yes{/if}";
+        assertConverts(input, expected,
+                "and/or inside string literals in conditions should not be replaced");
+    }
+
+    @Test
+    void testOrInsideStringNotCorrupted() {
+        String input = "{% if type == 'or' and active %}yes{% endif %}";
+        String expected = "{#if type == 'or' && active}yes{/if}";
+        assertConverts(input, expected,
+                "or inside quotes preserved, and outside quotes converted");
+    }
+
+    @Test
+    void testFilterNotConvertedInMarkdownTable() {
+        String input = "| Name | Size | Status |\n| sort | reverse | done |";
+        String expected = "| Name | Size | Status |\n| sort | reverse | done |";
+        assertConverts(input, expected,
+                "Pipes and filter-like words in markdown tables should not be converted");
+    }
+
+    @Test
+    void testCaseStatementWithMultipleWhens() {
+        String input = "{% case status %}{% when \"active\" %}A{% when \"inactive\" %}I{% when \"pending\" %}P{% endcase %}";
+        String expected = "{#if status == \"active\"}A{#else if status == \"inactive\"}I{#else if status == \"pending\"}P{/if}";
+        assertConverts(input, expected,
+                "Case with multiple whens should produce if/else if chain");
+    }
+
+    @Test
+    void testDateFilterWith12Hour() {
+        String input = "{{page.date | date: \"%I:%M %p\"}}";
+        String expected = "{=page.date.format('hh:mm a')}";
+        assertConverts(input, expected, "12-hour date format should convert");
+    }
+
+    @Test
+    void testDateFilterUnknownSpecifier() {
+        String input = "{{page.date | date: \"%Y-%Q\"}}";
+        String expected = "{=page.date.format('yyyy-%Q /* TODO: unsupported strftime specifiers */')}";
+        assertConverts(input, expected, "Unknown date specifier should emit TODO");
+    }
+
+    @Test
+    void testRawBlockPreservesLiquidTags() {
+        String input = "{% raw %}{% if x %}hello{% endif %}{% endraw %}";
+        String expected = "{|{% if x %}hello{% endif %}|}";
+        assertConverts(input, expected, "Raw block should preserve Liquid tags verbatim");
+    }
+
+    // --- Assign scope boundary tests ---
+
+    @Test
+    void testAssignScopeExtendsToEndOfContent() {
+        String input = "{% assign x = \"hello\" %}\n{=x}\nmore content";
+        String expected = "{#let x=\"hello\"}\n{=x}\nmore content{/let}";
+        assertConverts(input, expected,
+                "Assign at top level should scope to end of content");
+    }
+
+    @Test
+    void testAssignScopeEndsAtEnclosingForLoop() {
+        String input = "{#for item in items}{% assign x = item.name %}{=x}{/for}after";
+        String expected = "{#for item in items}{#let x=item.name}{=x}{/let}{/for}after";
+        assertConverts(input, expected,
+                "Assign inside a for loop should scope to the loop's end");
+    }
+
+    @Test
+    void testAssignScopeEndsAtEnclosingIf() {
+        String input = "{#if cond}{% assign x = \"val\" %}{=x}{/if}";
+        String expected = "{#if cond}{#let x=\"val\"}{=x}{/let}{/if}";
+        assertConverts(input, expected,
+                "Assign inside an if block should scope to the if's end");
+    }
+
+    @Test
+    void testMultipleAssignsNestCorrectly() {
+        String input = "{% assign a = 1 %}\n{% assign b = 2 %}\n{=a} {=b}";
+        String expected = "{#let a=1}\n{#let b=2}\n{=a} {=b}{/let}{/let}";
+        assertConverts(input, expected,
+                "Multiple top-level assigns should nest with both {/let}s at end");
+    }
+
+    @Test
+    void testAssignInIfBranchScopedBeforeElse() {
+        String input = "{% if page.title %}{% assign x = page.title %}{% else %}{% assign x = 'default' %}{% endif %}";
+        String expected = "{#if page.title}{#let x=page.title}{/let}{#else}{#let x='default'}{/let}{/if}";
+        assertConverts(input, expected,
+                "Assign in if branch should be scoped before the else, not crossing into it");
+    }
+
+    @Test
+    void testChainedFiltersRemoveSpaces() {
+        String input = "{{page.content | strip_html | truncatewords: 75}}";
+        String expected = "{=page.content.stripHtml.wordLimit(75)}";
+        assertConverts(input, expected,
+                "Chained filters should not have spaces between method calls");
+    }
+}


### PR DESCRIPTION
This is large, sorry. :( 

It's a standalone converter tool that transforms Jekyll/Liquid templates to Roq/Qute templates. Handles variables, filters, conditionals, loops, includes, assignments, case statements, layout tags, and special blocks.

I haven't hooked this into the docs yet, or into the larger migration logic, just to keep changes at a manageable size. 

### Limitations 
- Converting docs about Qute itself is hard, and probably doesn't work yet 
- There are two TODOs where the converter gives up and emits a TODO; I'll need to iterate on those, since they should be handled automatically, and even if they're not, I don't think a TODO in the output file is the right behaviour

### Good things 

It works on quarkus.io! "Works" is a strong word here: I didn't attempt the Qute docs, and I don't have the site fully up yet. 

Since Liquid is used more widely than just Jekyll, this converter may have a broader usefulness (cc @mkouba), but I'll store it here for now. 

I did look at conversion frameworks, like OpenRewrite, but for this kind of conversion I couldn't find anything that was obviously better than shell script + Java code. 

Partial resolution of #366 