### PR TITLE
Add Jekyll-compatible String methods to RoqUrl

### DIFF
--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/RoqUrl.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/RoqUrl.java
@@ -157,4 +157,37 @@ public record RoqUrl(
         return new RoqUrl(root, resourcePath);
     }
 
+    /**
+     * Check if the URL path starts with the given prefix
+     *
+     * @param prefix the prefix to check
+     * @return true if the path starts with the prefix
+     */
+    public boolean startsWith(String prefix) {
+        return path().startsWith(prefix);
+    }
+
+    /**
+     * Replace all occurrences matching the regex with the replacement
+     *
+     * @param regex the regular expression
+     * @param replacement the replacement string
+     * @return a new RoqUrl with the replaced path
+     */
+    public RoqUrl replaceAll(String regex, String replacement) {
+        String newPath = resourcePath().replaceAll(regex, replacement);
+        return new RoqUrl(root(), newPath);
+    }
+
+    /**
+     * Remove the first occurrence of the given string from the path
+     *
+     * @param str the string to remove
+     * @return a new RoqUrl with the string removed
+     */
+    public RoqUrl removeFirst(String str) {
+        String newPath = resourcePath().replaceFirst(java.util.regex.Pattern.quote(str), "");
+        return new RoqUrl(root(), newPath);
+    }
+
 }

--- a/roq-frontmatter/runtime/src/test/java/io/quarkiverse/roq/frontmatter/runtime/model/RoqUrlTest.java
+++ b/roq-frontmatter/runtime/src/test/java/io/quarkiverse/roq/frontmatter/runtime/model/RoqUrlTest.java
@@ -1,0 +1,64 @@
+package io.quarkiverse.roq.frontmatter.runtime.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class RoqUrlTest {
+
+    private RootUrl testRoot() {
+        return new RootUrl("https://example.com", "/blog");
+    }
+
+    @Test
+    void testStartsWith() {
+        RoqUrl url = new RoqUrl(testRoot(), "/version/3.0/guides/getting-started");
+        assertTrue(url.startsWith("/blog/version/"));
+        assertTrue(url.startsWith("/blog/"));
+        assertFalse(url.startsWith("/docs/"));
+    }
+
+    @Test
+    void testStartsWithRelativePath() {
+        RoqUrl url = new RoqUrl(testRoot(), "/posts/my-post");
+        assertTrue(url.startsWith("/blog/posts"));
+        assertFalse(url.startsWith("/posts")); // Root path is prepended
+    }
+
+    @Test
+    void testReplaceAll() {
+        // Operates on resource path only (without root)
+        RoqUrl url = new RoqUrl(testRoot(), "/version/3.0/guides/getting-started");
+        RoqUrl result = url.replaceAll("^/version/([^/]+)/.*", "$1");
+        // Result resource path is "3.0", full path is "/blog/3.0"
+        assertEquals("/blog/3.0", result.path());
+    }
+
+    @Test
+    void testReplaceAllRemovePrefix() {
+        RoqUrl url = new RoqUrl(testRoot(), "/version/3.0/guides");
+        RoqUrl result = url.replaceAll("^/version/[^/]+", "");
+        assertEquals("/blog/guides", result.path());
+    }
+
+    @Test
+    void testRemoveFirst() {
+        RoqUrl url = new RoqUrl(testRoot(), "/posts/my-post");
+        RoqUrl result = url.removeFirst("/posts");
+        assertEquals("/blog/my-post", result.path());
+    }
+
+    @Test
+    void testRemoveFirstSlash() {
+        RoqUrl url = new RoqUrl(testRoot(), "/posts/my-post");
+        RoqUrl result = url.removeFirst("/");
+        assertEquals("/blog/posts/my-post", result.path());
+    }
+
+    @Test
+    void testRemoveFirstWithSpecialCharacters() {
+        RoqUrl url = new RoqUrl(testRoot(), "/posts/my.post");
+        RoqUrl result = url.removeFirst("/posts/my.post");
+        assertEquals("/blog/", result.path());
+    }
+}


### PR DESCRIPTION
Add startsWith(), replaceAll(), and removeFirst() methods to RoqUrl to support common Jekyll URL manipulation patterns. I think this is harmless, and it makes Jekyll migrations easier.

These methods enable templates like:
- page.url.startsWith("/guides/") for conditional rendering
- page.url.replaceAll("^/version/([^/]+)/.*", "$1") for version extraction
- page.url.removeFirst("/blog") for path manipulation

 The RoqUrl methods enable these common Jekyll patterns:

  1. startsWith() - Conditional Navigation Highlighting

  Jekyll:
  
  ```
  {% if page.url contains "/guides/" %}
    <li class="active">Guides</li>
  {% else %}
    <li><a href="/guides/">Guides</a></li>
  {% endif %}
  ```
  Roq (with RoqUrl.startsWith()):
  
  ```
  {#if page.url.startsWith("/guides/")}
    <li class="active">Guides</li>
  {#else}
    <li><a href="/guides/">Guides</a></li>
  {/if}
  ```
  ---
  2. replaceAll() - Version Extraction from URL

  Jekyll:
  
  ```
  {% assign version = page.url | replace_first: "/version/", "" | split: "/" | first %}
  <span class="version">Version {= version}</span>
```
  Roq (with RoqUrl.replaceAll()):
  
  ```
  {#let version=page.url.replaceAll("^/version/([^/]+)/.*", "$1")}
  <span class="version">Version {=version}</span>
  {/let}
  
  ```

  Real-world use case from quarkus.io:
  Extract version numbers from versioned documentation URLs like /version/3.0/guides/getting-started → "3.0"

  ---
  3. removeFirst() - Path Manipulation for Canonical URLs

  Jekyll:
  
  ```
  {% assign canonical = page.url | remove_first: "/blog" %}
  <link rel="canonical" href="{= site.url}{=canonical}" />
```
  Roq (with RoqUrl.removeFirst()):
  
  ```
  {#let canonical=page.url.removeFirst("/blog")}
  <link rel="canonical" href="{=site.url.resolve(canonical)}" />
  {/let}
  
  ```
  
  Real-world use case:
  Strip prefixes from URLs when migrating from subdirectory-based sites (e.g., /blog/2024/post → /2024/post)

