### PR TITLE
Editor: publish via pull request

### DIFF
--- a/blog/includes/configs/quarkus-roq-editor.adoc
+++ b/blog/includes/configs/quarkus-roq-editor.adoc
@@ -154,6 +154,98 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-mode]] [.property-path]##link:#quarkus-roq-editor_editor-sync-mode[`+++editor.sync.mode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++editor.sync.mode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Publish workflow mode.
+
+`PR`: Publish from `main` creates a content branch, pushes it and surfaces a PR-creation link. Subsequent publishes on the content branch update the same branch until its remote ref disappears (PR merged), at which point the editor returns to `main`.
+
+`DIRECT`: Publish commits and pushes straight to the current branch.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++EDITOR_SYNC_MODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++EDITOR_SYNC_MODE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`pr`, `direct`
+|`+++pr+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-pr-flow-content-branch-prefix]] [.property-path]##link:#quarkus-roq-editor_editor-sync-pr-flow-content-branch-prefix[`+++editor.sync.pr-flow.content-branch-prefix+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++editor.sync.pr-flow.content-branch-prefix+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Prefix used for auto-generated content branches. A branch is considered a "content branch" when its name starts with this prefix.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++EDITOR_SYNC_PR_FLOW_CONTENT_BRANCH_PREFIX+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++EDITOR_SYNC_PR_FLOW_CONTENT_BRANCH_PREFIX+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++content/+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-pr-flow-commit-strategy]] [.property-path]##link:#quarkus-roq-editor_editor-sync-pr-flow-commit-strategy[`+++editor.sync.pr-flow.commit-strategy+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++editor.sync.pr-flow.commit-strategy+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Strategy for subsequent publishes on the same content branch.
+
+`NEW_COMMITS`: each Publish adds a new commit. No force-push, history preserved.
+
+`AMEND`: each Publish amends the previous commit. Single-commit PR, requires force-push (with-lease) on the content branch.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++EDITOR_SYNC_PR_FLOW_COMMIT_STRATEGY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++EDITOR_SYNC_PR_FLOW_COMMIT_STRATEGY+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`new-commits`, `amend`
+|`+++new-commits+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-pr-flow-main-branch]] [.property-path]##link:#quarkus-roq-editor_editor-sync-pr-flow-main-branch[`+++editor.sync.pr-flow.main-branch+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++editor.sync.pr-flow.main-branch+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Explicit name of the main/default branch. When empty, it is detected from `refs/remotes/origin/HEAD` and falls back to `main`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++EDITOR_SYNC_PR_FLOW_MAIN_BRANCH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++EDITOR_SYNC_PR_FLOW_MAIN_BRANCH+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-ssh-passphrase]] [.property-path]##link:#quarkus-roq-editor_editor-sync-ssh-passphrase[`+++editor.sync.ssh-passphrase+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++editor.sync.ssh-passphrase+++[]

--- a/blog/includes/configs/quarkus-roq-editor_editor.adoc
+++ b/blog/includes/configs/quarkus-roq-editor_editor.adoc
@@ -154,6 +154,98 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-mode]] [.property-path]##link:#quarkus-roq-editor_editor-sync-mode[`+++editor.sync.mode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++editor.sync.mode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Publish workflow mode.
+
+`PR`: Publish from `main` creates a content branch, pushes it and surfaces a PR-creation link. Subsequent publishes on the content branch update the same branch until its remote ref disappears (PR merged), at which point the editor returns to `main`.
+
+`DIRECT`: Publish commits and pushes straight to the current branch.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++EDITOR_SYNC_MODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++EDITOR_SYNC_MODE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`pr`, `direct`
+|`+++pr+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-pr-flow-content-branch-prefix]] [.property-path]##link:#quarkus-roq-editor_editor-sync-pr-flow-content-branch-prefix[`+++editor.sync.pr-flow.content-branch-prefix+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++editor.sync.pr-flow.content-branch-prefix+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Prefix used for auto-generated content branches. A branch is considered a "content branch" when its name starts with this prefix.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++EDITOR_SYNC_PR_FLOW_CONTENT_BRANCH_PREFIX+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++EDITOR_SYNC_PR_FLOW_CONTENT_BRANCH_PREFIX+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++content/+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-pr-flow-commit-strategy]] [.property-path]##link:#quarkus-roq-editor_editor-sync-pr-flow-commit-strategy[`+++editor.sync.pr-flow.commit-strategy+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++editor.sync.pr-flow.commit-strategy+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Strategy for subsequent publishes on the same content branch.
+
+`NEW_COMMITS`: each Publish adds a new commit. No force-push, history preserved.
+
+`AMEND`: each Publish amends the previous commit. Single-commit PR, requires force-push (with-lease) on the content branch.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++EDITOR_SYNC_PR_FLOW_COMMIT_STRATEGY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++EDITOR_SYNC_PR_FLOW_COMMIT_STRATEGY+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`new-commits`, `amend`
+|`+++new-commits+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-pr-flow-main-branch]] [.property-path]##link:#quarkus-roq-editor_editor-sync-pr-flow-main-branch[`+++editor.sync.pr-flow.main-branch+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++editor.sync.pr-flow.main-branch+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Explicit name of the main/default branch. When empty, it is detected from `refs/remotes/origin/HEAD` and falls back to `main`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++EDITOR_SYNC_PR_FLOW_MAIN_BRANCH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++EDITOR_SYNC_PR_FLOW_MAIN_BRANCH+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-editor_editor-sync-ssh-passphrase]] [.property-path]##link:#quarkus-roq-editor_editor-sync-ssh-passphrase[`+++editor.sync.ssh-passphrase+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++editor.sync.ssh-passphrase+++[]

--- a/roq-editor/deployment/src/main/java/io/quarkiverse/roq/editor/deployment/git/GitPrFlowPublisher.java
+++ b/roq-editor/deployment/src/main/java/io/quarkiverse/roq/editor/deployment/git/GitPrFlowPublisher.java
@@ -1,0 +1,359 @@
+package io.quarkiverse.roq.editor.deployment.git;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.TransportCommand;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.RepositoryState;
+import org.eclipse.jgit.lib.StoredConfig;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.PushResult;
+import org.eclipse.jgit.transport.RemoteRefUpdate;
+import org.jboss.logging.Logger;
+
+import io.quarkiverse.roq.editor.runtime.devui.RoqEditorConfig;
+import io.quarkiverse.roq.editor.runtime.devui.RoqEditorConfig.SyncConfig.PrFlowConfig.CommitStrategy;
+import io.quarkiverse.roq.editor.runtime.devui.git.GitSyncResult;
+
+/**
+ * Publish flow that routes edits through a content branch and a PR.
+ */
+public class GitPrFlowPublisher {
+
+    private static final Logger LOG = Logger.getLogger(GitPrFlowPublisher.class);
+
+    private static final String MSG_NOTHING_TO_PUBLISH = "Nothing to publish";
+    private static final String MSG_PUSH_SUCCESS = "Changes pushed successfully";
+    private static final String MSG_RESTORE_STASH_AFTER_SYNC = "Restoring local changes after sync.";
+
+    private static final DateTimeFormatter BRANCH_TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMdd-HHmm");
+    private static final Pattern PR_URL_PATTERN = Pattern.compile(
+            "https?://\\S+?(?:pull/new/|pull-requests/new|merge_requests/new)\\S*");
+
+    @FunctionalInterface
+    public interface PullExecutor {
+        GitSyncResult performPull(Git git, Repository repository);
+    }
+
+    @FunctionalInterface
+    public interface DirectPublisher {
+        GitSyncResult publish(Git git, Repository repository, String commitMessage, List<String> filePaths) throws Exception;
+    }
+
+    private final RoqEditorConfig editorConfig;
+    private final GitOperationHelper operationHelper;
+    private final GitCredentialHelper credentialHelper;
+    private final String configuredPassphrase;
+    private final PullExecutor pullExecutor;
+    private final DirectPublisher directPublisher;
+
+    public GitPrFlowPublisher(RoqEditorConfig editorConfig, GitOperationHelper operationHelper,
+            GitCredentialHelper credentialHelper, String configuredPassphrase,
+            PullExecutor pullExecutor, DirectPublisher directPublisher) {
+        this.editorConfig = editorConfig;
+        this.operationHelper = operationHelper;
+        this.credentialHelper = credentialHelper;
+        this.configuredPassphrase = configuredPassphrase;
+        this.pullExecutor = pullExecutor;
+        this.directPublisher = directPublisher;
+    }
+
+    /**
+     * Publishes the staged edits by routing on the current branch:
+     * <ul>
+     * <li>Main: create content branch, commit, push with upstream tracking, surface PR link.</li>
+     * <li>Content branch with remote ref still present: commit (or amend), push.</li>
+     * <li>Content branch whose remote ref was pruned: stash, return to main, pull, pop, start a new cycle.</li>
+     * <li>Any other branch: fall back to direct publish.</li>
+     * </ul>
+     *
+     * @param git the Git instance
+     * @param repository the JGit repository
+     * @param commitMessage the commit message to use
+     * @param filePaths the file paths to stage
+     * @param branchNameOverride optional name for the content branch (used when starting a new cycle)
+     * @return the result of the publish operation
+     * @throws Exception if a Git operation fails
+     */
+    public GitSyncResult publish(Git git, Repository repository, String commitMessage, List<String> filePaths,
+            String branchNameOverride) throws Exception {
+        String mainBranch = resolveMainBranch(repository);
+        String currentBranch = repository.getBranch();
+        String prefix = editorConfig.sync().prFlow().contentBranchPrefix();
+
+        if (!currentBranch.equals(mainBranch) && currentBranch.startsWith(prefix)) {
+            fetchAndPrune(git, repository);
+            if (remoteBranchExists(repository, currentBranch)) {
+                return publishOnContentBranch(git, repository, commitMessage, filePaths, currentBranch);
+            }
+            GitSyncResult switched = switchBackToMain(git, repository, mainBranch);
+            if (!switched.success()) {
+                return switched;
+            }
+            currentBranch = mainBranch;
+        }
+
+        if (currentBranch.equals(mainBranch)) {
+            return startContentBranchCycle(git, repository, commitMessage, filePaths, branchNameOverride);
+        }
+
+        LOG.debug("PR mode: current branch '" + currentBranch
+                + "' is neither the main branch nor a content branch; falling back to direct publish");
+        return directPublisher.publish(git, repository, commitMessage, filePaths);
+    }
+
+    /**
+     * Stages pending edits, branches off main, commits, and pushes with upstream tracking.
+     * Returns a "nothing to publish" result when the working tree has no significant changes.
+     *
+     * @param git the Git instance
+     * @param repository the JGit repository
+     * @param commitMessage the commit message to use
+     * @param filePaths the file paths to stage
+     * @param branchNameOverride optional explicit branch name; auto-generated when blank
+     * @return the result of the push, including the PR creation URL when surfaced by the remote
+     */
+    private GitSyncResult startContentBranchCycle(Git git, Repository repository, String commitMessage,
+            List<String> filePaths, String branchNameOverride) throws Exception {
+        operationHelper.stageChanges(git, repository, filePaths);
+        if (!operationHelper.hasStagedChanges(git) && repository.getRepositoryState() == RepositoryState.SAFE) {
+            return new GitSyncResult(true, MSG_NOTHING_TO_PUBLISH, false, Collections.emptyList(), false);
+        }
+
+        String newBranch = resolveNewBranchName(repository, branchNameOverride);
+        git.checkout().setCreateBranch(true).setName(newBranch).call();
+
+        GitSyncResult stateResult = operationHelper.finalizeState(git, repository, commitMessage);
+        if (stateResult != null) {
+            return stateResult;
+        }
+
+        return pushContentBranch(git, repository, newBranch, false);
+    }
+
+    /**
+     * Updates the existing content branch with a new commit, or amends the previous commit
+     * when {@link CommitStrategy#AMEND} is configured and the branch already has commits past main.
+     *
+     * @param git the Git instance
+     * @param repository the JGit repository
+     * @param commitMessage the commit message to use
+     * @param filePaths the file paths to stage
+     * @param branchName the current content branch name
+     * @return the result of the push
+     */
+    private GitSyncResult publishOnContentBranch(Git git, Repository repository, String commitMessage,
+            List<String> filePaths, String branchName) throws Exception {
+        operationHelper.stageChanges(git, repository, filePaths);
+
+        CommitStrategy strategy = editorConfig.sync().prFlow().commitStrategy();
+        boolean amend = strategy == CommitStrategy.AMEND
+                && hasCommitsBeyond(repository, branchName, resolveMainBranch(repository));
+
+        if (operationHelper.hasStagedChanges(git) || repository.getRepositoryState() == RepositoryState.MERGING) {
+            String msg = (commitMessage == null || commitMessage.isBlank())
+                    ? editorConfig.sync().commitMessage().template()
+                    : commitMessage;
+            git.commit().setMessage(msg).setAmend(amend).call();
+        } else if (repository.getRepositoryState().isRebasing()) {
+            GitSyncResult stateResult = operationHelper.finalizeState(git, repository, commitMessage);
+            if (stateResult != null) {
+                return stateResult;
+            }
+        } else {
+            return new GitSyncResult(true, MSG_NOTHING_TO_PUBLISH, false, Collections.emptyList(), false);
+        }
+
+        return pushContentBranch(git, repository, branchName, amend);
+    }
+
+    /**
+     * Pushes the named content branch to {@code origin}, optionally with force, and extracts the
+     * PR creation URL from the remote messages when available.
+     *
+     * @param git the Git instance
+     * @param repository the JGit repository
+     * @param branchName the branch to push
+     * @param force whether to force the push (required when amending)
+     * @return the result including the PR creation URL when surfaced by the remote
+     */
+    private GitSyncResult pushContentBranch(Git git, Repository repository, String branchName, boolean force)
+            throws Exception {
+        Iterable<PushResult> results = configureTransport(
+                git.push().setRemote("origin").setForce(force).add("refs/heads/" + branchName),
+                repository).call();
+
+        String prUrl = null;
+        for (PushResult pushResult : results) {
+            for (RemoteRefUpdate update : pushResult.getRemoteUpdates()) {
+                RemoteRefUpdate.Status updateStatus = update.getStatus();
+                if (updateStatus != RemoteRefUpdate.Status.OK
+                        && updateStatus != RemoteRefUpdate.Status.UP_TO_DATE) {
+                    return new GitSyncResult(false,
+                            "Push failed: " + updateStatus + " (" + update.getMessage() + ")",
+                            false, Collections.emptyList(), false);
+                }
+            }
+            String messages = pushResult.getMessages();
+            if (prUrl == null && messages != null) {
+                prUrl = extractPrCreationUrl(messages);
+            }
+        }
+
+        configureBranchTracking(repository, branchName);
+        return new GitSyncResult(true, MSG_PUSH_SUCCESS, false, Collections.emptyList(), false, prUrl, branchName);
+    }
+
+    /**
+     * Returns the editor to the main branch after the content branch's remote ref disappears
+     * (typically because the PR was merged or closed). Local edits are preserved via stash.
+     *
+     * @param git the Git instance
+     * @param repository the JGit repository
+     * @param mainBranch the resolved main branch name
+     * @return the result of the pull after switching back
+     */
+    private GitSyncResult switchBackToMain(Git git, Repository repository, String mainBranch) throws Exception {
+        boolean wasDirty = !git.status().call().isClean();
+        if (wasDirty) {
+            git.stashCreate().setIncludeUntracked(true).call();
+        }
+
+        git.checkout().setName(mainBranch).call();
+
+        GitSyncResult pullResult = pullExecutor.performPull(git, repository);
+        if (!pullResult.success()) {
+            if (wasDirty) {
+                operationHelper.restoreStash(git, pullResult, MSG_RESTORE_STASH_AFTER_SYNC);
+            }
+            return pullResult;
+        }
+
+        if (wasDirty) {
+            return operationHelper.restoreStash(git, pullResult, MSG_RESTORE_STASH_AFTER_SYNC);
+        }
+        return pullResult;
+    }
+
+    private void fetchAndPrune(Git git, Repository repository) {
+        try {
+            configureTransport(git.fetch().setRemote("origin").setRemoveDeletedRefs(true), repository).call();
+        } catch (Exception e) {
+            LOG.debug("Fetch+prune failed (will continue with cached refs): " + e.getMessage());
+        }
+    }
+
+    private boolean remoteBranchExists(Repository repository, String branchName) throws IOException {
+        return repository.findRef("refs/remotes/origin/" + branchName) != null;
+    }
+
+    /**
+     * Checks whether {@code branchName} contains at least one commit not reachable from
+     * {@code baseBranch}. Used to decide whether the previous commit can be amended.
+     *
+     * @param repository the JGit repository
+     * @param branchName the branch to inspect
+     * @param baseBranch the base branch to compare against
+     * @return true when the branch has commits past the base
+     */
+    private boolean hasCommitsBeyond(Repository repository, String branchName, String baseBranch) throws IOException {
+        ObjectId branchHead = repository.resolve(branchName);
+        ObjectId baseHead = repository.resolve(baseBranch);
+        if (branchHead == null || baseHead == null) {
+            return false;
+        }
+        try (RevWalk walk = new RevWalk(repository)) {
+            walk.markStart(walk.parseCommit(branchHead));
+            walk.markUninteresting(walk.parseCommit(baseHead));
+            return walk.iterator().hasNext();
+        }
+    }
+
+    private String resolveMainBranch(Repository repository) throws IOException {
+        return editorConfig.sync().prFlow().mainBranch()
+                .filter(b -> !b.isBlank())
+                .orElseGet(() -> detectDefaultBranch(repository));
+    }
+
+    private String detectDefaultBranch(Repository repository) {
+        try {
+            Ref head = repository.findRef("refs/remotes/origin/HEAD");
+            if (head != null && head.isSymbolic()) {
+                String target = head.getTarget().getName();
+                String prefix = "refs/remotes/origin/";
+                if (target.startsWith(prefix)) {
+                    return target.substring(prefix.length());
+                }
+            }
+            if (repository.findRef("refs/heads/main") != null) {
+                return "main";
+            }
+            if (repository.findRef("refs/heads/master") != null) {
+                return "master";
+            }
+        } catch (IOException ignored) {
+        }
+        return "main";
+    }
+
+    private String resolveNewBranchName(Repository repository, String override) throws IOException {
+        String prefix = editorConfig.sync().prFlow().contentBranchPrefix();
+        String base;
+        if (override != null && !override.isBlank()) {
+            String sanitized = override.replaceAll("[^A-Za-z0-9._/-]", "-");
+            base = sanitized.startsWith(prefix) ? sanitized : prefix + sanitized;
+        } else {
+            base = prefix + "update-" + LocalDateTime.now().format(BRANCH_TIMESTAMP);
+        }
+
+        String candidate = base;
+        int suffix = 2;
+        while (branchNameTaken(repository, candidate)) {
+            candidate = base + "-" + suffix++;
+        }
+        return candidate;
+    }
+
+    private boolean branchNameTaken(Repository repository, String name) throws IOException {
+        return repository.findRef("refs/heads/" + name) != null
+                || repository.findRef("refs/remotes/origin/" + name) != null;
+    }
+
+    private void configureBranchTracking(Repository repository, String branchName) throws IOException {
+        StoredConfig config = repository.getConfig();
+        if (config.getString("branch", branchName, "remote") == null) {
+            config.setString("branch", branchName, "remote", "origin");
+            config.setString("branch", branchName, "merge", "refs/heads/" + branchName);
+            config.save();
+        }
+    }
+
+    static String extractPrCreationUrl(String pushMessages) {
+        if (pushMessages == null || pushMessages.isEmpty()) {
+            return null;
+        }
+        Matcher matcher = PR_URL_PATTERN.matcher(pushMessages);
+        return matcher.find() ? matcher.group() : null;
+    }
+
+    private <C extends TransportCommand<C, ?>> C configureTransport(C cmd, Repository repository) {
+        cmd.setTransportConfigCallback(GitTransportHelper.createTransportCallback(configuredPassphrase));
+        if (!GitTransportHelper.isSsh(repository)) {
+            CredentialsProvider cp = credentialHelper.getCredentials(repository);
+            if (cp != null) {
+                cmd.setCredentialsProvider(cp);
+            }
+        }
+        return cmd;
+    }
+}

--- a/roq-editor/deployment/src/main/java/io/quarkiverse/roq/editor/deployment/git/GitSyncService.java
+++ b/roq-editor/deployment/src/main/java/io/quarkiverse/roq/editor/deployment/git/GitSyncService.java
@@ -43,7 +43,23 @@ public interface GitSyncService {
      * @param filePaths (optional) list of files to publish
      * @return the result of the publish operation
      */
-    GitSyncResult publish(String message, List<String> filePaths);
+    default GitSyncResult publish(String message, List<String> filePaths) {
+        return publish(message, filePaths, null);
+    }
+
+    /**
+     * Publishes local changes by staging, committing, and pushing them.
+     * <p>
+     * When PR mode is active and the current branch is the main branch, a new content branch
+     * is created. The caller may supply {@code branchNameOverride} to use a specific name
+     * (sanitised against the configured prefix); when {@code null}, a name is auto-generated.
+     *
+     * @param message the commit message
+     * @param filePaths (optional) list of files to publish
+     * @param branchNameOverride (optional) name for the new content branch when starting a PR cycle
+     * @return the result of the publish operation
+     */
+    GitSyncResult publish(String message, List<String> filePaths, String branchNameOverride);
 
     /**
      * Publishes local changes and then performs a full synchronization.
@@ -52,5 +68,18 @@ public interface GitSyncService {
      * @param filePaths (optional) list of files to publish
      * @return the combined result of publish and sync operations
      */
-    GitSyncResult publishAndSync(String message, List<String> filePaths);
+    default GitSyncResult publishAndSync(String message, List<String> filePaths) {
+        return publishAndSync(message, filePaths, null);
+    }
+
+    /**
+     * Publishes local changes (optionally creating a content branch in PR mode) and then
+     * performs a full synchronization.
+     *
+     * @param message the commit message
+     * @param filePaths (optional) list of files to publish
+     * @param branchNameOverride (optional) name for the new content branch when starting a PR cycle
+     * @return the combined result of publish and sync operations
+     */
+    GitSyncResult publishAndSync(String message, List<String> filePaths, String branchNameOverride);
 }

--- a/roq-editor/deployment/src/main/java/io/quarkiverse/roq/editor/deployment/git/GitSyncServiceImpl.java
+++ b/roq-editor/deployment/src/main/java/io/quarkiverse/roq/editor/deployment/git/GitSyncServiceImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.jgit.transport.RemoteRefUpdate;
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.roq.editor.runtime.devui.RoqEditorConfig;
+import io.quarkiverse.roq.editor.runtime.devui.RoqEditorConfig.SyncConfig.Mode;
 import io.quarkiverse.roq.editor.runtime.devui.git.GitStatusInfo;
 import io.quarkiverse.roq.editor.runtime.devui.git.GitSyncResult;
 import io.quarkiverse.roq.frontmatter.runtime.config.RoqSiteConfig;
@@ -46,8 +47,10 @@ public class GitSyncServiceImpl implements GitSyncService {
     private static final String MSG_NO_GIT_REPO = "no-git-repo";
 
     private final File rootDirectory;
+    private final RoqEditorConfig editorConfig;
     private final GitContentFilter contentFilter;
     private final GitOperationHelper operationHelper;
+    private final GitPrFlowPublisher prFlowPublisher;
     private final ReentrantLock lock = new ReentrantLock();
     private volatile Boolean cachedIsSsh;
     private volatile boolean lastAuthFailed;
@@ -63,9 +66,12 @@ public class GitSyncServiceImpl implements GitSyncService {
      */
     public GitSyncServiceImpl(RoqEditorConfig editorConfig, RoqSiteConfig siteConfig, File rootDirectory) {
         this.rootDirectory = rootDirectory;
+        this.editorConfig = editorConfig;
         this.contentFilter = new GitContentFilter(siteConfig, rootDirectory);
         this.operationHelper = new GitOperationHelper(editorConfig, contentFilter);
         this.configuredPassphrase = editorConfig.sync().sshPassphrase().filter(p -> !p.isEmpty()).orElse(null);
+        this.prFlowPublisher = new GitPrFlowPublisher(editorConfig, operationHelper, credentialHelper,
+                configuredPassphrase, this::performPull, this::doDirectPublish);
     }
 
     /**
@@ -259,14 +265,16 @@ public class GitSyncServiceImpl implements GitSyncService {
     }
 
     /**
-     * Publishes changes by staging, committing, and pushing to the remote repository.
+     * Publishes the given changes by staging, committing, and pushing to the remote.
+     * Routes to the direct flow or the PR flow based on the configured {@link Mode}.
      *
-     * @param commitMessage the commit message
-     * @param filePaths the file paths to publish
+     * @param commitMessage the commit message to use
+     * @param filePaths the file paths to stage
+     * @param branchNameOverride optional name for the content branch (PR flow only)
      * @return the result of the publish operation
      */
     @Override
-    public GitSyncResult publish(String commitMessage, List<String> filePaths) {
+    public GitSyncResult publish(String commitMessage, List<String> filePaths, String branchNameOverride) {
         lock.lock();
         try (Repository repository = openRepository()) {
             if (repository == null) {
@@ -274,33 +282,10 @@ public class GitSyncServiceImpl implements GitSyncService {
             }
 
             try (Git git = new Git(repository)) {
-                operationHelper.stageChanges(git, repository, filePaths);
-
-                GitSyncResult stateResult = operationHelper.finalizeState(git, repository, commitMessage);
-                if (stateResult != null) {
-                    return stateResult;
+                if (editorConfig.sync().mode() == Mode.DIRECT) {
+                    return doDirectPublish(git, repository, commitMessage, filePaths);
                 }
-
-                tryFetch(git, GitTransportHelper.isSsh(repository));
-
-                BranchTrackingStatus trackingStatus = BranchTrackingStatus.of(repository, repository.getBranch());
-                if (trackingStatus != null && trackingStatus.getBehindCount() > 0
-                        && repository.getRepositoryState() == RepositoryState.SAFE) {
-                    LOG.debug(MSG_AUTO_MERGE_DURING_PUBLISH);
-                    GitSyncResult syncResult = doSync(git, repository);
-                    if (!syncResult.success()) {
-                        return syncResult;
-                    }
-                }
-
-                RepositoryState state = repository.getRepositoryState();
-                if (state != RepositoryState.SAFE) {
-                    return new GitSyncResult(true,
-                            "Partial resolution successful (State: " + state + "). Continue resolving/publishing.", false,
-                            Collections.emptyList(), false);
-                }
-
-                return doPush(git, repository);
+                return prFlowPublisher.publish(git, repository, commitMessage, filePaths, branchNameOverride);
             }
         } catch (Exception e) {
             return handlePublishFailure(e);
@@ -314,14 +299,55 @@ public class GitSyncServiceImpl implements GitSyncService {
      *
      * @param commitMessage the commit message
      * @param filePaths the file paths to publish
+     * @param branchNameOverride optional name for the content branch (PR flow only)
      * @return the result of the publish and sync operation
      */
     @Override
-    public GitSyncResult publishAndSync(String commitMessage, List<String> filePaths) {
-        GitSyncResult publishResult = publish(commitMessage, filePaths);
+    public GitSyncResult publishAndSync(String commitMessage, List<String> filePaths, String branchNameOverride) {
+        GitSyncResult publishResult = publish(commitMessage, filePaths, branchNameOverride);
         if (!publishResult.success())
             return publishResult;
         return sync();
+    }
+
+    /**
+     * Direct publish flow: stage, commit, optionally merge if behind, then push to the current branch.
+     *
+     * @param git the Git instance
+     * @param repository the JGit repository
+     * @param commitMessage the commit message to use
+     * @param filePaths the file paths to stage
+     * @return the result of the publish operation
+     */
+    private GitSyncResult doDirectPublish(Git git, Repository repository, String commitMessage, List<String> filePaths)
+            throws Exception {
+        operationHelper.stageChanges(git, repository, filePaths);
+
+        GitSyncResult stateResult = operationHelper.finalizeState(git, repository, commitMessage);
+        if (stateResult != null) {
+            return stateResult;
+        }
+
+        tryFetch(git, GitTransportHelper.isSsh(repository));
+
+        BranchTrackingStatus trackingStatus = BranchTrackingStatus.of(repository, repository.getBranch());
+        if (trackingStatus != null && trackingStatus.getBehindCount() > 0
+                && repository.getRepositoryState() == RepositoryState.SAFE) {
+            LOG.debug(MSG_AUTO_MERGE_DURING_PUBLISH);
+            GitSyncResult syncResult = doSync(git, repository);
+            if (!syncResult.success()) {
+                return syncResult;
+            }
+        }
+
+        RepositoryState state = repository.getRepositoryState();
+        if (state != RepositoryState.SAFE) {
+            return new GitSyncResult(true,
+                    "Partial resolution successful (State: " + state + "). Continue resolving/publishing.", false,
+                    Collections.emptyList(), false);
+        }
+
+        return doPush(git, repository);
     }
 
     /**

--- a/roq-editor/deployment/src/main/java/io/quarkiverse/roq/editor/deployment/git/RoqEditorGitBuildActions.java
+++ b/roq-editor/deployment/src/main/java/io/quarkiverse/roq/editor/deployment/git/RoqEditorGitBuildActions.java
@@ -32,13 +32,15 @@ public class RoqEditorGitBuildActions {
         actions.actionBuilder().methodName("publishContent").function(parameters -> {
             String commitMessage = parseString(parameters.get("message"));
             List<String> filePaths = extractList(parameters.get("filePaths"));
-            return CompletableFuture.supplyAsync(() -> gitService.publish(commitMessage, filePaths));
+            String branchName = parseString(parameters.get("branchName"));
+            return CompletableFuture.supplyAsync(() -> gitService.publish(commitMessage, filePaths, branchName));
         }).build();
 
         actions.actionBuilder().methodName("publishAndSync").function(parameters -> {
             String commitMessage = parseString(parameters.get("message"));
             List<String> filePaths = extractList(parameters.get("filePaths"));
-            return CompletableFuture.supplyAsync(() -> gitService.publishAndSync(commitMessage, filePaths));
+            String branchName = parseString(parameters.get("branchName"));
+            return CompletableFuture.supplyAsync(() -> gitService.publishAndSync(commitMessage, filePaths, branchName));
         }).build();
 
         return actions;

--- a/roq-editor/deployment/src/main/resources/dev-ui/components/notification-toast.js
+++ b/roq-editor/deployment/src/main/resources/dev-ui/components/notification-toast.js
@@ -4,13 +4,14 @@ import { html, render } from 'lit';
 
 /**
  * Show a notification toast using Vaadin Notification
- * 
+ *
  * Usage:
  *   import { showNotification } from './components/notification-toast.js';
  *   showNotification('Error message here', 'error');
  *   showNotification('Success!', 'success');
- * 
- * @param {string} message - The message to display
+ *   showNotification(html`Pushed. <a href=${url} target="_blank">Open PR</a>`, 'success', 10000);
+ *
+ * @param {string|import('lit').TemplateResult} message - The message to display (plain text or lit template)
  * @param {'error' | 'success' | 'warning' | 'primary' | 'contrast'} theme - The theme/type of notification
  * @param {number} duration - Auto-dismiss duration in ms (0 for no auto-dismiss)
  */

--- a/roq-editor/deployment/src/main/resources/dev-ui/qwc-roq-editor.js
+++ b/roq-editor/deployment/src/main/resources/dev-ui/qwc-roq-editor.js
@@ -644,14 +644,41 @@ export class QwcRoqEditor extends LitElement {
             if (!message) return;
         }
 
+        let branchName = null;
+        if (needsCommit && this._isStartingPrCycle(freshStatus)) {
+            const suggested = this._suggestContentBranchName();
+            branchName = await showPrompt('Branch name for the content PR', suggested);
+            if (!branchName) return;
+        }
+
         this._publishing = true;
         try {
-            await this._syncManager.manualPublish(message, selectedFiles);
+            await this._syncManager.manualPublish(message, selectedFiles, branchName);
         } catch (error) {
             showNotification('Publish failed: ' + error.message, 'error');
         } finally {
             this._publishing = false;
         }
+    }
+
+    /**
+     * Returns true when the next publish will open a fresh content-branch cycle and the user
+     * should be prompted for a branch name: PR mode is active and the current branch is not
+     * already a content branch (heuristically, doesn't start with the configured prefix).
+     */
+    _isStartingPrCycle(status) {
+        if (config.sync?.mode !== 'PR') return false;
+        const prefix = config.sync?.prFlow?.contentBranchPrefix ?? 'content/';
+        const branch = status?.branch ?? '';
+        return !branch.startsWith(prefix);
+    }
+
+    _suggestContentBranchName() {
+        const prefix = config.sync?.prFlow?.contentBranchPrefix ?? 'content/';
+        const now = new Date();
+        const pad = (n) => String(n).padStart(2, '0');
+        const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}`;
+        return `${prefix}update-${stamp}`;
     }
 
 }

--- a/roq-editor/deployment/src/main/resources/dev-ui/utils/sync-manager.js
+++ b/roq-editor/deployment/src/main/resources/dev-ui/utils/sync-manager.js
@@ -1,3 +1,5 @@
+import { html } from 'lit';
+
 /**
  * Orchestrator for Git synchronization background tasks.
  * Handles polling for repository status and automatic sync/publish.
@@ -189,7 +191,16 @@ export class SyncManager {
      */
     async _handleOperationResult(result, successMessage, opType, fullRefresh = false) {
         if (result?.success) {
-            this.onNotification(successMessage, 'success');
+            if (result.prCreationUrl) {
+                const url = result.prCreationUrl;
+                const branch = result.targetBranch;
+                this.onNotification(
+                    html`Pushed to <code>${branch}</code>. <a href=${url} target="_blank" rel="noopener">Open pull request ↗</a>`,
+                    'success',
+                    15000);
+            } else {
+                this.onNotification(successMessage, 'success');
+            }
             if (this.status) {
                 const updated = { ...this.status };
                 if (opType === 'publish' || opType === 'publishAndSync') {
@@ -231,10 +242,13 @@ export class SyncManager {
      * Manually triggers a Git Publish (commit + push).
      * @param {string} message - The commit message
      * @param {string[]} filePaths - List of files to stage and commit
+     * @param {string|null} branchName - When set, name of the content branch to create (PR flow only)
      * @returns {Promise<Object>} Result of the operation
      */
-    async manualPublish(message, filePaths) {
-        const result = await this.jsonRpc.publishContent({ message, filePaths: filePaths ?? [] }).then(r => r.result);
+    async manualPublish(message, filePaths, branchName = null) {
+        const result = await this.jsonRpc
+                .publishContent({ message, filePaths: filePaths ?? [], branchName })
+                .then(r => r.result);
         return this._handleOperationResult(result, 'Content published successfully', 'publish', true);
     }
 
@@ -242,10 +256,13 @@ export class SyncManager {
      * Triggers a publish followed by a sync.
      * @param {string} message - The commit message
      * @param {string[]} filePaths - List of files to publish
+     * @param {string|null} branchName - When set, name of the content branch to create (PR flow only)
      * @returns {Promise<Object>} Combined result
      */
-    async publishAndSync(message, filePaths) {
-        const result = await this.jsonRpc.publishAndSync({ message, filePaths: filePaths ?? [] }).then(r => r.result);
+    async publishAndSync(message, filePaths, branchName = null) {
+        const result = await this.jsonRpc
+                .publishAndSync({ message, filePaths: filePaths ?? [], branchName })
+                .then(r => r.result);
         return this._handleOperationResult(result, 'Content published and synchronized successfully', 'publishAndSync', true);
     }
 }

--- a/roq-editor/deployment/src/test/java/io/quarkiverse/roq/editor/deployment/git/GitSyncServiceTest.java
+++ b/roq-editor/deployment/src/test/java/io/quarkiverse/roq/editor/deployment/git/GitSyncServiceTest.java
@@ -24,6 +24,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkiverse.roq.editor.runtime.devui.RoqEditorConfig;
+import io.quarkiverse.roq.editor.runtime.devui.RoqEditorConfig.SyncConfig.Mode;
+import io.quarkiverse.roq.editor.runtime.devui.RoqEditorConfig.SyncConfig.PrFlowConfig;
+import io.quarkiverse.roq.editor.runtime.devui.RoqEditorConfig.SyncConfig.PrFlowConfig.CommitStrategy;
 import io.quarkiverse.roq.editor.runtime.devui.git.GitStatusInfo;
 import io.quarkiverse.roq.editor.runtime.devui.git.GitSyncResult;
 import io.quarkiverse.roq.frontmatter.runtime.config.RoqSiteConfig;
@@ -610,6 +613,139 @@ class GitSyncServiceTest {
         assertThat(successCount.get()).isEqualTo(threadCount);
     }
 
+    @Test
+    void shouldCreateContentBranchAndPushOnPublishFromMainInPrMode() throws Exception {
+        String mainBranch = localRepository.getRepository().getBranch();
+        GitSyncServiceImpl prService = new GitSyncServiceImpl(
+                createEditorConfig(Mode.PR, CommitStrategy.NEW_COMMITS, Optional.of(mainBranch)),
+                createSiteConfig(), localDirectory.toFile());
+
+        Files.writeString(localDirectory.resolve("content/draft.md"), "draft content");
+
+        GitSyncResult result = prService.publish("Add draft", null, "my-draft");
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.targetBranch()).isEqualTo("content/my-draft");
+        assertThat(localRepository.getRepository().getBranch()).isEqualTo("content/my-draft");
+        assertThat(localRepository.getRepository().findRef("refs/remotes/origin/content/my-draft")).isNotNull();
+        assertThat(localRepository.getRepository().findRef("refs/heads/" + mainBranch)).isNotNull();
+    }
+
+    @Test
+    void shouldAutoGenerateBranchNameWhenOverrideMissing() throws Exception {
+        String mainBranch = localRepository.getRepository().getBranch();
+        GitSyncServiceImpl prService = new GitSyncServiceImpl(
+                createEditorConfig(Mode.PR, CommitStrategy.NEW_COMMITS, Optional.of(mainBranch)),
+                createSiteConfig(), localDirectory.toFile());
+
+        Files.writeString(localDirectory.resolve("content/auto-named.md"), "content");
+
+        GitSyncResult result = prService.publish("Update", null, null);
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.targetBranch()).startsWith("content/update-");
+    }
+
+    @Test
+    void shouldAddNewCommitWhenPublishingAgainOnContentBranch() throws Exception {
+        String mainBranch = localRepository.getRepository().getBranch();
+        GitSyncServiceImpl prService = new GitSyncServiceImpl(
+                createEditorConfig(Mode.PR, CommitStrategy.NEW_COMMITS, Optional.of(mainBranch)),
+                createSiteConfig(), localDirectory.toFile());
+
+        Files.writeString(localDirectory.resolve("content/post.md"), "first");
+        prService.publish("First", null, "feature");
+
+        Files.writeString(localDirectory.resolve("content/post.md"), "second");
+        GitSyncResult result = prService.publish("Second", null, null);
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.targetBranch()).isEqualTo("content/feature");
+        int commitsOnBranch = 0;
+        for (var ignored : localRepository.log().add(localRepository.getRepository().resolve("content/feature"))
+                .not(localRepository.getRepository().resolve(mainBranch)).call()) {
+            commitsOnBranch++;
+        }
+        assertThat(commitsOnBranch).isEqualTo(2);
+    }
+
+    @Test
+    void shouldAmendPreviousCommitWhenStrategyIsAmend() throws Exception {
+        String mainBranch = localRepository.getRepository().getBranch();
+        GitSyncServiceImpl prService = new GitSyncServiceImpl(
+                createEditorConfig(Mode.PR, CommitStrategy.AMEND, Optional.of(mainBranch)),
+                createSiteConfig(), localDirectory.toFile());
+
+        Files.writeString(localDirectory.resolve("content/post.md"), "first");
+        prService.publish("First", null, "amend-test");
+
+        Files.writeString(localDirectory.resolve("content/post.md"), "second");
+        GitSyncResult result = prService.publish("Second", null, null);
+
+        assertThat(result.success()).isTrue();
+        int commitsOnBranch = 0;
+        for (var ignored : localRepository.log().add(localRepository.getRepository().resolve("content/amend-test"))
+                .not(localRepository.getRepository().resolve(mainBranch)).call()) {
+            commitsOnBranch++;
+        }
+        assertThat(commitsOnBranch).isEqualTo(1);
+    }
+
+    @Test
+    void shouldSwitchBackToMainWhenContentBranchPrunedFromRemote() throws Exception {
+        String mainBranch = localRepository.getRepository().getBranch();
+        GitSyncServiceImpl prService = new GitSyncServiceImpl(
+                createEditorConfig(Mode.PR, CommitStrategy.NEW_COMMITS, Optional.of(mainBranch)),
+                createSiteConfig(), localDirectory.toFile());
+
+        Files.writeString(localDirectory.resolve("content/pr-1.md"), "wip");
+        prService.publish("Open PR", null, "merged");
+        assertThat(localRepository.getRepository().getBranch()).isEqualTo("content/merged");
+
+        try (Git bareGit = Git.open(remoteDirectory.toFile())) {
+            bareGit.branchDelete().setBranchNames("refs/heads/content/merged").setForce(true).call();
+        }
+
+        Files.writeString(localDirectory.resolve("content/next.md"), "new cycle");
+        GitSyncResult result = prService.publish("Start next", null, "next-pr");
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.targetBranch()).isEqualTo("content/next-pr");
+        assertThat(localRepository.getRepository().getBranch()).isEqualTo("content/next-pr");
+    }
+
+    @Test
+    void shouldFallBackToDirectPushOnUnknownBranchInPrMode() throws Exception {
+        String mainBranch = localRepository.getRepository().getBranch();
+        GitSyncServiceImpl prService = new GitSyncServiceImpl(
+                createEditorConfig(Mode.PR, CommitStrategy.NEW_COMMITS, Optional.of(mainBranch)),
+                createSiteConfig(), localDirectory.toFile());
+
+        localRepository.checkout().setCreateBranch(true).setName("feature-x").call();
+        Files.writeString(localDirectory.resolve("content/foo.md"), "x");
+
+        GitSyncResult result = prService.publish("Push to feature-x", null, null);
+
+        assertThat(result.success()).isTrue();
+        assertThat(localRepository.getRepository().getBranch()).isEqualTo("feature-x");
+    }
+
+    @Test
+    void shouldExtractGitHubPrCreationUrlFromPushMessages() {
+        String messages = "remote: \n"
+                + "remote: Create a pull request for 'content/draft' on GitHub by visiting:\n"
+                + "remote:   https://github.com/org/repo/pull/new/content/draft\n"
+                + "remote: \n";
+        assertThat(GitPrFlowPublisher.extractPrCreationUrl(messages))
+                .isEqualTo("https://github.com/org/repo/pull/new/content/draft");
+    }
+
+    @Test
+    void shouldReturnNullWhenPushMessagesContainNoPrUrl() {
+        assertThat(GitPrFlowPublisher.extractPrCreationUrl("remote: Everything up-to-date\n")).isNull();
+        assertThat(GitPrFlowPublisher.extractPrCreationUrl(null)).isNull();
+    }
+
     private RoqSiteConfig createSiteConfig() {
         return new RoqSiteConfig() {
             @Override
@@ -725,6 +861,10 @@ class GitSyncServiceTest {
     }
 
     private RoqEditorConfig createEditorConfig() {
+        return createEditorConfig(Mode.DIRECT, CommitStrategy.NEW_COMMITS, Optional.empty());
+    }
+
+    private RoqEditorConfig createEditorConfig(Mode mode, CommitStrategy commitStrategy, Optional<String> mainBranchName) {
         return new RoqEditorConfig() {
             @Override
             public Markup pageMarkup() {
@@ -762,6 +902,31 @@ class GitSyncServiceTest {
                     @Override
                     public boolean enabled() {
                         return true;
+                    }
+
+                    @Override
+                    public Mode mode() {
+                        return mode;
+                    }
+
+                    @Override
+                    public PrFlowConfig prFlow() {
+                        return new PrFlowConfig() {
+                            @Override
+                            public String contentBranchPrefix() {
+                                return "content/";
+                            }
+
+                            @Override
+                            public CommitStrategy commitStrategy() {
+                                return commitStrategy;
+                            }
+
+                            @Override
+                            public Optional<String> mainBranch() {
+                                return mainBranchName;
+                            }
+                        };
                     }
 
                     @Override

--- a/roq-editor/runtime/src/main/java/io/quarkiverse/roq/editor/runtime/devui/RoqEditorConfig.java
+++ b/roq-editor/runtime/src/main/java/io/quarkiverse/roq/editor/runtime/devui/RoqEditorConfig.java
@@ -107,6 +107,65 @@ public interface RoqEditorConfig {
         boolean enabled();
 
         /**
+         * Publish workflow mode.
+         * <p>
+         * {@code PR}: Publish from {@code main} creates a content branch, pushes it and surfaces a
+         * PR-creation link. Subsequent publishes on the content branch update the same branch until
+         * its remote ref disappears (PR merged), at which point the editor returns to {@code main}.
+         * <p>
+         * {@code DIRECT}: Publish commits and pushes straight to the current branch.
+         */
+        @JsonProperty("mode")
+        @WithDefault("PR")
+        Mode mode();
+
+        enum Mode {
+            PR,
+            DIRECT
+        }
+
+        /**
+         * PR-flow specific options. Only consulted when {@link #mode()} is {@code PR}.
+         */
+        @JsonProperty("prFlow")
+        PrFlowConfig prFlow();
+
+        interface PrFlowConfig {
+
+            /**
+             * Prefix used for auto-generated content branches. A branch is considered a
+             * "content branch" when its name starts with this prefix.
+             */
+            @JsonProperty("contentBranchPrefix")
+            @WithDefault("content/")
+            String contentBranchPrefix();
+
+            /**
+             * Strategy for subsequent publishes on the same content branch.
+             * <p>
+             * {@code NEW_COMMITS}: each Publish adds a new commit. No force-push, history preserved.
+             * <p>
+             * {@code AMEND}: each Publish amends the previous commit. Single-commit PR, requires
+             * force-push (with-lease) on the content branch.
+             */
+            @JsonProperty("commitStrategy")
+            @WithDefault("NEW_COMMITS")
+            CommitStrategy commitStrategy();
+
+            enum CommitStrategy {
+                NEW_COMMITS,
+                AMEND
+            }
+
+            /**
+             * Explicit name of the main/default branch. When empty, it is detected from
+             * {@code refs/remotes/origin/HEAD} and falls back to {@code main}.
+             */
+            @JsonIgnore
+            Optional<String> mainBranch();
+        }
+
+        /**
          * Optional SSH passphrase used as a fallback when no SSH agent is available to unlock a
          * passphrase-protected key for remote operations.
          * <p>

--- a/roq-editor/runtime/src/main/java/io/quarkiverse/roq/editor/runtime/devui/git/GitSyncResult.java
+++ b/roq-editor/runtime/src/main/java/io/quarkiverse/roq/editor/runtime/devui/git/GitSyncResult.java
@@ -4,11 +4,22 @@ import java.util.List;
 
 /**
  * Result of a Git synchronization operation.
+ * <p>
+ * {@code prCreationUrl} and {@code targetBranch} are populated by the PR-based publish flow
+ * to let the UI surface a clickable "Open PR" link and confirm which branch received the push.
+ * Both remain {@code null} for sync, direct-mode publish, and failure results.
  */
 public record GitSyncResult(
         boolean success,
         String message,
         boolean hasConflicts,
         List<String> conflictFiles,
-        boolean authFailed) {
+        boolean authFailed,
+        String prCreationUrl,
+        String targetBranch) {
+
+    public GitSyncResult(boolean success, String message, boolean hasConflicts, List<String> conflictFiles,
+            boolean authFailed) {
+        this(success, message, hasConflicts, conflictFiles, authFailed, null, null);
+    }
 }


### PR DESCRIPTION
## Describe your changes

Adds an alternative publish workflow to the Roq Editor where edits land on a content branch and surface a pull request creation link, rather than pushing straight to the current branch. Config-toggled via `editor.sync.mode` (`PR` is the new default, `DIRECT` keeps the previous behavior), with the PR flow implemented in a dedicated `GitPrFlowPublisher`. On main, Publish creates a content branch (`content/update-YYYYMMDD-HHMM` by default, overridable from the Dev UI prompt), commits, pushes with upstream tracking, and extracts the PR creation URL from `PushResult.getMessages()` via a regex covering GitHub, GitLab and Bitbucket. 

On a content branch with the remote ref still present it commits or amends (per `sync.prFlow.commitStrategy`, `NEW_COMMITS` or `AMEND`) and pushes. On a content branch whose remote ref was pruned (PR merged or closed) it stashes uncommitted edits, returns to main, pulls, pops the stash and starts a fresh cycle. The fetch-with-prune step at the start of every content-branch publish is what makes the "PR merged" detection race-free.

35 unit tests pass (7 new for the PR flow). End-to-end was driven on a fork through the five scenarios from the issue (create branch + PR link, second commit with `NEW_COMMITS`, `AMEND`, simulated PR merge with conflict surfacing, `DIRECT` regression).

---

- Closes #915
- Follow-up to #768
