### PR TITLE
Enhance Liquid-to-Qute converter for full Jekyll migration

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
@@ -1,7 +1,11 @@
 package io.quarkus.tools;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -35,10 +39,21 @@ public class LiquidToQuteConverter {
         content = convertComments(content);
         content = convertVariables(content);
         content = convertFilters(content);
-        content = convertConditionals(content);
         content = convertLoops(content);
+        content = convertConditionals(content);
+        content = convertPaginator(content);
         content = convertIncludes(content);
+        content = convertIncludeParamAccess(content);
+
+        // Convert if/else blocks with assigns to ternary expressions (must run before convertAssignments)
+        content = convertIfElseAssignsToTernary(content);
+
         content = convertAssignments(content);
+
+        // Collapse "init empty list + push in loop + iterate" into str:splitTrimmed
+        // Must run after convertAssignments (which creates {#let}) and convertLoops
+        content = collapsePushInLoopPattern(content);
+
         content = convertCaseStatements(content);
         content = convertLayoutTags(content);
         content = convertSpecialTags(content);
@@ -49,6 +64,34 @@ public class LiquidToQuteConverter {
         // Remove spaces first so ternary wrapping can match properly
         content = removeSpacesBeforeMethods(content);
         content = wrapTernaryBeforeMethods(content);
+
+        // Convert site.data.X references to cdi:X (Roq data file access)
+        content = convertSiteDataReferences(content);
+
+        // Convert site properties that come from data/site.yml to CDI references
+        content = convertSiteDataProperties(content);
+
+        // Convert custom page frontmatter fields to page.data.*
+        content = convertCustomPageFields(content);
+
+        // Make page.data.* references lenient — custom frontmatter may not exist on every page
+        content = makePageDataLenient(content);
+
+        // Convert URL concatenation to RoqUrl methods
+        content = convertUrlConcatenation(content);
+
+        // Convert page.url equality comparisons to use .path (RoqUrl is not a String)
+        content = convertPageUrlComparisons(content);
+
+        // Convert Jekyll site.posts to Roq collections access
+        content = convertSiteCollections(content);
+
+        // Make site.tags lenient (not available in Roq by default)
+        content = makeSiteTagsLenient(content);
+
+        // Append .raw to output expressions containing .replace() calls.
+        // Jekyll never escapes output, but Qute auto-escapes in HTML templates.
+        content = appendRawToReplaceOutputs(content);
 
         // Restore raw blocks with Qute verbatim delimiters
         content = restoreRawBlocks(content, rawBlocks);
@@ -119,8 +162,9 @@ public class LiquidToQuteConverter {
         while (matcher.find()) {
             String var = matcher.group(1).trim();
 
-            // Convert post.* to page.* (Roq uses page for all content)
-            var = var.replaceAll("\\bpost\\.", "page.");
+            // Note: post.* is NOT converted to page.* here because post may be a loop variable
+            // (e.g., {#for post in site.collections.get('posts')}). In Roq, iterated items
+            // are page-like objects so post.title, post.url etc. work directly.
 
             matcher.appendReplacement(sb, Matcher.quoteReplacement(exprOpen) + Matcher.quoteReplacement(var) + "}");
         }
@@ -151,14 +195,30 @@ public class LiquidToQuteConverter {
     }
 
     private String convertFiltersInBlock(String block) {
-        block = convertConcatenationFilters(block);
+        // Convert method-call filters first so concatenation filters see clean expressions
+        block = convertTwoArgFilters(block);
         block = convertTableDrivenFilters(block);
         block = convertDateFilter(block);
+        block = stripDefaultBeforeSplit(block);
         block = convertDefaultFilter(block);
-        block = convertTwoArgFilters(block);
         block = convertPushFilter(block);
         block = convertSplitFilter(block);
+        block = convertUrlFilters(block);
+        // Concatenation filters (append/prepend) run last since they need
+        // the base expression fully converted to method calls
+        block = convertConcatenationFilters(block);
         return block;
+    }
+
+    private String convertUrlFilters(String content) {
+        // Jekyll's | relative_url prepends site.baseurl to a path.
+        // Rewrite as | prepend: so the concatenation filter handles the expression walk.
+        content = content.replaceAll("\\|\\s*relative_url", "| prepend: cdi:siteConfig.baseurl");
+        // TODO: absolute_url should prepend site.url + site.baseurl, but chaining two prepends
+        // interacts badly with convertUrlConcatenation's site.url.resolve() transform.
+        // For now, treat same as relative_url (sufficient when site.url is not needed).
+        content = content.replaceAll("\\|\\s*absolute_url", "| prepend: cdi:siteConfig.baseurl");
+        return content;
     }
 
     private String convertConcatenationFilters(String content) {
@@ -197,22 +257,68 @@ public class LiquidToQuteConverter {
             content = result;
         }
 
-        // Prepend filter: path | prepend: base -> base + path
-        Pattern prependPattern = Pattern.compile("([a-zA-Z0-9_.\"']+)\\s*\\|\\s*prepend:\\s*([^|}%]+)");
-        Matcher prependMatcher = prependPattern.matcher(content);
-        StringBuilder prependSb = new StringBuilder();
+        // Prepend filter: expr | prepend: value -> value + expr
+        // Uses paren-aware backward walk to handle method calls like .replaceAll(...)
+        content = convertPrependFilter(content);
 
-        while (prependMatcher.find()) {
-            String base = prependMatcher.group(1).trim();
-            String prefix = prependMatcher.group(2).trim();
-            prependMatcher.appendReplacement(prependSb, Matcher.quoteReplacement(prefix + " + " + base));
-        }
-        prependMatcher.appendTail(prependSb);
+        return content;
+    }
 
-        result = prependSb.toString();
-        if (!result.equals(content)) {
+    private String convertPrependFilter(String content) {
+        Pattern prependPipe = Pattern.compile("\\|\\s*prepend:\\s*([^|}%]+)");
+
+        while (true) {
+            Matcher m = prependPipe.matcher(content);
+            if (!m.find())
+                break;
+
+            String value = m.group(1).trim();
+            int pipeStart = m.start();
+
+            int baseEnd = pipeStart;
+            while (baseEnd > 0 && Character.isWhitespace(content.charAt(baseEnd - 1)))
+                baseEnd--;
+
+            int baseStart = baseEnd;
+            int parenDepth = 0;
+            while (baseStart > 0) {
+                char c = content.charAt(baseStart - 1);
+                if (c == ')') {
+                    parenDepth++;
+                    baseStart--;
+                } else if (c == '(') {
+                    if (parenDepth > 0) {
+                        parenDepth--;
+                        baseStart--;
+                    } else {
+                        break;
+                    }
+                } else if (parenDepth > 0) {
+                    baseStart--;
+                } else if (c == '\'' || c == '"') {
+                    // Walk backward through the entire string literal
+                    char quote = c;
+                    baseStart--;
+                    while (baseStart > 0 && content.charAt(baseStart - 1) != quote) {
+                        baseStart--;
+                    }
+                    if (baseStart > 0) {
+                        baseStart--; // include the opening quote
+                    }
+                } else if (Character.isLetterOrDigit(c) || c == '.' || c == '_') {
+                    baseStart--;
+                } else {
+                    break;
+                }
+            }
+
+            if (baseStart >= baseEnd) {
+                break;
+            }
+
+            String base = content.substring(baseStart, baseEnd);
+            content = content.substring(0, baseStart) + value + " + " + base + content.substring(m.end());
             conversionsApplied.add("Converted prepend filter to string concatenation");
-            content = result;
         }
 
         return content;
@@ -240,7 +346,7 @@ public class LiquidToQuteConverter {
         for (String[] mapping : filterWithArgMap) {
             String liquidFilter = mapping[0];
             String quteMethod = mapping[1];
-            Pattern fwaPattern = Pattern.compile("\\|\\s*" + liquidFilter + ":\\s*([^|}%]+)");
+            Pattern fwaPattern = Pattern.compile("\\s*\\|\\s*" + liquidFilter + ":\\s*([^|}%]+)");
             Matcher fwaMatcher = fwaPattern.matcher(content);
             StringBuilder fwaSb = new StringBuilder();
 
@@ -283,7 +389,7 @@ public class LiquidToQuteConverter {
         for (String[] mapping : filterMap) {
             String liquidFilter = mapping[0];
             String quteFilter = mapping[1];
-            Pattern pattern = Pattern.compile("\\|\\s*" + liquidFilter + "\\b");
+            Pattern pattern = Pattern.compile("\\s*\\|\\s*" + liquidFilter + "\\b");
             String replacement = "." + quteFilter;
             String newContent = pattern.matcher(content).replaceAll(replacement);
             if (!newContent.equals(content)) {
@@ -296,7 +402,7 @@ public class LiquidToQuteConverter {
     }
 
     private String convertDateFilter(String content) {
-        Pattern datePattern = Pattern.compile("\\|\\s*date:\\s*[\"']([^\"']+)[\"']");
+        Pattern datePattern = Pattern.compile("\\s*\\|\\s*date:\\s*[\"']([^\"']+)[\"']");
         Matcher dateMatcher = datePattern.matcher(content);
         StringBuilder sb = new StringBuilder();
 
@@ -346,7 +452,7 @@ public class LiquidToQuteConverter {
     }
 
     private String convertDefaultFilter(String content) {
-        Pattern defaultPattern = Pattern.compile("\\|\\s*default:\\s*([\"'][^\"']*[\"']|\\S+)");
+        Pattern defaultPattern = Pattern.compile("\\s*\\|\\s*default:\\s*([\"'][^\"']*[\"']|\\S+)");
         Matcher defaultMatcher = defaultPattern.matcher(content);
         StringBuilder sb = new StringBuilder();
 
@@ -367,9 +473,23 @@ public class LiquidToQuteConverter {
         return content;
     }
 
+    private String stripDefaultBeforeSplit(String content) {
+        // When | default: X | split: Y appear in sequence, drop the default filter.
+        // The split is converted to a namespace call str:split() which handles null,
+        // so the default is redundant. More importantly, keeping it produces
+        // (expr ?: X).split(Y) which Qute's {#let} parser silently drops the .split() call.
+        String result = content.replaceAll(
+                "\\s*\\|\\s*default:\\s*(?:[\"'][^\"']*[\"']|\\S+)(\\s*\\|\\s*split:)",
+                "$1");
+        if (!result.equals(content)) {
+            conversionsApplied.add("Stripped default filter before split (namespace split handles null)");
+        }
+        return result;
+    }
+
     private String convertTwoArgFilters(String content) {
         // Truncatewords: | truncatewords: 50 -> .wordLimit(50)
-        Pattern truncatePattern = Pattern.compile("\\|\\s*truncatewords:\\s*(\\d+)");
+        Pattern truncatePattern = Pattern.compile("\\s*\\|\\s*truncatewords:\\s*(\\d+)");
         String result = truncatePattern.matcher(content).replaceAll(".wordLimit($1)");
         if (!result.equals(content)) {
             conversionsApplied.add("Converted truncate filter");
@@ -377,15 +497,29 @@ public class LiquidToQuteConverter {
         }
 
         // Replace_regex (must be before replace to avoid partial match)
-        Pattern replaceRegexPattern = Pattern.compile("\\|\\s*replace_regex:\\s*(['\"][^'\"]*['\"])\\s*,\\s*(['\"][^'\"]*['\"])");
-        result = replaceRegexPattern.matcher(content).replaceAll(".replaceAll($1, $2)");
-        if (!result.equals(content)) {
+        // Also convert Ruby backreferences (\1, \2) to Java ($1, $2)
+        // \\s* before \\| consumes whitespace so .replaceAll attaches directly to the expression
+        Pattern replaceRegexPattern = Pattern.compile("\\s*\\|\\s*replace_regex:\\s*(['\"][^'\"]*['\"])\\s*,\\s*(['\"][^'\"]*['\"])");
+        Matcher replaceRegexMatcher = replaceRegexPattern.matcher(content);
+        StringBuilder replaceRegexSb = new StringBuilder();
+        boolean replaceRegexChanged = false;
+        while (replaceRegexMatcher.find()) {
+            String pattern_arg = replaceRegexMatcher.group(1);
+            String replacement_arg = replaceRegexMatcher.group(2);
+            // Convert \1, \2, etc. to $1, $2 in the replacement string
+            replacement_arg = replacement_arg.replaceAll("\\\\(\\d)", "\\$$1");
+            replaceRegexMatcher.appendReplacement(replaceRegexSb,
+                    Matcher.quoteReplacement(".replaceAll(" + pattern_arg + ", " + replacement_arg + ")"));
+            replaceRegexChanged = true;
+        }
+        replaceRegexMatcher.appendTail(replaceRegexSb);
+        if (replaceRegexChanged) {
             conversionsApplied.add("Converted replace_regex filter");
-            content = result;
+            content = replaceRegexSb.toString();
         }
 
-        // Replace
-        Pattern replacePattern = Pattern.compile("\\|\\s*replace:\\s*(['\"][^'\"]*['\"])\\s*,\\s*(['\"][^'\"]*['\"])");
+        // Replace (second arg can be quoted string or variable reference)
+        Pattern replacePattern = Pattern.compile("\\s*\\|\\s*replace:\\s*(['\"][^'\"]*['\"])\\s*,\\s*(['\"][^'\"]*['\"]|\\w+)");
         result = replacePattern.matcher(content).replaceAll(".replace($1, $2)");
         if (!result.equals(content)) {
             conversionsApplied.add("Converted replace filter");
@@ -393,7 +527,7 @@ public class LiquidToQuteConverter {
         }
 
         // Where: | where: "key", "value" -> .where("key", "value")
-        Pattern wherePattern = Pattern.compile("\\|\\s*where:\\s*(['\"][^'\"]*['\"])\\s*,\\s*(['\"][^'\"]*['\"])");
+        Pattern wherePattern = Pattern.compile("\\s*\\|\\s*where:\\s*(['\"][^'\"]*['\"])\\s*,\\s*(['\"][^'\"]*['\"])");
         result = wherePattern.matcher(content).replaceAll(".where($1, $2)");
         if (!result.equals(content)) {
             conversionsApplied.add("Converted where filter");
@@ -404,7 +538,7 @@ public class LiquidToQuteConverter {
     }
 
     private String convertPushFilter(String content) {
-        Pattern pushPattern = Pattern.compile("\\|\\s*push:\\s*([^}|%]+)");
+        Pattern pushPattern = Pattern.compile("\\s*\\|\\s*push:\\s*([^}|%]+)");
         Matcher pushMatcher = pushPattern.matcher(content);
         StringBuilder pushSb = new StringBuilder();
 
@@ -424,13 +558,24 @@ public class LiquidToQuteConverter {
     }
 
     private String convertSplitFilter(String content) {
-        Pattern splitPattern = Pattern.compile("\\|\\s*split:\\s*(['\"][^'\"]*['\"])");
-        String result = splitPattern.matcher(content).replaceAll(".split($1)");
-        if (!result.equals(content)) {
-            conversionsApplied.add("Converted split filter");
-            content = result;
+        // Use namespace form str:split(base, delim) instead of base.split(delim).
+        // Namespace extensions receive null as a regular parameter, so they handle
+        // null base objects that instance extensions can't dispatch on.
+        Pattern splitPattern = Pattern.compile("([a-zA-Z0-9_\\.\"'\\[\\]()]+)\\s*\\|\\s*split:\\s*(['\"][^'\"]*['\"])");
+        Matcher m = splitPattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+        boolean found = false;
+        while (m.find()) {
+            String base = m.group(1);
+            String delim = m.group(2);
+            m.appendReplacement(sb, Matcher.quoteReplacement("str:split(" + base + ", " + delim + ")"));
+            found = true;
         }
-
+        m.appendTail(sb);
+        if (found) {
+            conversionsApplied.add("Converted split filter");
+            return sb.toString();
+        }
         return content;
     }
 
@@ -443,8 +588,8 @@ public class LiquidToQuteConverter {
         content = content.replaceAll("\\{%\\s*else\\s*%\\}", "{#else}");
         content = content.replaceAll("\\{%\\s*endif\\s*%\\}", "{/if}");
 
-        // unless (negative if)
-        content = content.replaceAll("\\{%\\s*unless\\s+([^%]+?)\\s*%\\}", "{#if !($1)}");
+        // unless (negative if) — apply De Morgan's law to avoid !(...)
+        content = convertUnless(content);
         content = content.replaceAll("\\{%\\s*endunless\\s*%\\}", "{/if}");
 
         // Convert operators ONLY inside conditional blocks to avoid corrupting prose text
@@ -470,6 +615,67 @@ public class LiquidToQuteConverter {
         return content;
     }
 
+    private String convertUnless(String content) {
+        Pattern p = Pattern.compile("\\{%\\s*unless\\s+([^%]+?)\\s*%\\}");
+        Matcher m = p.matcher(content);
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            String cond = m.group(1).trim();
+            String negated = negateLiquidCondition(cond);
+            m.appendReplacement(sb, Matcher.quoteReplacement("{#if " + negated + "}"));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    private String negateLiquidCondition(String condition) {
+        // Split on " or " (Liquid's OR) and negate each part, joining with " and "
+        // De Morgan: !(A or B or C) => !A and !B and !C
+        String[] orParts = condition.split("\\s+or\\s+");
+        if (orParts.length > 1) {
+            StringBuilder result = new StringBuilder();
+            for (int i = 0; i < orParts.length; i++) {
+                if (i > 0) result.append(" and ");
+                result.append(negateSingleCondition(orParts[i].trim()));
+            }
+            return result.toString();
+        }
+        // Split on " and " and negate each part, joining with " or "
+        // De Morgan: !(A and B) => !A or !B
+        String[] andParts = condition.split("\\s+and\\s+");
+        if (andParts.length > 1) {
+            StringBuilder result = new StringBuilder();
+            for (int i = 0; i < andParts.length; i++) {
+                if (i > 0) result.append(" or ");
+                result.append(negateSingleCondition(andParts[i].trim()));
+            }
+            return result.toString();
+        }
+        return negateSingleCondition(condition.trim());
+    }
+
+    private String negateSingleCondition(String cond) {
+        // If already negated, remove the negation (double negative)
+        if (cond.startsWith("!")) {
+            return cond.substring(1);
+        }
+        // If it contains a comparison operator, flip it
+        if (cond.contains(" != ")) {
+            return cond.replace(" != ", " == ");
+        }
+        if (cond.contains("!=")) {
+            return cond.replace("!=", " == ");
+        }
+        if (cond.contains(" == ")) {
+            return cond.replace(" == ", " != ");
+        }
+        if (cond.contains("==")) {
+            return cond.replace("==", " != ");
+        }
+        // Simple variable — prefix with !
+        return "!" + cond;
+    }
+
     private String replaceOperatorsOutsideStrings(String condition) {
         StringBuilder result = new StringBuilder();
         boolean inSingleQuote = false;
@@ -492,6 +698,44 @@ public class LiquidToQuteConverter {
                 } else if (matchesWord(condition, i, "or")) {
                     result.append("||");
                     i += 2;
+                } else if (i + 1 < condition.length()
+                        && (condition.substring(i, i + 2).equals("!=")
+                            || condition.substring(i, i + 2).equals("=="))) {
+                    // Qute uses 'ne' for !=, '==' stays as-is but needs spaces
+                    String op = condition.substring(i, i + 2);
+                    String quteOp = op.equals("!=") ? "ne" : op;
+                    String before = result.toString();
+                    if (!before.isEmpty() && before.charAt(before.length() - 1) != ' ') {
+                        result.append(' ');
+                    }
+                    result.append(quteOp);
+                    i += 2;
+                    if (i < condition.length() && condition.charAt(i) != ' ') {
+                        result.append(' ');
+                    }
+                } else if (matchesWord(condition, i, "contains")) {
+                    // Convert operator to method call: X contains 'Y' → X.contains('Y')
+                    // Walk backwards to find the base expression
+                    String before = result.toString().stripTrailing();
+                    result.setLength(0);
+                    result.append(before);
+                    result.append(".contains(");
+                    i += "contains".length();
+                    // Skip whitespace after "contains"
+                    while (i < condition.length() && condition.charAt(i) == ' ') i++;
+                    // Find the argument (quoted string or expression)
+                    int argStart = i;
+                    if (i < condition.length() && (condition.charAt(i) == '\'' || condition.charAt(i) == '"')) {
+                        char quote = condition.charAt(i);
+                        i++;
+                        while (i < condition.length() && condition.charAt(i) != quote) i++;
+                        if (i < condition.length()) i++; // consume closing quote
+                    } else {
+                        while (i < condition.length() && condition.charAt(i) != ' '
+                                && condition.charAt(i) != ')') i++;
+                    }
+                    result.append(condition, argStart, i);
+                    result.append(")");
                 } else {
                     result.append(condition.charAt(i));
                     i++;
@@ -526,12 +770,42 @@ public class LiquidToQuteConverter {
         return true;
     }
 
+    private String convertPaginator(String content) {
+        String original = content;
+
+        // Jekyll's paginator.posts -> Roq's collection access
+        content = content.replaceAll("\\bpaginator\\.posts\\b",
+                "site.collections.get('posts').paginated(page.paginator)");
+
+        // Jekyll field names -> Roq Paginator field names
+        content = content.replaceAll("\\bpaginator\\.total_pages\\b", "page.paginator.total");
+        content = content.replaceAll("\\bpaginator\\.next_page_path\\b", "page.paginator.next");
+        content = content.replaceAll("\\bpaginator\\.previous_page_path\\b", "page.paginator.previous");
+        content = content.replaceAll("\\bpaginator\\.next_page\\b", "page.paginator.next");
+        content = content.replaceAll("\\bpaginator\\.previous_page\\b", "page.paginator.previous");
+
+        // Any remaining paginator.X -> page.paginator.X
+        content = content.replaceAll("(?<!page\\.)\\bpaginator\\.", "page.paginator.");
+
+        // Guard conditionals: page.paginator is null on non-paginated pages
+        Pattern pattern = Pattern.compile("(\\{#(?:if|else if) )(?!page\\.paginator &&)(page\\.paginator\\.[^}]+\\})");
+        content = pattern.matcher(content).replaceAll("$1page.paginator && $2");
+
+        if (!content.equals(original)) {
+            conversionsApplied.add("Converted Jekyll paginator to Roq pagination");
+        }
+        return content;
+    }
+
     private String convertLoops(String content) {
         String original = content;
 
         // Basic for loop
         content = content.replaceAll("\\{%\\s*for\\s+(\\w+)\\s+in\\s+([^%]+?)\\s*%\\}", "{#for $1 in $2}");
         content = content.replaceAll("\\{%\\s*endfor\\s*%\\}", "{/for}");
+
+        // Append .orEmpty to property-access iterables (e.g., post.tags) that might be null
+        content = appendOrEmptyToForLoops(content);
 
         // Loop variables: replace forloop.* with Qute metadata derived from the actual loop variable name.
         // We find each {#for VAR in ...} and replace forloop.* references with VAR_* in the loop body.
@@ -553,6 +827,28 @@ public class LiquidToQuteConverter {
             conversionsApplied.add("Converted loops");
         }
         return content;
+    }
+
+    private String appendOrEmptyToForLoops(String content) {
+        // Iterables in for loops might be null/not-found at runtime (e.g. post.tags,
+        // or {#let}-bound variables whose expression failed to resolve).
+        // Append .orEmpty so Qute returns an empty list instead of throwing.
+        // Skip cdi: references (always defined) and already-safe expressions.
+        Pattern p = Pattern.compile("(\\{#for\\s+\\w+\\s+in\\s+)([^\\s}]+)(\\s[^}]*\\}|\\})");
+        Matcher m = p.matcher(content);
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            String prefix = m.group(1);
+            String iterable = m.group(2).trim();
+            String suffix = m.group(3);
+            if (!iterable.startsWith("cdi:") && !iterable.endsWith(".orEmpty")) {
+                m.appendReplacement(sb, Matcher.quoteReplacement(prefix + iterable + ".orEmpty" + suffix));
+            } else {
+                m.appendReplacement(sb, Matcher.quoteReplacement(m.group(0)));
+            }
+        }
+        m.appendTail(sb);
+        return sb.toString();
     }
 
     private String replaceLoopVariables(String content) {
@@ -632,11 +928,15 @@ public class LiquidToQuteConverter {
             String file = includeMatcher.group(1);
             String params = includeMatcher.group(2).trim();
 
+            // Roq resolves includes from templates/ directory;
+            // partials go under templates/partials/
+            String path = file.startsWith("partials/") ? file : "partials/" + file;
+
             String replacement;
             if (!params.isEmpty()) {
-                replacement = "{#include " + file + " " + params + " /}";
+                replacement = "{#include " + path + " " + params + " /}";
             } else {
-                replacement = "{#include " + file + " /}";
+                replacement = "{#include " + path + " /}";
             }
 
             includeMatcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
@@ -651,11 +951,167 @@ public class LiquidToQuteConverter {
         return result;
     }
 
+    private String convertIncludeParamAccess(String content) {
+        String result = content.replaceAll("\\binclude\\.", "");
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted include.param references to direct param access");
+        }
+        return result;
+    }
+
+    private String convertIfElseAssignsToTernary(String content) {
+        // Detect if/else blocks where the same variable is assigned in both branches.
+        // Replace both assigns with a single ternary assign BEFORE the if block.
+        // The result is still a {% assign %} tag, so convertAssignments handles scoping.
+
+        Pattern ifElsePattern = Pattern.compile(
+                "\\{#if\\s+([^}]+?)\\}(.*?)\\{#else\\}(.*?)\\{/if\\}",
+                Pattern.DOTALL);
+
+        Matcher matcher = ifElsePattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+        boolean changed = false;
+
+        while (matcher.find()) {
+            String condition = matcher.group(1);
+            String ifBranch = matcher.group(2);
+            String elseBranch = matcher.group(3);
+
+            Pattern assignPattern = Pattern.compile("\\{%\\s*assign\\s+(\\w+)\\s*=\\s*([^%]+?)\\s*%\\}");
+            Matcher ifAssigns = assignPattern.matcher(ifBranch);
+            Matcher elseAssigns = assignPattern.matcher(elseBranch);
+
+            Map<String, String> ifVars = new HashMap<>();
+            Map<String, String> elseVars = new HashMap<>();
+
+            while (ifAssigns.find()) {
+                ifVars.put(ifAssigns.group(1), ifAssigns.group(2));
+            }
+            while (elseAssigns.find()) {
+                elseVars.put(elseAssigns.group(1), elseAssigns.group(2));
+            }
+
+            Set<String> commonVars = new HashSet<>(ifVars.keySet());
+            commonVars.retainAll(elseVars.keySet());
+
+            if (!commonVars.isEmpty()) {
+                StringBuilder ternaryAssigns = new StringBuilder();
+                String modifiedIfBranch = ifBranch;
+                String modifiedElseBranch = elseBranch;
+
+                for (String var : commonVars) {
+                    String ifExpr = ifVars.get(var);
+                    String elseExpr = elseVars.get(var);
+
+                    // Qute doesn't support ternary (? :), so use alternative constructs.
+                    // 'contains' is only valid as an operator in {#if} sections —
+                    // convert to method call for use in {#let} expressions.
+                    String exprCondition = condition.replaceAll(
+                            "(\\S+)\\s+contains\\s+('[^']*'|\"[^\"]*\")",
+                            "$1.contains($2)");
+
+                    String combinedExpr;
+                    if (condition.trim().equals(ifExpr.trim())) {
+                        // condition ? condition : fallback  →  condition ?: fallback
+                        combinedExpr = ifExpr + " ?: " + elseExpr;
+                    } else {
+                        // General case: find trailing content that uses this variable
+                        // and duplicate it into each branch so {#let} scope covers it
+                        int afterIfElse = matcher.end();
+                        String trailing = content.substring(afterIfElse);
+                        int useEnd = findTrailingUsageEnd(trailing, var);
+                        if (useEnd > 0) {
+                            String trailingContent = trailing.substring(0, useEnd);
+                            String ifAssign = "{% assign " + var + " = " + ifExpr + " %}";
+                            String elseAssign = "{% assign " + var + " = " + elseExpr + " %}";
+                            String before = content.substring(0, matcher.start());
+                            String after = trailing.substring(useEnd);
+                            String result = before
+                                    + "{#if " + condition + "}"
+                                    + ifAssign + trailingContent
+                                    + "{#else}"
+                                    + elseAssign + trailingContent
+                                    + "{/if}" + after;
+                            conversionsApplied.add("Inlined trailing content into if/else branches for variable scope");
+                            return result;
+                        }
+                        continue;
+                    }
+
+                    ternaryAssigns.append("{% assign ").append(var).append(" = ")
+                            .append(combinedExpr).append(" %}\n");
+
+                    modifiedIfBranch = modifiedIfBranch.replaceFirst(
+                            "\\{%\\s*assign\\s+" + var + "\\s*=\\s*" + Pattern.quote(ifExpr) + "\\s*%\\}",
+                            "");
+                    modifiedElseBranch = modifiedElseBranch.replaceFirst(
+                            "\\{%\\s*assign\\s+" + var + "\\s*=\\s*" + Pattern.quote(elseExpr) + "\\s*%\\}",
+                            "");
+                }
+
+                if (ternaryAssigns.length() == 0) {
+                    // No variables could be converted, leave unchanged
+                    matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group(0)));
+                    continue;
+                }
+
+                // Check if the if/else block is now empty (only whitespace)
+                boolean ifEmpty = modifiedIfBranch.trim().isEmpty();
+                boolean elseEmpty = modifiedElseBranch.trim().isEmpty();
+
+                String replacement;
+                if (ifEmpty && elseEmpty) {
+                    // Both branches are empty after removing assigns — drop the if/else entirely
+                    replacement = ternaryAssigns.toString();
+                } else {
+                    replacement = ternaryAssigns.toString()
+                            + "{#if " + condition + "}"
+                            + modifiedIfBranch
+                            + "{#else}"
+                            + modifiedElseBranch
+                            + "{/if}";
+                }
+
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+                changed = true;
+            } else {
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group(0)));
+            }
+        }
+        matcher.appendTail(sb);
+
+        if (changed) {
+            conversionsApplied.add("Converted if/else assigns to ternary expressions");
+            return sb.toString();
+        }
+
+        return content;
+    }
+
+    private int findTrailingUsageEnd(String trailing, String varName) {
+        // Find the end of the first line that uses the variable.
+        // Only inline a small amount of trailing content to avoid duplicating
+        // large template blocks.
+        Pattern usePattern = Pattern.compile("\\b" + Pattern.quote(varName) + "\\b");
+        Matcher useMatcher = usePattern.matcher(trailing);
+        if (!useMatcher.find()) {
+            return 0;
+        }
+        // Only inline if the first usage is within the first few lines
+        int firstUse = useMatcher.start();
+        long newlinesBefore = trailing.substring(0, firstUse).chars().filter(c -> c == '\n').count();
+        if (newlinesBefore > 3) {
+            return 0;
+        }
+        // Extend to the end of the line containing the last usage on consecutive lines
+        int lineEnd = trailing.indexOf('\n', useMatcher.end());
+        return lineEnd >= 0 ? lineEnd + 1 : trailing.length();
+    }
+
     private String convertAssignments(String content) {
         String original = content;
 
-        // Convert post.* to page.* inside assign tags before converting the tags themselves
-        content = content.replaceAll("(\\{%\\s*assign\\s+\\w+\\s*=\\s*[^%]*?)\\bpost\\.", "$1page.");
+        // Note: post.* is NOT converted to page.* — post may be a loop variable
 
         // Place {/let} at the enclosing scope boundary for each assign
         Pattern assignPattern = Pattern.compile("\\{%\\s*assign\\s+(\\w+)\\s*=\\s*([^%]+?)\\s*%\\}");
@@ -695,7 +1151,85 @@ public class LiquidToQuteConverter {
         return content;
     }
 
+    private String collapsePushInLoopPattern(String content) {
+        // Detect the Liquid idiom: init empty list, push in loop, iterate after.
+        // Qute's block-scoped {#let} makes push-in-loop silently discard results.
+        // Collapse into a single str:splitTrimmed() call.
+        //
+        // Input pattern (after convertAssignments/convertLoops):
+        //   {#let RAW=str:split(EXPR)}
+        //   {#let CLEAN=str:split("", "")}
+        //   {#for V in RAW.orEmpty}...CLEAN.push...{/for}
+        //   {#for ITER in CLEAN.orEmpty}...{/for}
+        //   {/let}{/let}  (closing RAW and CLEAN)
+        String original = content;
+
+        while (true) {
+            // Find the init pattern: {#let X=str:split(EXPR)}\n{#let Y=str:split("", "")}
+            Pattern initPattern = Pattern.compile(
+                    "\\{#let (\\w+)=str:split\\(([^)]+)\\)\\}\\s*" +
+                    "\\{#let (\\w+)=str:split\\(\"\", \"\"\\)\\}");
+            Matcher m = initPattern.matcher(content);
+            if (!m.find()) break;
+
+            String rawVar = m.group(1);
+            String splitExpr = m.group(2);
+            String cleanVar = m.group(3);
+            int initStart = m.start();
+            int afterInit = m.end();
+
+            // Find the push loop: {#for ... in RAW.orEmpty}...CLEAN.push...{/for}
+            String afterInitContent = content.substring(afterInit);
+            Pattern pushLoopPattern = Pattern.compile(
+                    "\\s*\\{#for \\w+ in " + Pattern.quote(rawVar) + "\\.orEmpty\\}");
+            Matcher pushLoopMatcher = pushLoopPattern.matcher(afterInitContent);
+            if (!pushLoopMatcher.find() || pushLoopMatcher.start() != 0) break;
+
+            int pushLoopBodyStart = afterInit + pushLoopMatcher.end();
+            int pushLoopEnd = findMatchingEndFor(content, pushLoopBodyStart);
+            String pushLoopBody = content.substring(pushLoopBodyStart, pushLoopEnd);
+            if (!pushLoopBody.contains(cleanVar + ".push(")) break;
+
+            int afterPushLoop = pushLoopEnd + "{/for}".length();
+
+            // Find the iteration loop: {#for ITER in CLEAN.orEmpty}
+            // May have HTML content between the push loop and the iteration loop
+            String afterPushContent = content.substring(afterPushLoop);
+            Pattern iterPattern = Pattern.compile(
+                    "\\{#for (\\w+) in " + Pattern.quote(cleanVar) + "\\.orEmpty\\}");
+            Matcher iterMatcher = iterPattern.matcher(afterPushContent);
+            if (!iterMatcher.find()) break;
+
+            String iterVar = iterMatcher.group(1);
+            String contentBetween = afterPushContent.substring(0, iterMatcher.start()).stripLeading();
+            int iterBodyStart = afterPushLoop + iterMatcher.end();
+            int iterForEnd = findMatchingEndFor(content, iterBodyStart);
+            String iterBody = content.substring(iterBodyStart, iterForEnd);
+
+            // Build replacement: preserve HTML between push loop and iteration loop,
+            // then a single for loop with str:splitTrimmed
+            String replacement = contentBetween +
+                    "{#for " + iterVar + " in str:splitTrimmed(" + splitExpr + ").orEmpty}" +
+                    iterBody + "{/for}";
+
+            // Remove the trailing {/let}{/let} that closed rawVar and cleanVar
+            String afterFor = content.substring(iterForEnd + "{/for}".length());
+            afterFor = afterFor.replaceFirst("\\{/let\\}\\{/let\\}", "");
+
+            content = content.substring(0, initStart) + replacement + afterFor;
+        }
+
+        if (!content.equals(original)) {
+            conversionsApplied.add("Collapsed push-in-loop pattern to str:splitTrimmed");
+        }
+        return content;
+    }
+
     private int findScopeBoundary(String content, int startPos) {
+        // Place {/let} BEFORE the next enclosing block's closing tag at depth 0.
+        // This ensures valid nesting: the let closes before its enclosing block closes.
+        // {#else} is also a boundary — assigns in if-branches scope to before the else.
+        // (If/else assigns for the same variable are handled separately by convertIfElseAssignsToTernary.)
         int depth = 0;
         Pattern tagPattern = Pattern.compile("\\{#(for|if|let)\\b|\\{#else\\b|\\{/(for|if|let)\\}");
         Matcher matcher = tagPattern.matcher(content);
@@ -773,6 +1307,9 @@ public class LiquidToQuteConverter {
         // {% prepend name %} -> {#prepend name}
         content = content.replaceAll("\\{%\\s*prepend\\s+(\\w+)\\s*%\\}", "{#prepend $1}");
         content = content.replaceAll("\\{%\\s*endprepend\\s*%\\}", "{/prepend}");
+
+        // Jekyll's {{ content }} in layouts renders child content; Qute uses {#insert /}
+        content = content.replaceAll("\\{=content\\}", "{#insert /}");
 
         if (!content.equals(original)) {
             conversionsApplied.add("Converted layout tags");
@@ -892,5 +1429,212 @@ public class LiquidToQuteConverter {
         }
 
         return sb.toString();
+    }
+
+    private String convertSiteDataReferences(String content) {
+        String original = content;
+        Pattern p = Pattern.compile("\\bsite\\.data\\.(\\w+)");
+        Matcher m = p.matcher(content);
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            String name = m.group(1);
+            if (name.equals("get")) {
+                m.appendReplacement(sb, Matcher.quoteReplacement(m.group(0)));
+            } else {
+                m.appendReplacement(sb, "cdi:" + name);
+            }
+        }
+        m.appendTail(sb);
+        content = sb.toString();
+        if (!content.equals(original)) {
+            conversionsApplied.add("Converted site.data references to cdi: prefix");
+        }
+        return content;
+    }
+
+    private String convertSiteDataProperties(String content) {
+        // Jekyll site.* properties that aren't part of Roq's Site model come from _config.yml.
+        // These are migrated to data/siteConfig.yml and accessed via cdi:siteConfig.*
+        // Note: Using "siteConfig" instead of "site" to avoid conflict with Roq's built-in Site object
+        String knownSiteProps = "url|title|description|image|imageExists|data|pages|allPages|collections|" +
+                "index|files|file|fileExists|page|normalPage|document|imagesDirUrl|pageContent|" +
+                "posts|tags";
+
+        Pattern pattern = Pattern.compile(
+                "\\bsite\\.((?!(?:" + knownSiteProps + ")\\b)[a-zA-Z_][a-zA-Z0-9_]*)\\b");
+        String result = pattern.matcher(content).replaceAll("cdi:siteConfig.$1");
+
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted site data properties to CDI references");
+        }
+
+        return result;
+    }
+
+    private String convertCustomPageFields(String content) {
+        // Roq's Page model has specific built-in properties. Custom frontmatter must use page.data.*
+        // This applies to 'page' and page-like loop variables like 'post'
+        String knownPageProps = "url|title|description|image|imageExists|date|data|content|contentAbstract|" +
+                "rawTemplate|sourcePath|sourceFileName|baseFileName|id|draft|files|file|fileExists|source|site|" +
+                "collectionId|collection|next|nextPage|previous|prev|previousPage|prevPage|hidden|paginator|" +
+                "tags|tagsCount";
+
+        // Match page.customField or post.customField (not *.data.*, *.url.*, or known properties)
+        // and convert to *.data.customField
+        Pattern pattern = Pattern.compile(
+                "(?<!-)\\b(page|post)\\.((?!(?:" + knownPageProps + ")\\b|data\\.|url\\.)[a-zA-Z_][a-zA-Z0-9_]*)\\b");
+        String result = pattern.matcher(content).replaceAll("$1.data.$2");
+
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted custom page frontmatter fields to page.data.*");
+        }
+
+        return result;
+    }
+
+    private String makePageDataLenient(String content) {
+        // page.data.* and post.data.* access a JsonObject — fields may not exist on every page.
+        // Append ?? to make them lenient (resolve to null instead of throwing).
+        // Skip if already lenient (??) or has a default (?:).
+        Pattern pattern = Pattern.compile("((?<!-)(?:page|post)\\.data\\.[a-zA-Z0-9_.]+)(\\?\\?| \\?:)?");
+        Matcher matcher = pattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+        while (matcher.find()) {
+            if (matcher.group(2) != null) {
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group(0)));
+            } else {
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group(1) + "??"));
+            }
+        }
+        matcher.appendTail(sb);
+        String result = sb.toString();
+        if (!result.equals(content)) {
+            conversionsApplied.add("Made page.data.* references lenient");
+        }
+        return result;
+    }
+
+    private String convertUrlConcatenation(String content) {
+        // RoqUrl doesn't support + operator. Convert url + something to url.resolve(something)
+        // Patterns:
+        // - site.url + page.url -> site.url.resolve(page.url)
+        // - page.url + "/path" -> page.url.resolve("/path")
+
+        // Match: (site.url or page.url) + (something)
+        // We need to handle the full expression inside {=...}
+        Pattern pattern = Pattern.compile(
+                "(\\{=)([^}]*?)((?:site|page)\\.url)\\s*\\+\\s*([^}]+?)(\\})");
+        Matcher matcher = pattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+
+        while (matcher.find()) {
+            String prefix = matcher.group(1);  // {=
+            String before = matcher.group(2);   // anything before site.url
+            String urlExpr = matcher.group(3);  // site.url or page.url
+            String arg = matcher.group(4).trim(); // what's being concatenated
+            String suffix = matcher.group(5);   // }
+
+            String replacement = prefix + before + urlExpr + ".resolve(" + arg + ")" + suffix;
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(sb);
+
+        String result = sb.toString();
+        if (!result.equals(content)) {
+            conversionsApplied.add("Converted URL concatenation to .resolve()");
+        }
+
+        return result;
+    }
+
+    private String convertPageUrlComparisons(String content) {
+        // RoqUrl is an object, not a String. Equality comparisons like page.url == '/'
+        // need to use page.url.path instead so they compare strings.
+        Pattern pattern = Pattern.compile("\\bpage\\.url\\s*(==|!=|\\bne\\b)");
+        Matcher matcher = pattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+        boolean found = false;
+        while (matcher.find()) {
+            matcher.appendReplacement(sb, Matcher.quoteReplacement("page.url.path " + matcher.group(1)));
+            found = true;
+        }
+        matcher.appendTail(sb);
+
+        if (found) {
+            conversionsApplied.add("Converted page.url comparisons to page.url.path (RoqUrl is not a String)");
+            return sb.toString();
+        }
+        return content;
+    }
+
+    private String convertSiteCollections(String content) {
+        String original = content;
+        // Jekyll's site.posts → Roq's site.collections.get('posts')
+        content = content.replaceAll("\\bsite\\.posts\\b", "site.collections.get('posts')");
+        if (!content.equals(original)) {
+            conversionsApplied.add("Converted site.posts to site.collections.get('posts')");
+        }
+        return content;
+    }
+
+    private String appendRawToReplaceOutputs(String content) {
+        // Jekyll never escapes HTML in output tags, but Qute auto-escapes in .html templates.
+        // Append .raw to output expressions containing .replace() so HTML content renders correctly.
+        Pattern pattern = Pattern.compile("(\\{=([^}]*\\.replace(?:All)?\\([^)]*\\)))\\}");
+        Matcher matcher = pattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+        boolean found = false;
+        while (matcher.find()) {
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group(1) + ".raw}"));
+            found = true;
+        }
+        matcher.appendTail(sb);
+
+        if (found) {
+            conversionsApplied.add("Appended .raw to replace() outputs (Jekyll never escapes HTML)");
+            return sb.toString();
+        }
+        return content;
+    }
+
+    private String makeSiteTagsLenient(String content) {
+        // Jekyll's site.tags is auto-generated and doesn't exist in Roq by default.
+        // Replace with cdi:siteConfig.tags which is set to an empty list by the migration script.
+
+        Pattern pattern = Pattern.compile("\\bsite\\.tags\\b");
+        Matcher matcher = pattern.matcher(content);
+
+        if (!matcher.find()) {
+            return content; // No site.tags usage
+        }
+
+        // Split frontmatter from template body
+        String frontmatter = "";
+        String body = content;
+
+        Pattern frontmatterPattern = Pattern.compile("^(---\\s*\\n.*?\\n---\\s*\\n)", Pattern.DOTALL);
+        Matcher fmMatcher = frontmatterPattern.matcher(content);
+        if (fmMatcher.find()) {
+            frontmatter = fmMatcher.group(1);
+            body = content.substring(fmMatcher.end());
+        }
+
+        // Add a warning comment at the start of the body
+        String warning = "\n{! TODO: site.tags not available in Roq by default.\n" +
+                "   The tag listing feature is currently disabled (replaced with cdi:siteConfig.tags=[]).\n" +
+                "   Options to restore functionality:\n" +
+                "   (1) Use collection.tagsCount() for a specific collection,\n" +
+                "   (2) Add a site.tags extension method, or\n" +
+                "   (3) Remove the tag listing feature entirely.\n" +
+                "   See migration implementation notes for details. !}\n";
+
+        // Replace all site.tags with cdi:siteConfig.tags (which is an empty list)
+        body = pattern.matcher(body).replaceAll("cdi:siteConfig.tags");
+
+        String result = frontmatter + warning + body;
+
+        conversionsApplied.add("Replaced site.tags with cdi:siteConfig.tags (needs manual implementation)");
+
+        return result;
     }
 }

--- a/migration/src/main/resources/migration-helpers/JekyllFiltersExtension.java
+++ b/migration/src/main/resources/migration-helpers/JekyllFiltersExtension.java
@@ -1,0 +1,167 @@
+package io.quarkus.tools.migration;
+
+import io.quarkus.qute.RawString;
+import io.quarkus.qute.TemplateExtension;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@TemplateExtension
+public class JekyllFiltersExtension {
+
+    /**
+     * Null-safe get for JsonObject. Prevents NPE when key is null (e.g. from ?? operator).
+     */
+    static Object get(JsonObject obj, String key) {
+        if (obj == null || key == null || key.isEmpty()) {
+            return null;
+        }
+        return obj.getValue(key);
+    }
+
+    /**
+     * Jekyll's "where" filter: select items from an array where a property matches a value.
+     * Usage in Qute: {myArray.where("key", "value")}
+     */
+    static JsonArray where(JsonArray array, String property, String value) {
+        JsonArray result = new JsonArray();
+        for (int i = 0; i < array.size(); i++) {
+            Object item = array.getValue(i);
+            if (item instanceof JsonObject obj) {
+                Object propValue = obj.getValue(property);
+                if (propValue != null && propValue.toString().equals(value)) {
+                    result.add(obj);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Get the first element of a JsonArray.
+     * Usage in Qute: {myArray.first}
+     */
+    static Object first(JsonArray array) {
+        if (array == null || array.isEmpty()) {
+            return null;
+        }
+        return array.getValue(0);
+    }
+
+    /**
+     * Get the last element of a JsonArray.
+     * Usage in Qute: {myArray.last}
+     */
+    static Object last(JsonArray array) {
+        if (array == null || array.isEmpty()) {
+            return null;
+        }
+        return array.getValue(array.size() - 1);
+    }
+
+    /**
+     * Get the size of a JsonArray.
+     * Usage in Qute: {myArray.size}
+     */
+    static int size(JsonArray array) {
+        return array == null ? 0 : array.size();
+    }
+
+    /**
+     * Jekyll's "truncate" filter: truncate a string to a given number of characters.
+     * Usage in Qute: {myString.truncate(280)}
+     */
+    static String truncate(String str, int length) {
+        if (str == null) return "";
+        if (str.length() <= length) return str;
+        return str.substring(0, length) + "...";
+    }
+
+    /**
+     * Jekyll's "sort" filter: sort a list by a named property.
+     * Usage in Qute: {myList.sort('title')}
+     */
+    static List<?> sort(List<?> list, String property) {
+        if (list == null || list.isEmpty()) {
+            return List.of();
+        }
+        List<Object> sorted = new ArrayList<>(list);
+        sorted.sort((a, b) -> {
+            String va = extractProperty(a, property);
+            String vb = extractProperty(b, property);
+            if (va == null) return vb == null ? 0 : 1;
+            if (vb == null) return -1;
+            return va.compareToIgnoreCase(vb);
+        });
+        return sorted;
+    }
+
+    private static String extractProperty(Object obj, String property) {
+        if (obj instanceof JsonObject json) {
+            Object val = json.getValue(property);
+            return val != null ? val.toString() : null;
+        }
+        if (obj instanceof java.util.Map<?, ?> map) {
+            Object val = map.get(property);
+            return val != null ? val.toString() : null;
+        }
+        return obj != null ? obj.toString() : null;
+    }
+
+    /**
+     * Jekyll's "push" filter: append an element to a list and return the new list.
+     * Usage in Qute: {myList.push(item)}
+     */
+    static List<Object> push(List<?> list, Object item) {
+        List<Object> result = new ArrayList<>(list);
+        result.add(item);
+        return result;
+    }
+
+    /**
+     * Output a string without HTML escaping.
+     * Qute auto-escapes HTML in .html templates; this bypasses that for trusted content.
+     * Usage in Qute: {=myString.raw}
+     */
+    static RawString raw(String str) {
+        if (str == null) return new RawString("");
+        return new RawString(str);
+    }
+
+    /**
+     * Split a string by delimiter, returning an iterable list.
+     * Uses namespace form so it can handle null base objects (instance extensions can't
+     * dispatch on null). Also returns List instead of String[] for Qute iteration.
+     * Usage in Qute: {str:split(myString, ",")}
+     */
+    @TemplateExtension(namespace = "str")
+    static List<String> split(String str, String delimiter) {
+        if (str == null || str.isEmpty()) {
+            return List.of();
+        }
+        return Arrays.asList(str.split(delimiter));
+    }
+
+    /**
+     * Split, trim each element, and filter out empty strings.
+     * Replaces the Liquid pattern: assign clean = "" | split: "" / for x in raw / push trimmed / endfor
+     * That pattern doesn't work in Qute because {#let} is block-scoped (push results are discarded).
+     * Usage in Qute: {str:splitTrimmed(myString, ",")}
+     */
+    @TemplateExtension(namespace = "str")
+    static List<String> splitTrimmed(String str, String delimiter) {
+        if (str == null || str.isEmpty()) {
+            return List.of();
+        }
+        List<String> result = new ArrayList<>();
+        for (String s : str.split(delimiter)) {
+            String trimmed = s.trim();
+            if (!trimmed.isEmpty()) {
+                result.add(trimmed);
+            }
+        }
+        return result;
+    }
+}

--- a/migration/src/test/java/io/quarkus/tools/LiquidToQuteCommandTest.java
+++ b/migration/src/test/java/io/quarkus/tools/LiquidToQuteCommandTest.java
@@ -51,7 +51,7 @@ class LiquidToQuteCommandTest {
         assertTrue(Files.exists(outputDir.resolve("post.html")), "post.html should be converted");
 
         String defaultContent = Files.readString(outputDir.resolve("default.html"));
-        assertEquals("<html>{=content}</html>", defaultContent);
+        assertEquals("<html>{#insert /}</html>", defaultContent);
 
         String postContent = Files.readString(outputDir.resolve("post.html"));
         assertEquals("{#if page.title}<h1>{=page.title}</h1>{/if}", postContent);

--- a/migration/src/test/java/io/quarkus/tools/LiquidToQuteConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/LiquidToQuteConverterTest.java
@@ -22,21 +22,21 @@ class LiquidToQuteConverterTest {
     @Test
     void testEmptyStringSplit() {
         String input = "{=\"\" | split: \",\"}";
-        String expected = "{=\"\".split(\",\")}";
-        assertConverts(input, expected, "Empty string split should use split method");
+        String expected = "{=str:split(\"\", \",\")}";
+        assertConverts(input, expected, "Empty string split should use namespace split");
     }
 
     @Test
     void testTernaryWithMethodCall() {
-        String input = "{=post.author ?: \"\".split(\",\")}";
-        String expected = "{=(post.author ?: \"\").split(\",\")}";
+        String input = "{=post.data.author ?: \"\".split(\",\")}";
+        String expected = "{=(post.data.author ?: \"\").split(\",\")}";
         assertConverts(input, expected, "Ternary before method call should be wrapped in parentheses");
     }
 
     @Test
     void testTernaryWithTrim() {
-        String input = "{=page.author ?: \"\".trim()}";
-        String expected = "{=(page.author ?: \"\").trim()}";
+        String input = "{=page.data.author ?: \"\".trim()}";
+        String expected = "{=(page.data.author ?: \"\").trim()}";
         assertConverts(input, expected, "Ternary with trim should be wrapped");
     }
 
@@ -64,20 +64,16 @@ class LiquidToQuteConverterTest {
     @Test
     void testSplitFilter() {
         String input = "{{text | split: \",\"}}";
-        String expected = "{=text.split(\",\")}";
-        assertConverts(input, expected, "Split filter should convert to method call");
+        String expected = "{=str:split(text, \",\")}";
+        assertConverts(input, expected, "Split filter should use namespace form");
     }
 
     @Test
-    void testComplexTernaryWithSplit() {
+    void testDefaultBeforeSplitStripsDefault() {
         String input = "{{post.author | default: \"\" | split: \",\"}}";
-        // After variable conversion: post.author -> page.author
-        // After default filter: page.author ?: ""
-        // After split filter: page.author ?: "".split(",")
-        // After space removal: page.author ?: "".split(",")
-        // After ternary wrapping: (page.author ?: "").split(",")
-        String expected = "{=(page.author ?: \"\").split(\",\")}";
-        assertConverts(input, expected, "Complex ternary with split should be properly wrapped");
+        // default is stripped because namespace split handles null
+        String expected = "{=str:split(post.data.author??, \",\")}";
+        assertConverts(input, expected, "default before split should be stripped; split uses namespace form");
     }
 
     @Test
@@ -88,10 +84,10 @@ class LiquidToQuteConverterTest {
     }
 
     @Test
-    void testPostToPageConversion() {
+    void testPostKeepsPostPrefix() {
         String input = "{{post.title}}";
-        String expected = "{=page.title}";
-        assertConverts(input, expected, "post.* should convert to page.*");
+        String expected = "{=post.title}";
+        assertConverts(input, expected, "post.* should stay as post.* (may be a loop variable)");
     }
 
     @Test
@@ -102,9 +98,57 @@ class LiquidToQuteConverterTest {
     }
 
     @Test
+    void testPaginatorPostsConverted() {
+        String input = "{% for post in paginator.posts %}{{post.title}}{% endfor %}";
+        String expected = "{#for post in site.collections.get('posts').paginated(page.paginator).orEmpty}{=post.title}{/for}";
+        assertConverts(input, expected,
+                "paginator.posts should convert to Roq collection access");
+    }
+
+    @Test
+    void testPaginatorTotalPages() {
+        String input = "{% if paginator.total_pages > 1 %}yes{% endif %}";
+        String expected = "{#if page.paginator && page.paginator.total > 1}yes{/if}";
+        assertConverts(input, expected,
+                "paginator.total_pages should convert to page.paginator.total with null guard");
+    }
+
+    @Test
+    void testPaginatorNextPage() {
+        String input = "{% if paginator.next_page %}yes{% endif %}";
+        String expected = "{#if page.paginator && page.paginator.next}yes{/if}";
+        assertConverts(input, expected,
+                "paginator.next_page should convert to page.paginator.next");
+    }
+
+    @Test
+    void testPaginatorPreviousPage() {
+        String input = "{% if paginator.previous_page %}yes{% endif %}";
+        String expected = "{#if page.paginator && page.paginator.previous}yes{/if}";
+        assertConverts(input, expected,
+                "paginator.previous_page should convert to page.paginator.previous");
+    }
+
+    @Test
+    void testPaginatorNextPagePath() {
+        String input = "{{paginator.next_page_path}}";
+        String expected = "{=page.paginator.next}";
+        assertConverts(input, expected,
+                "paginator.next_page_path should convert to page.paginator.next");
+    }
+
+    @Test
+    void testPaginatorPreviousPagePath() {
+        String input = "{{paginator.previous_page_path}}";
+        String expected = "{=page.paginator.previous}";
+        assertConverts(input, expected,
+                "paginator.previous_page_path should convert to page.paginator.previous");
+    }
+
+    @Test
     void testForLoop() {
         String input = "{% for item in items %}{{item}}{% endfor %}";
-        String expected = "{#for item in items}{=item}{/for}";
+        String expected = "{#for item in items.orEmpty}{=item}{/for}";
         assertConverts(input, expected, "For loop should convert");
     }
 
@@ -153,8 +197,32 @@ class LiquidToQuteConverterTest {
     @Test
     void testInclude() {
         String input = "{% include \"header.html\" %}";
-        String expected = "{#include header.html /}";
-        assertConverts(input, expected, "Include should convert");
+        String expected = "{#include partials/header.html /}";
+        assertConverts(input, expected, "Include should convert with partials/ prefix");
+    }
+
+    @Test
+    void testIncludeParamAccess() {
+        String input = "{=include.page_title}";
+        String expected = "{=page_title}";
+        assertConverts(input, expected,
+                "include.param should convert to just param (Qute exposes include params directly)");
+    }
+
+    @Test
+    void testIncludeParamInConditional() {
+        String input = "{#if include.page_title}yes{/if}";
+        String expected = "{#if page_title}yes{/if}";
+        assertConverts(input, expected,
+                "include.param in conditionals should also be stripped");
+    }
+
+    @Test
+    void testIncludeParamInAssignment() {
+        String input = "{% assign x = include.url %}";
+        String expected = "{#let x=url}{/let}";
+        assertConverts(input, expected,
+                "include.param in assignments should be stripped");
     }
 
     @Test
@@ -167,8 +235,29 @@ class LiquidToQuteConverterTest {
     @Test
     void testUnless() {
         String input = "{% unless condition %}content{% endunless %}";
-        String expected = "{#if !(condition)}content{/if}";
+        String expected = "{#if !condition}content{/if}";
         assertConverts(input, expected, "Unless should convert to negated if");
+    }
+
+    @Test
+    void testUnlessWithOr() {
+        String input = "{% unless item.completed or item.lts or item.status != 'on track' %}content{% endunless %}";
+        String expected = "{#if !item.completed && !item.lts && item.status == 'on track'}content{/if}";
+        assertConverts(input, expected, "Unless with or should apply De Morgan's law");
+    }
+
+    @Test
+    void testUnlessWithComparison() {
+        String input = "{% unless item.status == 'active' %}content{% endunless %}";
+        String expected = "{#if item.status ne 'active'}content{/if}";
+        assertConverts(input, expected, "Unless with == should negate to ne");
+    }
+
+    @Test
+    void testUnlessForloopLast() {
+        String input = "{% for x in items %}{% unless forloop.last %}, {% endunless %}{% endfor %}";
+        String expected = "{#for x in items.orEmpty}{#if x_hasNext}, {/if}{/for}";
+        assertConverts(input, expected, "Unless forloop.last should become if hasNext (no double negation)");
     }
 
     @Test
@@ -187,10 +276,11 @@ class LiquidToQuteConverterTest {
 
     @Test
     void testRealWorldAuthorExample() {
-        // This is the actual pattern from _layouts/author.html that was causing issues
-        // Note: post.author is converted to page.author by the converter
+        // This is the actual pattern from _layouts/author.html
+        // post.author is custom frontmatter -> post.data.author
+        // default is stripped; split uses namespace form for null safety
         String input = "{{post.author | default: \"\" | split: \",\"}}";
-        String expected = "{=(page.author ?: \"\").split(\",\")}";
+        String expected = "{=str:split(post.data.author??, \",\")}";
         assertConverts(input, expected, "Real-world author pattern should convert correctly");
     }
 
@@ -225,8 +315,8 @@ class LiquidToQuteConverterTest {
     @Test
     void testReplaceFilter() {
         String input = "{{text | replace: 'old', 'new'}}";
-        String expected = "{=text.replace('old', 'new')}";
-        assertConverts(input, expected, "Replace filter should convert");
+        String expected = "{=text.replace('old', 'new').raw}";
+        assertConverts(input, expected, "Replace filter should convert with .raw (Jekyll never escapes)");
     }
 
     @Test
@@ -260,8 +350,8 @@ class LiquidToQuteConverterTest {
     @Test
     void testAssignWithEmptyStringSplit() {
         String input = "{% assign authors_clean = \"\" | split: \"\" %}";
-        String expected = "{#let authors_clean=\"\".split(\"\")}{/let}";
-        assertConverts(input, expected, "Empty string split in assignment should produce valid Qute");
+        String expected = "{#let authors_clean=str:split(\"\", \"\")}{/let}";
+        assertConverts(input, expected, "Empty string split in assignment should use namespace form");
     }
 
     @Test
@@ -277,6 +367,50 @@ class LiquidToQuteConverterTest {
         String input = "{% assign authors_clean = authors_clean | push: a_trimmed %}";
         String expected = "{#let authors_clean=authors_clean.push(a_trimmed)}{/let}";
         assertConverts(input, expected, "Assignment with push filter should convert correctly");
+    }
+
+    @Test
+    void testPushInLoopCollapsedToSplitTrimmed() {
+        String input = "{% assign authors_raw = post.author | default: \"\" | split: \",\" %}\n" +
+                "{% assign authors_clean = \"\" | split: \"\" %}\n" +
+                "{% for a in authors_raw %}\n" +
+                "{% assign a_trimmed = a | strip %}\n" +
+                "{% if a_trimmed != \"\" %}\n" +
+                "{% assign authors_clean = authors_clean | push: a_trimmed %}\n" +
+                "{% endif %}\n" +
+                "{% endfor %}\n" +
+                "{% for author_key in authors_clean %}\n" +
+                "{{author_key}}\n" +
+                "{% endfor %}";
+        String expected = "{#for author_key in str:splitTrimmed(post.data.author??, \",\").orEmpty}\n" +
+                "{=author_key}\n" +
+                "{/for}";
+        assertConverts(input, expected,
+                "Init-empty-list + push-in-loop + iterate should collapse to str:splitTrimmed");
+    }
+
+    @Test
+    void testPushInLoopWithHtmlBetween() {
+        String input = "{% assign authors_raw = post.author | default: \"\" | split: \",\" %}\n" +
+                "{% assign authors_clean = \"\" | split: \"\" %}\n" +
+                "{% for a in authors_raw %}\n" +
+                "{% assign a_trimmed = a | strip %}\n" +
+                "{% if a_trimmed != \"\" %}\n" +
+                "{% assign authors_clean = authors_clean | push: a_trimmed %}\n" +
+                "{% endif %}\n" +
+                "{% endfor %}\n" +
+                "<p class=\"byline\">\n" +
+                "By\n" +
+                "{% for author_key in authors_clean %}\n" +
+                "{{author_key}}\n" +
+                "{% endfor %}";
+        String expected = "<p class=\"byline\">\n" +
+                "By\n" +
+                "{#for author_key in str:splitTrimmed(post.data.author??, \",\").orEmpty}\n" +
+                "{=author_key}\n" +
+                "{/for}";
+        assertConverts(input, expected,
+                "Push-in-loop with HTML between should collapse, preserving the HTML");
     }
 
     @Test
@@ -296,8 +430,8 @@ class LiquidToQuteConverterTest {
                        "      {% assign authors_clean = \"\" | split: \"\" %}";
 
         String expected = "      {!  Build multi-author list for this post  !}\n" +
-                         "      {#let authors_raw=(page.author ?: \"\").split(\",\")}\n" +
-                         "      {#let authors_clean=\"\".split(\"\")}{/let}{/let}";
+                         "      {#let authors_raw=str:split(post.data.author??, \",\")}\n" +
+                         "      {#let authors_clean=str:split(\"\", \"\")}{/let}{/let}";
 
         assertConverts(input, expected, "Author file lines 36-38 should convert without {?:} errors");
     }
@@ -314,7 +448,7 @@ class LiquidToQuteConverterTest {
     @Test
     void testWhitespaceTrimmingEndFor() {
         String input = "{% for item in items %}{=item}{% endfor -%}";
-        String expected = "{#for item in items}{=item}{/for}";
+        String expected = "{#for item in items.orEmpty}{=item}{/for}";
         assertConverts(input, expected,
                 "endfor with whitespace trimming should convert");
     }
@@ -322,9 +456,9 @@ class LiquidToQuteConverterTest {
     @Test
     void testReplaceRegexFilter() {
         String input = "{{page.url | replace_regex: '^/version/([^/]+)/.*', '\\1'}}";
-        String expected = "{=page.url.replaceAll('^/version/([^/]+)/.*', '\\1')}";
+        String expected = "{=page.url.replaceAll('^/version/([^/]+)/.*', '$1')}";
         assertConverts(input, expected,
-                "replace_regex filter should convert to .replaceAll() method call");
+                "replace_regex filter should convert to .replaceAll() with Java backreference syntax");
     }
 
     @Test
@@ -346,7 +480,7 @@ class LiquidToQuteConverterTest {
     @Test
     void testSortFilterWithArgument() {
         String input = "{% assign authors = site.data.authors | sort: name %}";
-        String expected = "{#let authors=site.data.authors.sort(name)}{/let}";
+        String expected = "{#let authors=cdi:authors.sort(name)}{/let}";
         assertConverts(input, expected,
                 "Sort filter with argument should convert to method call with argument");
     }
@@ -354,17 +488,17 @@ class LiquidToQuteConverterTest {
     @Test
     void testPrependFilter() {
         // Liquid: {{ path | prepend: site.baseurl }}
-        // Qute: site.baseurl + path (prepend = concatenate before)
+        // Qute: cdi:siteConfig.baseurl + path (prepend = concatenate before, siteConfig from data/siteConfig.yml)
         String input = "{{paginator.next_page_path | prepend: site.baseurl}}";
-        String expected = "{=site.baseurl + paginator.next_page_path}";
+        String expected = "{=cdi:siteConfig.baseurl + page.paginator.next}";
         assertConverts(input, expected,
-                "Prepend filter should convert to string concatenation");
+                "Prepend filter should convert to string concatenation with CDI reference for site.baseurl");
     }
 
     @Test
     void testDynamicBracketNotation() {
         String input = "{% assign author = site.data.authors[author_key] %}";
-        String expected = "{#let author=site.data.authors.get(author_key)}{/let}";
+        String expected = "{#let author=cdi:authors.get(author_key)}{/let}";
         assertConverts(input, expected,
                 "Dynamic bracket notation should be converted to .get() method call");
     }
@@ -372,7 +506,7 @@ class LiquidToQuteConverterTest {
     @Test
     void testDynamicBracketNotationInVariable() {
         String input = "{{ site.data.authors[key].name }}";
-        String expected = "{=site.data.authors.get(key).name}";
+        String expected = "{=cdi:authors.get(key).name}";
         assertConverts(input, expected,
                 "Bracket notation followed by property access should convert correctly");
     }
@@ -382,7 +516,7 @@ class LiquidToQuteConverterTest {
     @Test
     void testForLoopIndexWithNamedVar() {
         String input = "{% for post in posts %}{{forloop.index0}} {{forloop.index}}{% endfor %}";
-        String expected = "{#for post in posts}{=post_index} {=post_count}{/for}";
+        String expected = "{#for post in posts.orEmpty}{=post_index} {=post_count}{/for}";
         assertConverts(input, expected,
                 "forloop.index0/index should use the loop variable name");
     }
@@ -390,7 +524,7 @@ class LiquidToQuteConverterTest {
     @Test
     void testForLoopFirstUsesCount() {
         String input = "{% for item in items %}{% if forloop.first %}first{% endif %}{% endfor %}";
-        String expected = "{#for item in items}{#if item_count == 1}first{/if}{/for}";
+        String expected = "{#for item in items.orEmpty}{#if item_count == 1}first{/if}{/for}";
         assertConverts(input, expected,
                 "forloop.first should convert to var_count == 1");
     }
@@ -398,7 +532,7 @@ class LiquidToQuteConverterTest {
     @Test
     void testForLoopLastUsesHasNext() {
         String input = "{% for entry in entries %}{% if forloop.last %}last{% endif %}{% endfor %}";
-        String expected = "{#for entry in entries}{#if !entry_hasNext}last{/if}{/for}";
+        String expected = "{#for entry in entries.orEmpty}{#if !entry_hasNext}last{/if}{/for}";
         assertConverts(input, expected,
                 "forloop.last should convert to !var_hasNext");
     }
@@ -406,7 +540,7 @@ class LiquidToQuteConverterTest {
     @Test
     void testNestedForLoopsUseDifferentVarNames() {
         String input = "{% for cat in categories %}{% for post in cat.posts %}{{forloop.index}}{% endfor %}{% endfor %}";
-        String expected = "{#for cat in categories}{#for post in cat.posts}{=post_count}{/for}{/for}";
+        String expected = "{#for cat in categories.orEmpty}{#for post in cat.posts.orEmpty}{=post_count}{/for}{/for}";
         assertConverts(input, expected,
                 "Nested loops should use their own variable name for metadata");
     }
@@ -414,7 +548,7 @@ class LiquidToQuteConverterTest {
     @Test
     void testForLoopWithLimitAndOffset() {
         String input = "{% for item in items limit:3 offset:2 %}{{item}}{% endfor %}";
-        String expected = "{#for item in items.skip(2).limit(3)}{=item}{/for}";
+        String expected = "{#for item in items.orEmpty.skip(2).limit(3)}{=item}{/for}";
         assertConverts(input, expected,
                 "Loop with limit and offset should convert to .skip().limit()");
     }
@@ -549,8 +683,8 @@ class LiquidToQuteConverterTest {
 
     @Test
     void testAssignScopeEndsAtEnclosingForLoop() {
-        String input = "{#for item in items}{% assign x = item.name %}{=x}{/for}after";
-        String expected = "{#for item in items}{#let x=item.name}{=x}{/let}{/for}after";
+        String input = "{#for item in items.orEmpty}{% assign x = item.name %}{=x}{/for}after";
+        String expected = "{#for item in items.orEmpty}{#let x=item.name}{=x}{/let}{/for}after";
         assertConverts(input, expected,
                 "Assign inside a for loop should scope to the loop's end");
     }
@@ -572,11 +706,28 @@ class LiquidToQuteConverterTest {
     }
 
     @Test
-    void testAssignInIfBranchScopedBeforeElse() {
-        String input = "{% if page.title %}{% assign x = page.title %}{% else %}{% assign x = 'default' %}{% endif %}";
-        String expected = "{#if page.title}{#let x=page.title}{/let}{#else}{#let x='default'}{/let}{/if}";
+    void testAssignInIfElseBranchesWithFalseElse() {
+        String input = "{% if page.title %}{% assign x = page.title %}{% else %}{% assign x = false %}{% endif %}";
+        // condition == ifExpr, so Elvis applies: page.title ?: false
+        String expected = "{#let x=page.title ?: false}\n{/let}";
         assertConverts(input, expected,
-                "Assign in if branch should be scoped before the else, not crossing into it");
+                "Same variable in if/else with false else should convert to Elvis");
+    }
+
+    @Test
+    void testAssignInIfElseBranchesElvisCase() {
+        String input = "{% if page.title %}{% assign x = page.title %}{% else %}{% assign x = 'default' %}{% endif %}";
+        String expected = "{#let x=page.title ?: 'default'}\n{/let}";
+        assertConverts(input, expected,
+                "Same variable in if/else where condition matches if-value should use Elvis operator");
+    }
+
+    @Test
+    void testReplaceRegexWithPrependChain() {
+        String input = "{% assign x = page.url | replace_regex: '^/version/([^/]+)/.*', '\\1' | prepend: ' - ' %}";
+        String expected = "{#let x=' - ' + page.url.replaceAll('^/version/([^/]+)/.*', '$1')}{/let}";
+        assertConverts(input, expected,
+                "replace_regex chained with prepend should produce valid method call");
     }
 
     @Test
@@ -585,6 +736,284 @@ class LiquidToQuteConverterTest {
         String expected = "{=page.content.stripHtml.wordLimit(75)}";
         assertConverts(input, expected,
                 "Chained filters should not have spaces between method calls");
+    }
+
+    @Test
+    void testPostCustomFieldConvertToData() {
+        String input = "{{post.author}}";
+        String expected = "{=post.data.author??}";
+        assertConverts(input, expected,
+                "post.customField should convert to post.data.customField (DocumentPage custom frontmatter)");
+    }
+
+    @Test
+    void testPostBuiltInFieldsNotConverted() {
+        String input = "{{post.title}} {{post.url}} {{post.date}} {{post.content}}";
+        String expected = "{=post.title} {=post.url} {=post.date} {=post.content}";
+        assertConverts(input, expected,
+                "post built-in properties should not be converted to post.data.*");
+    }
+
+    @Test
+    void testPostSynopsisConverted() {
+        String input = "{#if post.synopsis}yes{/if}";
+        String expected = "{#if post.data.synopsis??}yes{/if}";
+        assertConverts(input, expected,
+                "post.synopsis should convert to post.data.synopsis");
+    }
+
+    @Test
+    void testIncludePathWithPageNotMangled() {
+        String input = "{% include share-page.html title=post.title url=post.url %}";
+        String expected = "{#include partials/share-page.html title=post.title url=post.url /}";
+        assertConverts(input, expected,
+                "Include paths containing '-page.' should not be treated as page field access");
+    }
+
+    @Test
+    void testSiteBaseurlConvertsToCdi() {
+        String input = "<a href=\"{{site.baseurl}}/path\">Link</a>";
+        String expected = "<a href=\"{=cdi:siteConfig.baseurl}/path\">Link</a>";
+        assertConverts(input, expected,
+                "site.baseurl should convert to CDI reference");
+    }
+
+    @Test
+    void testSiteLanguageConvertsToCdi() {
+        String input = "<html lang=\"{{site.language}}\">";
+        String expected = "<html lang=\"{=cdi:siteConfig.language}\">";
+        assertConverts(input, expected,
+                "site.language should convert to CDI reference");
+    }
+
+    @Test
+    void testSiteBaseurlInConditional() {
+        String input = "{% if site.baseurl %}<base href=\"{{site.baseurl}}\">{% endif %}";
+        String expected = "{#if cdi:siteConfig.baseurl}<base href=\"{=cdi:siteConfig.baseurl}\">{/if}";
+        assertConverts(input, expected,
+                "site.baseurl in conditionals should convert to CDI reference");
+    }
+
+    @Test
+    void testSiteCustomPropertyConvertsToCdi() {
+        String input = "{=site.twitter_username}";
+        String expected = "{=cdi:siteConfig.twitter_username}";
+        assertConverts(input, expected,
+                "Custom site properties should convert to cdi:siteConfig references");
+    }
+
+    @Test
+    void testSiteBuiltInPropertiesNotConverted() {
+        String input = "{=site.url} {=site.title} {=site.collections} {=site.pages} {=site.data}";
+        String expected = "{=site.url} {=site.title} {=site.collections} {=site.pages} {=site.data}";
+        assertConverts(input, expected,
+                "Roq Site built-in properties should not be converted to cdi:siteConfig");
+    }
+
+    @Test
+    void testCustomPageFieldConvertToData() {
+        String input = "{{page.data.author}}";
+        String expected = "{=page.data.author??}";
+        assertConverts(input, expected,
+                "Custom page frontmatter fields should be lenient (may not exist)");
+    }
+
+    @Test
+    void testBuiltInPageFieldsNotConverted() {
+        String input = "{{page.title}} {{page.date}} {{page.url}}";
+        String expected = "{=page.title} {=page.date} {=page.url}";
+        assertConverts(input, expected,
+                "Built-in page properties should not be converted to page.data.*");
+    }
+
+    @Test
+    void testMultipleCustomPageFields() {
+        String input = "{{page.data.author}} - {{page.synopsis}}";
+        String expected = "{=page.data.author??} - {=page.data.synopsis??}";
+        assertConverts(input, expected,
+                "Multiple custom fields should all convert to page.data.* with lenient operator");
+    }
+
+    @Test
+    void testCustomFieldInConditional() {
+        String input = "{% if page.search_wc %}...{% endif %}";
+        String expected = "{#if page.data.search_wc??}...{/if}";
+        assertConverts(input, expected,
+                "Custom fields in conditionals should convert to page.data.* with lenient operator");
+    }
+
+    @Test
+    void testSiteSearchConvertsToCdi() {
+        String input = "{{site.search.host}}";
+        String expected = "{=cdi:siteConfig.search.host}";
+        assertConverts(input, expected,
+                "site.search properties should convert to CDI reference");
+    }
+
+    @Test
+    void testSiteSearchScriptMode() {
+        String input = "{% if site.search.script-mode == 'direct' %}...{% endif %}";
+        String expected = "{#if cdi:siteConfig.search.script-mode == 'direct'}...{/if}";
+        assertConverts(input, expected,
+                "site.search.script-mode should convert to CDI reference");
+    }
+
+    @Test
+    void testUrlConcatenationWithSiteUrl() {
+        String input = "{{site.url | append: page.url}}";
+        String expected = "{=site.url.resolve(page.url)}";
+        assertConverts(input, expected,
+                "URL concatenation should use .resolve() instead of +");
+    }
+
+    @Test
+    void testUrlConcatenationWithVariable() {
+        String input = "{{canonical_url | prepend: site.url}}";
+        String expected = "{=site.url.resolve(canonical_url)}";
+        assertConverts(input, expected,
+                "Prepending to URL should use .resolve()");
+    }
+
+    @Test
+    void testPageUrlEqualityComparison() {
+        String input = "{#if page.url == '/'}homepage{#else}{=page.data.layout}{/if}";
+        String expected = "{#if page.url.path == '/'}homepage{#else}{=page.data.layout??}{/if}";
+        assertConverts(input, expected,
+                "page.url == should convert to page.url.path == (RoqUrl is not a String)");
+    }
+
+    @Test
+    void testPageUrlNotEqualsComparison() {
+        String input = "{#if page.url != '/about/'}other{/if}";
+        String expected = "{#if page.url.path ne '/about/'}other{/if}";
+        assertConverts(input, expected,
+                "page.url != should convert to page.url.path ne");
+    }
+
+    @Test
+    void testSiteDataToCdiReference() {
+        assertConverts("{{ site.data.projectfooter.links }}", "{=cdi:projectfooter.links}",
+                "site.data.X should convert to cdi:X");
+    }
+
+    @Test
+    void testSiteDataNestedReference() {
+        assertConverts("{{ site.data.versions.documentation }}",
+                "{=cdi:versions.documentation}",
+                "site.data.X.Y should convert to cdi:X.Y");
+    }
+
+    @Test
+    void testContainsInIfCondition() {
+        assertConverts("{% if page.url contains '/guides/' %}yes{% endif %}",
+                "{#if page.url.contains('/guides/')}yes{/if}",
+                "contains operator in if should convert to method call");
+    }
+
+    @Test
+    void testContainsInIfConditionWithAnd() {
+        assertConverts("{% if page.url contains '/guides/' and page.title %}yes{% endif %}",
+                "{#if page.url.contains('/guides/') && page.title}yes{/if}",
+                "contains with and should convert both operators");
+    }
+
+    @Test
+    void testAssignInIfElseBlockGeneralCaseInlinesTrailingContent() {
+        String input = """
+                {% if page.layout == 'guides' %}
+                  {%assign canonical_url = page.url | replace: 'foo', '' %}
+                {% else %}
+                  {%assign canonical_url = page.url %}
+                {% endif %}
+                <link rel="canonical" href="{{ canonical_url }}">
+                """;
+        String result = converter.convert(input);
+
+        // General case: trailing content using the variable is duplicated into each branch
+        assertTrue(result.contains("{#if"), "If/else should be preserved");
+        // The <link> line should appear twice (once per branch)
+        int firstLink = result.indexOf("canonical");
+        int secondLink = result.indexOf("canonical", firstLink + 1);
+        assertTrue(secondLink > firstLink, "Trailing content should be duplicated into both branches");
+    }
+
+    @Test
+    void testRelativeUrlFilter() {
+        String input = "{{ '/assets/javascript/highlight.pack.js' | relative_url }}";
+        String expected = "{=cdi:siteConfig.baseurl + '/assets/javascript/highlight.pack.js'}";
+        assertConverts(input, expected, "relative_url filter should prepend baseurl");
+    }
+
+    @Test
+    void testRelativeUrlFilterWithVariable() {
+        String input = "{{ page.url | relative_url }}";
+        String expected = "{=cdi:siteConfig.baseurl + page.url}";
+        assertConverts(input, expected, "relative_url filter on variable should prepend baseurl");
+    }
+
+    @Test
+    void testAbsoluteUrlFilter() {
+        String input = "{{ '/feed.xml' | absolute_url }}";
+        String expected = "{=cdi:siteConfig.baseurl + '/feed.xml'}";
+        assertConverts(input, expected, "absolute_url filter should prepend baseurl");
+    }
+
+    @Test
+    void testPrependWithStringLiteral() {
+        String input = "{{ '/assets/images/quarkus_card.png' | prepend: site.url }}";
+        String expected = "{=site.url.resolve('/assets/images/quarkus_card.png')}";
+        assertConverts(input, expected, "prepend with string literal containing slashes should work");
+    }
+
+    @Test
+    void testNotEqualsConvertsToNe() {
+        String input = "{% if site.cname != 'quarkus.io' %}content{% endif %}";
+        String expected = "{#if cdi:siteConfig.cname ne 'quarkus.io'}content{/if}";
+        assertConverts(input, expected, "!= should convert to ne in if conditions");
+    }
+
+    @Test
+    void testContentVariableInLayout() {
+        String input = "<div>{{ content }}</div>";
+        String expected = "<div>{#insert /}</div>";
+        assertConverts(input, expected, "{{ content }} in layout should become {#insert /}");
+    }
+
+    @Test
+    void testSitePostsConversion() {
+        String input = "{% for post in site.posts %}text{% endfor %}";
+        String expected = "{#for post in site.collections.get('posts').orEmpty}text{/for}";
+        assertConverts(input, expected, "site.posts should convert to site.collections.get('posts')");
+    }
+
+    @Test
+    void testForLoopPropertyIterableGetsOrEmpty() {
+        String input = "{% for tag in post.tags %}{{ tag }}{% endfor %}";
+        String expected = "{#for tag in post.tags.orEmpty}{=tag}{/for}";
+        assertConverts(input, expected, "Property-access iterable in for loop should get .orEmpty");
+    }
+
+    @Test
+    void testForLoopCdiIterableNoOrEmpty() {
+        String input = "{% for item in cdi:books %}text{% endfor %}";
+        String expected = "{#for item in cdi:books}text{/for}";
+        assertConverts(input, expected, "cdi: iterable should not get .orEmpty");
+    }
+
+    @Test
+    void testSplitWithDefaultUsesNamespaceForm() {
+        // default is stripped, split uses namespace form for null safety
+        String input = "{% assign result = foo.bar | default: \"\" | split: \",\" %}{result}";
+        String result = converter.convert(input);
+        assertTrue(result.contains("{#let result=str:split(foo.bar, \",\")}"),
+                "Should use namespace split form: " + result);
+    }
+
+    @Test
+    void testForLoopSimpleVariableGetsOrEmpty() {
+        String input = "{% for a in authors_raw %}{{ a }}{% endfor %}";
+        String expected = "{#for a in authors_raw.orEmpty}{=a}{/for}";
+        assertConverts(input, expected, "Simple variable iterable in for loop should get .orEmpty");
     }
 
     @Test
@@ -672,14 +1101,14 @@ class LiquidToQuteConverterTest {
         @Test
         void testTernaryWrapping() {
             assertConverts("{{post.author | default: \"\" | split: \",\"}}",
-                    "{(page.author ?: \"\").split(\",\")}",
-                    "Standard syntax should wrap ternary before method calls");
+                    "{str:split(post.data.author??, \",\")}",
+                    "Standard syntax should use namespace split");
         }
 
         @Test
         void testForLoop() {
             assertConverts("{% for item in items %}{{item}}{% endfor %}",
-                    "{#for item in items}{item}{/for}",
+                    "{#for item in items.orEmpty}{item}{/for}",
                     "Standard syntax for loop should use {expr} for outputs");
         }
 


### PR DESCRIPTION
Sorry, this is another whopper. 

I've left the JekyllFiltersExtension in `migration-helpers`. I know we had some discussion about making it generally available, but I suggest we leave it there for now and then once we have migration fully working (which is definitely not yet), we can review the extensions and see which might be generally useful, and which you'd only want if you were doing a Jekyll conversion. 

At some point I think I should split the converter into sub-files, but I'd like to do that refactor after it's basically working. I'm also planning to add some e2e tests, but I'll do that in a separate PR. 

Major converter improvements:
- Convert site.* properties to cdi:siteConfig references
- Convert site.data.* to CDI bean references
- Convert page/post custom frontmatter fields to .data.* access
- Convert post.* to keep post prefix (may be loop variable)
- Convert paginator.* to Roq paginator API
- Convert page.url comparisons to page.url.path
- Convert URL concatenation to .resolve()
- Convert relative_url/absolute_url to baseurl prepend
- Apply De Morgan's law for unless with compound conditions
- Collapse push-in-loop pattern to str:splitTrimmed
- Convert {{ content }} in layouts to {#insert /}
- Convert include.param to direct param access
- Add .orEmpty to property-access iterables in for loops
- Strip Liquid whitespace-trimming markers
- Add replace_regex, prepend, sort, contains, and more filters
- Add JekyllFiltersExtension resource for runtime support