### PR TITLE
Jekyll migration: Add converter to transform _config.yml 

### DIFF
--- a/migration/pom.xml
+++ b/migration/pom.xml
@@ -50,6 +50,13 @@
             <artifactId>vertx-core</artifactId>
         </dependency>
 
+        <!-- YAML parsing -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.18.2</version>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/migration/src/main/java/io/quarkus/tools/JekyllConfigCommand.java
+++ b/migration/src/main/java/io/quarkus/tools/JekyllConfigCommand.java
@@ -1,0 +1,61 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS info.picocli:picocli:4.7.5
+//DEPS com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.2
+
+package io.quarkus.tools;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "jekyll-config", mixinStandardHelpOptions = true, version = "1.0",
+        description = "Converts Jekyll _config.yml to Roq application.properties and data/siteConfig.yml")
+public class JekyllConfigCommand implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "Jekyll project directory")
+    private Path projectDir;
+
+    private JekyllConfigConverter converter = new JekyllConfigConverter();
+
+    public static void main(String... args) {
+        int exitCode = new CommandLine(new JekyllConfigCommand()).execute(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        if (!Files.exists(projectDir)) {
+            System.err.println("Error: Project directory '" + projectDir + "' does not exist");
+            return 1;
+        }
+
+        if (!Files.isDirectory(projectDir)) {
+            System.err.println("Error: '" + projectDir + "' is not a directory");
+            return 1;
+        }
+
+        Path configFile = projectDir.resolve("_config.yml");
+        if (!Files.exists(configFile)) {
+            System.err.println("Error: _config.yml not found in " + projectDir);
+            return 1;
+        }
+
+        try {
+            converter.convertProject(projectDir);
+            
+            System.out.println("✓ Jekyll config conversion complete:");
+            System.out.println("  - Created/updated: config/application.properties");
+            System.out.println("  - Created: data/siteConfig.yml");
+            
+            return 0;
+        } catch (Exception e) {
+            System.err.println("✗ Error converting Jekyll config: " + e.getMessage());
+            e.printStackTrace();
+            return 1;
+        }
+    }
+}

--- a/migration/src/main/java/io/quarkus/tools/JekyllConfigCommand.java
+++ b/migration/src/main/java/io/quarkus/tools/JekyllConfigCommand.java
@@ -12,8 +12,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
-@Command(name = "jekyll-config", mixinStandardHelpOptions = true, version = "1.0",
-        description = "Converts Jekyll _config.yml to Roq application.properties and data/siteConfig.yml")
+@Command(name = "jekyll-config", mixinStandardHelpOptions = true, version = "1.0", description = "Converts Jekyll _config.yml to Roq application.properties and data/siteConfig.yml")
 public class JekyllConfigCommand implements Callable<Integer> {
 
     @Parameters(index = "0", description = "Jekyll project directory")
@@ -46,11 +45,11 @@ public class JekyllConfigCommand implements Callable<Integer> {
 
         try {
             converter.convertProject(projectDir);
-            
+
             System.out.println("✓ Jekyll config conversion complete:");
             System.out.println("  - Created/updated: config/application.properties");
             System.out.println("  - Created: data/siteConfig.yml");
-            
+
             return 0;
         } catch (Exception e) {
             System.err.println("✗ Error converting Jekyll config: " + e.getMessage());

--- a/migration/src/main/java/io/quarkus/tools/JekyllConfigConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/JekyllConfigConverter.java
@@ -1,0 +1,166 @@
+package io.quarkus.tools;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
+import static io.quarkus.tools.LiquidToQuteConverter.DATA_NAME;
+
+/**
+ * Converts Jekyll _config.yml to Roq application.properties and data/siteConfig.yml.
+ * Replaces the bash script logic from roq-it-jekyll lines 61-62, 184-192, and 238-277.
+ */
+public class JekyllConfigConverter {
+
+    private final YAMLMapper yamlMapper;
+    private final ObjectMapper objectMapper;
+
+    public JekyllConfigConverter() {
+        this.yamlMapper = new YAMLMapper();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * Create application.properties values with standard Roq properties for Jekyll compatibility.
+     * Replaces roq-it-jekyll lines 184-192.
+     *
+     * @return Application properties
+     */
+    public Properties createApplicationProperties() {
+        Properties properties = new Properties();
+
+        // Always enable the alternative expression syntax to reduce overhead of escaping braces
+        properties.setProperty("quarkus.qute.alt-expr-syntax", "true");
+        // Set a date format with a sensible default for Jekyll.
+        properties.setProperty("site.date-format", "yyyy-MM-dd['T'HH:mm:ss][X]");
+        // Jekyll templates access arbitrary frontmatter fields that may not exist on every page
+        // echo "quarkus.qute.strict-rendering=false" >> ${project_dir}/config/application.properties
+        // Exclude type checking for:
+        // - Object.* (JsonArray iteration yields Object at build time)
+        // - Page.paginator (only on NormalPage subclass, not visible at compile time)
+        // - DocumentPage.* (post loop variables access custom frontmatter via data)
+        properties.setProperty("quarkus.qute.strict-rendering", "false");
+        properties.setProperty("quarkus.qute.type-check-excludes",
+                "java.lang.Object.*,"
+                        + "io.quarkiverse.roq.frontmatter.runtime.model.Page.paginator,"
+                        + "io.quarkiverse.roq.frontmatter.runtime.model.Page.tags,"
+                        + "io.quarkiverse.roq.frontmatter.runtime.model.Page.tagsCount,"
+                        + "io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage.*");
+        return properties;
+    }
+
+    /**
+     * Create a siteConfig.yml file for template access to site properties.
+     * This makes Jekyll's site.* properties available as cdi:siteConfig.* in Roq.
+     * Replaces roq-it-jekyll lines 238-277.
+     * 
+     * @param configYaml The content of _config.yml
+     * @param cnameContent Optional CNAME file content (can be null)
+     * @return YAML content for data/siteConfig.yml
+     * @throws IOException if parsing fails
+     */
+    public String createSiteConfigYaml(String configYaml, String cnameContent) throws IOException {
+        // Parse the original config
+        JsonNode config = yamlMapper.readTree(configYaml);
+        
+        // Build a new config with selected properties
+        Map<String, Object> siteConfig = new LinkedHashMap<>();
+        
+        // Add CNAME
+        siteConfig.put("cname", cnameContent != null ? cnameContent.trim() : "");
+        
+        // Copy common properties
+        copyIfPresent(config, siteConfig, "baseurl");
+        copyIfPresent(config, siteConfig, "language");
+        copyIfPresent(config, siteConfig, "twitter_username");
+        copyIfPresent(config, siteConfig, "github_username");
+        
+        // Handle nested search config
+        if (config.has("search")) {
+            JsonNode search = config.get("search");
+            Map<String, Object> searchConfig = new LinkedHashMap<>();
+            copyIfPresent(search, searchConfig, "script-mode");
+            copyIfPresent(search, searchConfig, "host");
+            copyIfPresent(search, searchConfig, "script-path");
+            copyIfPresent(search, searchConfig, "cached-script-file");
+            if (!searchConfig.isEmpty()) {
+                siteConfig.put("search", searchConfig);
+            }
+        }
+        
+        // Add empty tags array (for Jekyll compatibility)
+        siteConfig.put("tags", new Object[0]);
+        
+        // Convert to YAML
+        return yamlMapper.writeValueAsString(siteConfig);
+    }
+
+    /**
+     * Convert Jekyll config files from a project directory.
+     * Reads _config.yml and CNAME, creates config/application.properties and data/siteConfig.yml.
+     * Replaces roq-it-jekyll lines 61-62, 184-192, and 238-277.
+     * 
+     * @param projectDir The Jekyll project directory
+     * @throws IOException if file operations fail
+     */
+    public void convertProject(Path projectDir) throws IOException {
+        Path configFile = projectDir.resolve("_config.yml");
+        Path cnameFile = projectDir.resolve("CNAME");
+        
+        if (!Files.exists(configFile)) {
+            throw new IOException("_config.yml not found in " + projectDir + ". Is this a Jekyll project?");
+        }
+        
+        // Read input files
+        String configYaml = Files.readString(configFile);
+        String cnameContent = Files.exists(cnameFile) ? Files.readString(cnameFile) : null;
+        
+        // Create config/application.properties
+        Path configDir = projectDir.resolve("config");
+        Files.createDirectories(configDir);
+        Path propsFile = configDir.resolve("application.properties");
+
+        // Write properties manually — Properties.store() escapes colons in values,
+        // which corrupts date format patterns like yyyy-MM-dd['T'HH:mm:ss][X]
+        try (Writer writer = Files.newBufferedWriter(propsFile)) {
+            Properties props = createApplicationProperties();
+            for (String key : props.stringPropertyNames()) {
+                writer.write(key + "=" + props.getProperty(key) + "\n");
+            }
+        }
+        
+        // Create data/siteConfig.yml
+        String siteConfigYaml = createSiteConfigYaml(configYaml, cnameContent);
+        Path dataDir = projectDir.resolve("data");
+        Files.createDirectories(dataDir);
+        Path siteConfigFile = dataDir.resolve(DATA_NAME + ".yml");
+        Files.writeString(siteConfigFile, siteConfigYaml);
+    }
+
+    private void copyIfPresent(JsonNode source, Map<String, Object> target, String key) {
+        if (source.has(key)) {
+            JsonNode value = source.get(key);
+            if (value.isTextual()) {
+                target.put(key, value.asText());
+            } else if (value.isNumber()) {
+                target.put(key, value.numberValue());
+            } else if (value.isBoolean()) {
+                target.put(key, value.asBoolean());
+            } else if (value.isObject() || value.isArray()) {
+                try {
+                    target.put(key, objectMapper.convertValue(value, Object.class));
+                } catch (IllegalArgumentException e) {
+                    // Skip if conversion fails
+                }
+            }
+        }
+    }
+}

--- a/migration/src/main/java/io/quarkus/tools/JekyllConfigConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/JekyllConfigConverter.java
@@ -4,15 +4,16 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-
-import static io.quarkus.tools.LiquidToQuteConverter.DATA_NAME;
 
 /**
  * Converts Jekyll _config.yml to Roq application.properties and data/siteConfig.yml.
@@ -20,40 +21,86 @@ import static io.quarkus.tools.LiquidToQuteConverter.DATA_NAME;
  */
 public class JekyllConfigConverter {
 
+    public static final String DEFAULT_COLLECTION_NAME = "posts";
+    public static final String APPLICATION_PROPERTIES = "application.properties";
+    public static final String CONFIG_DIR = "config";
+    public static final String DATA_DIR = "data";
+    public static final String SITE_CONFIG_FILE = "siteConfig.yml";
     private final YAMLMapper yamlMapper;
     private final ObjectMapper objectMapper;
+    private boolean strictProperties;
 
     public JekyllConfigConverter() {
         this.yamlMapper = new YAMLMapper();
         this.objectMapper = new ObjectMapper();
     }
 
+    public void setStrictProperties(boolean strictProperties) {
+        this.strictProperties = strictProperties;
+    }
+
     /**
      * Create application.properties values with standard Roq properties for Jekyll compatibility.
-     * Replaces roq-it-jekyll lines 184-192.
      *
-     * @return Application properties
+     * @return Application properties (without plugin-dependent properties)
      */
     public Properties createApplicationProperties() {
+        return createApplicationProperties(null);
+    }
+
+    /**
+     * Create application.properties values with standard Roq properties for Jekyll compatibility,
+     * including properties derived from detected Jekyll plugins.
+     *
+     * @param config Parsed _config.yml (can be null)
+     * @return Application properties
+     */
+    public Properties createApplicationProperties(JsonNode config) {
         Properties properties = new Properties();
 
         // Always enable the alternative expression syntax to reduce overhead of escaping braces
         properties.setProperty("quarkus.qute.alt-expr-syntax", "true");
         // Set a date format with a sensible default for Jekyll.
         properties.setProperty("site.date-format", "yyyy-MM-dd['T'HH:mm:ss][X]");
-        // Jekyll templates access arbitrary frontmatter fields that may not exist on every page
-        // echo "quarkus.qute.strict-rendering=false" >> ${project_dir}/config/application.properties
+        properties.setProperty("quarkus.qute.strict-rendering", "false");
+        if (!strictProperties) {
+            // Liquid silently swallows missing properties (outputs nothing).
+            // NOOP replicates that behaviour so converted templates work without
+            // wrapping every optional field in {#if}.
+            properties.setProperty("quarkus.qute.property-not-found-strategy", "NOOP");
+        }
         // Exclude type checking for:
         // - Object.* (JsonArray iteration yields Object at build time)
         // - Page.paginator (only on NormalPage subclass, not visible at compile time)
         // - DocumentPage.* (post loop variables access custom frontmatter via data)
-        properties.setProperty("quarkus.qute.strict-rendering", "false");
         properties.setProperty("quarkus.qute.type-check-excludes",
                 "java.lang.Object.*,"
                         + "io.quarkiverse.roq.frontmatter.runtime.model.Page.paginator,"
                         + "io.quarkiverse.roq.frontmatter.runtime.model.Page.tags,"
                         + "io.quarkiverse.roq.frontmatter.runtime.model.Page.tagsCount,"
                         + "io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage.*");
+
+        // Jekyll SCSS often uses absolute url('/assets/...') references. EsBuild can't resolve
+        // these at build time since it doesn't know public/ is the site root. Mark them as external.
+        properties.setProperty("quarkus.web-bundler.bundling.external", "/assets/*");
+
+        if (hasPlugin(config, "jekyll-auto-authors")) {
+            addAutoAuthorProperties(config, properties);
+        }
+
+        if (config != null && config.has("url")) {
+            properties.setProperty("site.url", config.get("url").asText());
+        }
+
+        // Roq sets showtitle + noheader by default, which renders the AsciiDoc title
+        // in the body. Jekyll layouts render page.title as <h1>, so unset showtitle
+        // to avoid a duplicate title.
+        properties.setProperty("quarkus.asciidoc.attributes.\"!showtitle\"", "true");
+
+        addAsciidoctorAttributes(config, properties);
+        addCollectionProperties(config, properties);
+        addEscapedPages(config, properties);
+
         return properties;
     }
 
@@ -61,106 +108,426 @@ public class JekyllConfigConverter {
      * Create a siteConfig.yml file for template access to site properties.
      * This makes Jekyll's site.* properties available as cdi:siteConfig.* in Roq.
      * Replaces roq-it-jekyll lines 238-277.
-     * 
+     *
      * @param configYaml The content of _config.yml
      * @param cnameContent Optional CNAME file content (can be null)
      * @return YAML content for data/siteConfig.yml
      * @throws IOException if parsing fails
      */
     public String createSiteConfigYaml(String configYaml, String cnameContent) throws IOException {
-        // Parse the original config
-        JsonNode config = yamlMapper.readTree(configYaml);
-        
-        // Build a new config with selected properties
+        return createSiteConfigYaml(yamlMapper.readTree(configYaml), cnameContent);
+    }
+
+    public static final String COLLECTIONS = "collections";
+    /**
+     * Create a siteConfig.yml from a pre-parsed config.
+     */
+    private static final Set<String> KEYS_HANDLED_ELSEWHERE = Set.of(
+            "url", // → application.properties site.url
+            COLLECTIONS, // → application.properties site.collections.*
+            "plugins", // → application.properties (auto-author, etc.)
+            "defaults", // → application.properties (collection layouts)
+            "description", // → index page frontmatter
+            "autopages", // → application.properties (auto-author config)
+            "title", // → index page frontmatter / Roq site.title
+            "asciidoctor" // → application.properties quarkus.asciidoc.attributes.*
+    );
+
+    public String createSiteConfigYaml(JsonNode config, String cnameContent) throws IOException {
         Map<String, Object> siteConfig = new LinkedHashMap<>();
-        
+
         // Add CNAME
         siteConfig.put("cname", cnameContent != null ? cnameContent.trim() : "");
-        
-        // Copy common properties
-        copyIfPresent(config, siteConfig, "baseurl");
-        copyIfPresent(config, siteConfig, "language");
-        copyIfPresent(config, siteConfig, "twitter_username");
-        copyIfPresent(config, siteConfig, "github_username");
-        
-        // Handle nested search config
-        if (config.has("search")) {
-            JsonNode search = config.get("search");
-            Map<String, Object> searchConfig = new LinkedHashMap<>();
-            copyIfPresent(search, searchConfig, "script-mode");
-            copyIfPresent(search, searchConfig, "host");
-            copyIfPresent(search, searchConfig, "script-path");
-            copyIfPresent(search, searchConfig, "cached-script-file");
-            if (!searchConfig.isEmpty()) {
-                siteConfig.put("search", searchConfig);
+
+        // Copy all config keys except those handled by application.properties or index page
+        // Transform all hyphenated keys to camelCase for Qute template compatibility
+        // (Qute doesn't support hyphens in property access - interprets as subtraction)
+        config.fieldNames().forEachRemaining(key -> {
+            if (KEYS_HANDLED_ELSEWHERE.contains(key)) {
+                return;
             }
-        }
-        
+            copyNodeWithCamelCaseKeys(config.get(key), siteConfig, key);
+        });
+
         // Add empty tags array (for Jekyll compatibility)
         siteConfig.put("tags", new Object[0]);
-        
+
         // Convert to YAML
         return yamlMapper.writeValueAsString(siteConfig);
+    }
+
+    private void copyNodeWithCamelCaseKeys(JsonNode node, Map<String, Object> target, String key) {
+        if (node.isObject()) {
+            // Recursively transform all nested object keys to camelCase
+            Map<String, Object> nestedMap = new LinkedHashMap<>();
+            node.fields().forEachRemaining(entry -> {
+                String camelKey = hyphenToCamelCase(entry.getKey());
+                copyNodeWithCamelCaseKeys(entry.getValue(), nestedMap, camelKey);
+            });
+            target.put(key, nestedMap);
+        } else if (node.isArray()) {
+            target.put(key, objectMapper.convertValue(node, Object.class));
+        } else if (node.isTextual()) {
+            target.put(key, node.asText());
+        } else if (node.isNumber()) {
+            target.put(key, node.numberValue());
+        } else if (node.isBoolean()) {
+            target.put(key, node.asBoolean());
+        } else if (node.isNull()) {
+            target.put(key, null);
+        }
     }
 
     /**
      * Convert Jekyll config files from a project directory.
      * Reads _config.yml and CNAME, creates config/application.properties and data/siteConfig.yml.
      * Replaces roq-it-jekyll lines 61-62, 184-192, and 238-277.
-     * 
+     *
+     * <p>
+     * <strong>Warning:</strong> This method performs destructive file operations:
+     * </p>
+     * <ul>
+     * <li>Moves collection directories from {@code _<name>} to {@code content/<name>}
+     * (e.g., {@code _guides} → {@code content/guides})</li>
+     * <li>Modifies {@code index.md/index.html/index.adoc} frontmatter to add site description</li>
+     * <li>Creates/overwrites {@code config/application.properties} and {@code data/siteConfig.yml}</li>
+     * </ul>
+     *
+     * <p>
+     * Run on a clean working tree or ensure you have backups before conversion.
+     * </p>
+     *
      * @param projectDir The Jekyll project directory
-     * @throws IOException if file operations fail
+     * @throws IOException if file operations fail, including if collection directory moves fail
      */
     public void convertProject(Path projectDir) throws IOException {
         Path configFile = projectDir.resolve("_config.yml");
         Path cnameFile = projectDir.resolve("CNAME");
-        
+
         if (!Files.exists(configFile)) {
             throw new IOException("_config.yml not found in " + projectDir + ". Is this a Jekyll project?");
         }
-        
+
         // Read input files
         String configYaml = Files.readString(configFile);
         String cnameContent = Files.exists(cnameFile) ? Files.readString(cnameFile) : null;
-        
+
         // Create config/application.properties
-        Path configDir = projectDir.resolve("config");
+        Path configDir = projectDir.resolve(CONFIG_DIR);
         Files.createDirectories(configDir);
-        Path propsFile = configDir.resolve("application.properties");
+        Path propsFile = configDir.resolve(APPLICATION_PROPERTIES);
+
+        JsonNode config = yamlMapper.readTree(configYaml);
 
         // Write properties manually — Properties.store() escapes colons in values,
         // which corrupts date format patterns like yyyy-MM-dd['T'HH:mm:ss][X]
         try (Writer writer = Files.newBufferedWriter(propsFile)) {
-            Properties props = createApplicationProperties();
-            for (String key : props.stringPropertyNames()) {
+            Properties props = createApplicationProperties(config);
+            for (String key : props.stringPropertyNames().stream().sorted().toList()) {
                 writer.write(key + "=" + props.getProperty(key) + "\n");
             }
         }
-        
+
         // Create data/siteConfig.yml
-        String siteConfigYaml = createSiteConfigYaml(configYaml, cnameContent);
-        Path dataDir = projectDir.resolve("data");
+        String siteConfigYaml = createSiteConfigYaml(config, cnameContent);
+        Path dataDir = projectDir.resolve(DATA_DIR);
         Files.createDirectories(dataDir);
-        Path siteConfigFile = dataDir.resolve(DATA_NAME + ".yml");
+        Path siteConfigFile = dataDir.resolve(SITE_CONFIG_FILE);
         Files.writeString(siteConfigFile, siteConfigYaml);
+
+        // Move Jekyll collection directories (_<name>) to Roq content/<name>
+        moveCollectionDirectories(projectDir, config);
+
+        // Add site description to index page frontmatter (Roq reads site.description from there)
+        if (config.has("description")) {
+            addDescriptionToIndexPage(projectDir, config.get("description").asText());
+        }
     }
 
-    private void copyIfPresent(JsonNode source, Map<String, Object> target, String key) {
-        if (source.has(key)) {
-            JsonNode value = source.get(key);
-            if (value.isTextual()) {
-                target.put(key, value.asText());
-            } else if (value.isNumber()) {
-                target.put(key, value.numberValue());
-            } else if (value.isBoolean()) {
-                target.put(key, value.asBoolean());
-            } else if (value.isObject() || value.isArray()) {
+    void moveCollectionDirectories(Path projectDir, JsonNode config) throws IOException {
+        if (!config.has(COLLECTIONS)) {
+            return;
+        }
+        JsonNode collections = config.get(COLLECTIONS);
+        if (!collections.isObject()) {
+            return;
+        }
+        Path contentDir = projectDir.resolve("content");
+        List<String> failures = new ArrayList<>();
+        collections.fieldNames().forEachRemaining(name -> {
+            if (DEFAULT_COLLECTION_NAME.equals(name)) {
+                return;
+            }
+            Path source = projectDir.resolve("_" + name);
+            if (Files.isDirectory(source)) {
+                Path target = contentDir.resolve(name);
                 try {
-                    target.put(key, objectMapper.convertValue(value, Object.class));
-                } catch (IllegalArgumentException e) {
-                    // Skip if conversion fails
+                    Files.createDirectories(target.getParent());
+                    Files.move(source, target);
+                } catch (IOException e) {
+                    failures.add("Failed to move _" + name + " to content/" + name + ": " + e.getMessage());
+                }
+            }
+        });
+        if (!failures.isEmpty()) {
+            throw new IOException("Collection directory migration failed:\n  " + String.join("\n  ", failures));
+        }
+    }
+
+    void addDescriptionToIndexPage(Path projectDir, String description) throws IOException {
+        Path indexFile = findIndexFile(projectDir);
+        if (indexFile == null) {
+            return;
+        }
+        String content = Files.readString(indexFile);
+        if (content.contains("description:")) {
+            return;
+        }
+        // Insert description after the opening --- (handle both LF and CRLF line endings)
+        String escapedDescription = description.replace("\\", "\\\\").replace("\"", "\\\"");
+        content = content.replaceFirst("(---\\s*(?:\\r\\n|\\n))", "$1description: \"" +
+                escapedDescription + "\"\n");
+        Files.writeString(indexFile, content);
+    }
+
+    private Path findIndexFile(Path projectDir) {
+        for (String dir : new String[] { "", "content" }) {
+            for (String name : new String[] { "index.md", "index.html", "index.adoc" }) {
+                Path p = projectDir.resolve(dir).resolve(name);
+                if (Files.exists(p)) {
+                    return p;
                 }
             }
         }
+        return null;
+    }
+
+    private boolean hasPlugin(JsonNode config, String pluginName) {
+        if (config == null || !config.has("plugins")) {
+            return false;
+        }
+        JsonNode plugins = config.get("plugins");
+        if (!plugins.isArray()) {
+            return false;
+        }
+        for (JsonNode plugin : plugins) {
+            if (pluginName.equals(plugin.asText())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void addAsciidoctorAttributes(JsonNode config, Properties properties) {
+        if (config == null || !config.has("asciidoctor")) {
+            return;
+        }
+        JsonNode asciidoctor = config.get("asciidoctor");
+        if (!asciidoctor.has("attributes")) {
+            return;
+        }
+        JsonNode attributes = asciidoctor.get("attributes");
+        if (!attributes.isObject()) {
+            return;
+        }
+        attributes.fields().forEachRemaining(entry -> {
+            String value = entry.getValue().asText();
+            if (!value.isEmpty()) {
+                properties.setProperty("quarkus.asciidoc.attributes." + entry.getKey(), value);
+            }
+        });
+    }
+
+    private void addCollectionProperties(JsonNode config, Properties properties) {
+        Map<String, String> permalinks = getCollectionPermalinks(config);
+
+        if (config != null && config.has(COLLECTIONS)) {
+            JsonNode collections = config.get(COLLECTIONS);
+            if (collections.isObject()) {
+                collections.fields().forEachRemaining(entry -> {
+                    String name = entry.getKey();
+                    if (DEFAULT_COLLECTION_NAME.equals(name)) {
+                        return;
+                    }
+                    JsonNode collectionConfig = entry.getValue();
+                    boolean output = collectionConfig.isObject()
+                            && collectionConfig.has("output")
+                            && collectionConfig.get("output").asBoolean(false);
+                    if (!output) {
+                        return;
+                    }
+                    properties.setProperty("site.collections." + name, "true");
+                    if (collectionConfig.has("layout")) {
+                        properties.setProperty("site.collections." + name + ".layout",
+                                collectionConfig.get("layout").asText());
+                    } else {
+                        String defaultLayout = getDefaultLayout(config, name);
+                        if (defaultLayout != null) {
+                            properties.setProperty("site.collections." + name + ".layout", defaultLayout);
+                        }
+                    }
+                });
+            }
+        }
+
+        permalinks.forEach((name, linkTemplate) -> properties.setProperty("site.collections." + name + ".link", linkTemplate));
+    }
+
+    private Map<String, String> getCollectionPermalinks(JsonNode config) {
+        Map<String, String> result = new LinkedHashMap<>();
+        if (config == null || !config.has("defaults")) {
+            return result;
+        }
+        JsonNode defaults = config.get("defaults");
+        if (!defaults.isArray()) {
+            return result;
+        }
+        for (JsonNode entry : defaults) {
+            if (!entry.has("scope") || !entry.has("values")) {
+                continue;
+            }
+            JsonNode scope = entry.get("scope");
+            if (!scope.has("type")) {
+                continue;
+            }
+            String type = scope.get("type").asText();
+            JsonNode values = entry.get("values");
+            if (values.has("permalink")) {
+                String permalink = values.get("permalink").asText();
+                result.put(type, translatePermalinkPlaceholders(permalink));
+            }
+        }
+        return result;
+    }
+
+    static String translatePermalinkPlaceholders(String permalink) {
+        return permalink
+                .replace(":path", ":dir[1:]/:name")
+                .replace(":title", ":name")
+                .replace(":categories", ":collection");
+    }
+
+    private static final Set<String> SKIP_ESCAPE_COLLECTIONS = Set.of(DEFAULT_COLLECTION_NAME, "redirects");
+
+    private void addEscapedPages(JsonNode config, Properties properties) {
+        if (config == null || !config.has(COLLECTIONS)) {
+            return;
+        }
+        JsonNode collections = config.get(COLLECTIONS);
+        if (!collections.isObject()) {
+            return;
+        }
+        StringBuilder escaped = new StringBuilder();
+        collections.fieldNames().forEachRemaining(name -> {
+            if (SKIP_ESCAPE_COLLECTIONS.contains(name)) {
+                return;
+            }
+            if (!escaped.isEmpty()) {
+                escaped.append(",");
+            }
+            escaped.append(name).append("/**");
+        });
+        if (!escaped.isEmpty()) {
+            properties.setProperty("site.escaped-pages", escaped.toString());
+        }
+    }
+
+    private void addAutoAuthorProperties(JsonNode config, Properties properties) {
+        String layout = "author";
+        String dataName = "authors";
+
+        if (config != null && config.has("autopages")) {
+            JsonNode autopages = config.get("autopages");
+            if (autopages.has("authors")) {
+                JsonNode authors = autopages.get("authors");
+                if (authors.has("layouts") && authors.get("layouts").isArray()
+                        && authors.get("layouts").size() > 0) {
+                    layout = stripExtension(authors.get("layouts").get(0).asText());
+                }
+                if (authors.has("data")) {
+                    dataName = stripExtension(stripPath(authors.get("data").asText()));
+                }
+            }
+        }
+
+        properties.setProperty("site.collections.author.layout", layout);
+        properties.setProperty("site.collections.author.from-data.id-key", "_key");
+        properties.setProperty("site.collections.author.from-data.name", dataName);
+    }
+
+    private String stripExtension(String filename) {
+        int dot = filename.lastIndexOf('.');
+        return dot > 0 ? filename.substring(0, dot) : filename;
+    }
+
+    private String stripPath(String path) {
+        int slash = path.lastIndexOf('/');
+        return slash >= 0 ? path.substring(slash + 1) : path;
+    }
+
+    private String getDefaultLayout(JsonNode config, String collectionName) {
+        if (!config.has("defaults")) {
+            return null;
+        }
+        JsonNode defaults = config.get("defaults");
+        if (!defaults.isArray()) {
+            return null;
+        }
+        for (JsonNode entry : defaults) {
+            if (!entry.has("scope") || !entry.has("values")) {
+                continue;
+            }
+            JsonNode scope = entry.get("scope");
+            if (scope.has("type") && collectionName.equals(scope.get("type").asText())) {
+                JsonNode values = entry.get("values");
+                if (values.has("layout")) {
+                    return values.get("layout").asText();
+                }
+            }
+        }
+        return null;
+    }
+
+    private void copyIfPresent(JsonNode source, Map<String, Object> target, String key) {
+        copyIfPresent(source, target, key, key);
+    }
+
+    private void copyIfPresent(JsonNode source, Map<String, Object> target, String sourceKey, String targetKey) {
+        if (source.has(sourceKey)) {
+            JsonNode value = source.get(sourceKey);
+            if (value.isTextual()) {
+                target.put(targetKey, value.asText());
+            } else if (value.isNumber()) {
+                target.put(targetKey, value.numberValue());
+            } else if (value.isBoolean()) {
+                target.put(targetKey, value.asBoolean());
+            } else if (value.isObject() || value.isArray()) {
+                try {
+                    target.put(targetKey, objectMapper.convertValue(value, Object.class));
+                } catch (IllegalArgumentException e) {
+                    System.err
+                            .println("Warning: could not convert config value for key '" + sourceKey + "': " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    static String hyphenToCamelCase(String key) {
+        if (!key.contains("-")) {
+            return key;
+        }
+        StringBuilder sb = new StringBuilder();
+        boolean capitalizeNext = false;
+        for (char c : key.toCharArray()) {
+            if (c == '-') {
+                capitalizeNext = true;
+            } else if (capitalizeNext) {
+                sb.append(Character.toUpperCase(c));
+                capitalizeNext = false;
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 }

--- a/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
@@ -11,6 +11,8 @@ import java.util.regex.Pattern;
 
 public class LiquidToQuteConverter {
 
+    public static final String DATA_NAME = "siteConfig";
+    private static final String CDI_REFERENCE = "cdi:" + DATA_NAME;
     private final boolean useExtensionSyntax;
     private final String exprOpen;
     private final List<String> conversionsApplied = new ArrayList<>();
@@ -218,11 +220,11 @@ public class LiquidToQuteConverter {
     private String convertUrlFilters(String content) {
         // Jekyll's | relative_url prepends site.baseurl to a path.
         // Rewrite as | prepend: so the concatenation filter handles the expression walk.
-        content = content.replaceAll("\\|\\s*relative_url", "| prepend: cdi:siteConfig.baseurl");
+        content = content.replaceAll("\\|\\s*relative_url", "| prepend: " + CDI_REFERENCE + ".baseurl");
         // TODO: absolute_url should prepend site.url + site.baseurl, but chaining two prepends
         // interacts badly with convertUrlConcatenation's site.url.resolve() transform.
         // For now, treat same as relative_url (sufficient when site.url is not needed).
-        content = content.replaceAll("\\|\\s*absolute_url", "| prepend: cdi:siteConfig.baseurl");
+        content = content.replaceAll("\\|\\s*absolute_url", "| prepend: " + CDI_REFERENCE + ".baseurl");
         return content;
     }
 
@@ -1490,7 +1492,7 @@ public class LiquidToQuteConverter {
 
         Pattern pattern = Pattern.compile(
                 "\\bsite\\.((?!(?:" + knownSiteProps + ")\\b)[a-zA-Z_][a-zA-Z0-9_]*)\\b");
-        String result = pattern.matcher(content).replaceAll("cdi:siteConfig.$1");
+        String result = pattern.matcher(content).replaceAll(CDI_REFERENCE + ".$1");
 
         if (!result.equals(content)) {
             conversionsApplied.add("Converted site data properties to CDI references");
@@ -1649,19 +1651,19 @@ public class LiquidToQuteConverter {
 
         // Add a warning comment at the start of the body
         String warning = "\n{! TODO: site.tags not available in Roq by default.\n" +
-                "   The tag listing feature is currently disabled (replaced with cdi:siteConfig.tags=[]).\n" +
+                "   The tag listing feature is currently disabled (replaced with " + CDI_REFERENCE + ".tags=[]).\n" +
                 "   Options to restore functionality:\n" +
                 "   (1) Use collection.tagsCount() for a specific collection,\n" +
                 "   (2) Add a site.tags extension method, or\n" +
                 "   (3) Remove the tag listing feature entirely.\n" +
                 "   See migration implementation notes for details. !}\n";
 
-        // Replace all site.tags with cdi:siteConfig.tags (which is an empty list)
-        body = pattern.matcher(body).replaceAll("cdi:siteConfig.tags");
+        // Replace all site.tags with " + CDI_REFERENCE + ".tags (which is an empty list)
+        body = pattern.matcher(body).replaceAll(CDI_REFERENCE + ".tags");
 
         String result = frontmatter + warning + body;
 
-        conversionsApplied.add("Replaced site.tags with cdi:siteConfig.tags (needs manual implementation)");
+        conversionsApplied.add("Replaced site.tags with " + CDI_REFERENCE + ".tags (needs manual implementation)");
 
         return result;
     }

--- a/migration/src/test/java/io/quarkus/tools/JekyllConfigConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/JekyllConfigConverterTest.java
@@ -1,18 +1,20 @@
 package io.quarkus.tools;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
 import java.util.Properties;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JekyllConfigConverterTest {
 
@@ -32,12 +34,34 @@ class JekyllConfigConverterTest {
         assertTrue(props.containsKey("site.date-format"));
         assertTrue(props.containsKey("quarkus.qute.strict-rendering"));
         assertTrue(props.containsKey("quarkus.qute.type-check-excludes"));
-        assertTrue("true".equals(props.getProperty("quarkus.qute.alt-expr-syntax")));
-        assertTrue("yyyy-MM-dd['T'HH:mm:ss][X]".equals(props.getProperty("site.date-format")));
-        assertTrue("false".equals(props.getProperty("quarkus.qute.strict-rendering")));
+        assertEquals("true", props.getProperty("quarkus.qute.alt-expr-syntax"));
+        assertEquals("yyyy-MM-dd['T'HH:mm:ss][X]", props.getProperty("site.date-format"));
+        assertEquals("false", props.getProperty("quarkus.qute.strict-rendering"));
         assertTrue(props.getProperty("quarkus.qute.type-check-excludes").contains("java.lang.Object.*"));
         assertTrue(props.getProperty("quarkus.qute.type-check-excludes")
                 .contains("io.quarkiverse.roq.frontmatter.runtime.model.Page.paginator"));
+        assertTrue(props.containsKey("quarkus.web-bundler.bundling.external"));
+        assertTrue(props.getProperty("quarkus.web-bundler.bundling.external").contains("/assets/*"));
+        assertEquals("NOOP", props.getProperty("quarkus.qute.property-not-found-strategy"));
+    }
+
+    @Test
+    void testSiteUrlFromJekyllConfig() throws IOException {
+        String configYaml = """
+                url: https://example.com
+                """;
+        Properties props = converter.createApplicationProperties(
+                new com.fasterxml.jackson.dataformat.yaml.YAMLMapper().readTree(configYaml));
+        assertEquals("https://example.com", props.getProperty("site.url"),
+                "Jekyll url should map to site.url in application.properties");
+    }
+
+    @Test
+    void testStrictPropertiesOmitsOutputOriginal() {
+        converter.setStrictProperties(true);
+        Properties props = converter.createApplicationProperties();
+        assertFalse(props.containsKey("quarkus.qute.property-not-found-strategy"),
+                "strict mode should not set property-not-found-strategy (defaults to THROW)");
     }
 
     @Test
@@ -69,16 +93,22 @@ class JekyllConfigConverterTest {
                   host: https://search.example.com
                   script-path: /search.js
                   cached-script-file: search-cached.js
+                  initial-timeout: 1500
+                  more-timeout: 2500
+                  min-chars: 2
                 """;
 
         String siteConfigYaml = converter.createSiteConfigYaml(configYaml, null);
 
         assertNotNull(siteConfigYaml);
         assertTrue(siteConfigYaml.contains("search:"));
-        assertTrue(siteConfigYaml.contains("script-mode: \"defer\""));
+        assertTrue(siteConfigYaml.contains("scriptMode: \"defer\""));
         assertTrue(siteConfigYaml.contains("host: \"https://search.example.com\""));
-        assertTrue(siteConfigYaml.contains("script-path: \"/search.js\""));
-        assertTrue(siteConfigYaml.contains("cached-script-file: \"search-cached.js\""));
+        assertTrue(siteConfigYaml.contains("scriptPath: \"/search.js\""));
+        assertTrue(siteConfigYaml.contains("cachedScriptFile: \"search-cached.js\""));
+        assertTrue(siteConfigYaml.contains("initialTimeout: 1500"));
+        assertTrue(siteConfigYaml.contains("moreTimeout: 2500"));
+        assertTrue(siteConfigYaml.contains("minChars: 2"));
     }
 
     @Test
@@ -92,6 +122,22 @@ class JekyllConfigConverterTest {
 
         assertNotNull(siteConfigYaml);
         assertTrue(siteConfigYaml.contains("cname: \"\""));
+    }
+
+    @Test
+    void testSiteConfigYamlWithFeedAndAuthor() throws IOException {
+        String configYaml = """
+                title: My Site
+                author: janedoe
+                feed:
+                  posts_limit: 50
+                """;
+
+        String siteConfigYaml = converter.createSiteConfigYaml(configYaml, null);
+
+        assertTrue(siteConfigYaml.contains("author: \"janedoe\""));
+        assertTrue(siteConfigYaml.contains("feed:"));
+        assertTrue(siteConfigYaml.contains("posts_limit: 50"));
     }
 
     @Test
@@ -120,6 +166,7 @@ class JekyllConfigConverterTest {
         assertTrue(propsContent.contains("quarkus.qute.alt-expr-syntax=true"));
         assertTrue(propsContent.contains("site.date-format=yyyy-MM-dd['T'HH:mm:ss][X]"));
         assertTrue(propsContent.contains("quarkus.qute.strict-rendering=false"));
+        assertTrue(propsContent.contains("quarkus.qute.property-not-found-strategy=NOOP"));
         assertTrue(propsContent.contains("quarkus.qute.type-check-excludes="));
 
         // Verify siteConfig.yml was created
@@ -131,6 +178,51 @@ class JekyllConfigConverterTest {
         assertTrue(siteConfigContent.contains("baseurl: \"/test\""));
         assertTrue(siteConfigContent.contains("language: \"en\""));
         assertTrue(siteConfigContent.contains("twitter_username: \"testuser\""));
+    }
+
+    @Test
+    void testConvertProjectAddsDescriptionToIndexPage(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                description: Supersonic Subatomic Java
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+        Files.writeString(tempDir.resolve("index.md"), """
+                ---
+                layout: index
+                title: My Site
+                ---
+                Hello
+                """);
+
+        converter.convertProject(tempDir);
+
+        String indexContent = Files.readString(tempDir.resolve("index.md"));
+        assertTrue(indexContent.contains("description: \"Supersonic Subatomic Java\""),
+                "Index page should have description from _config.yml: " + indexContent);
+    }
+
+    @Test
+    void testConvertProjectAddsDescriptionToIndexPageInContentDir(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                description: Supersonic Subatomic Java
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+        Files.createDirectories(tempDir.resolve("content"));
+        Files.writeString(tempDir.resolve("content/index.md"), """
+                ---
+                layout: index
+                title: My Site
+                ---
+                Hello
+                """);
+
+        converter.convertProject(tempDir);
+
+        String indexContent = Files.readString(tempDir.resolve("content/index.md"));
+        assertTrue(indexContent.contains("description: \"Supersonic Subatomic Java\""),
+                "Index page in content/ should have description from _config.yml: " + indexContent);
     }
 
     @Test
@@ -177,6 +269,476 @@ class JekyllConfigConverterTest {
     }
 
     @Test
+    void testAutoAuthorPluginAddsCollectionProperties(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                plugins:
+                  - jekyll-feed
+                  - jekyll-auto-authors
+                autopages:
+                  authors:
+                    enabled: true
+                    data: '_data/authors.yaml'
+                    layouts:
+                      - 'author.html'
+                    permalink: '/author/:author/'
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertTrue(propsContent.contains("site.collections.author.layout=author"));
+        assertTrue(propsContent.contains("site.collections.author.from-data.id-key=_key"));
+        assertTrue(propsContent.contains("site.collections.author.from-data.name=authors"));
+    }
+
+    @Test
+    void testAutoAuthorPluginWithCustomDataFile(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                plugins:
+                  - jekyll-auto-authors
+                autopages:
+                  authors:
+                    enabled: true
+                    data: '_data/contributors.yml'
+                    layouts:
+                      - 'contributor-page.html'
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertTrue(propsContent.contains("site.collections.author.layout=contributor-page"));
+        assertTrue(propsContent.contains("site.collections.author.from-data.name=contributors"));
+        assertTrue(propsContent.contains("site.collections.author.from-data.id-key=_key"));
+    }
+
+    @Test
+    void testAutoAuthorPluginWithoutAutopagesConfig(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                plugins:
+                  - jekyll-auto-authors
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertTrue(propsContent.contains("site.collections.author.layout=author"));
+        assertTrue(propsContent.contains("site.collections.author.from-data.name=authors"));
+    }
+
+    @Test
+    void testNoAutoAuthorPluginOmitsCollectionProperties(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                plugins:
+                  - jekyll-feed
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertFalse(propsContent.contains("site.collections.author"));
+    }
+
+    @Test
+    void testCollectionsWithOutputTrueGeneratesProperties(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                collections:
+                  guides:
+                    output: true
+                  redirects:
+                    output: true
+                  versions:
+                    output: true
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertTrue(propsContent.contains("site.collections.guides=true"),
+                "Should have guides collection: " + propsContent);
+        assertTrue(propsContent.contains("site.collections.redirects=true"),
+                "Should have redirects collection: " + propsContent);
+        assertTrue(propsContent.contains("site.collections.versions=true"),
+                "Should have versions collection: " + propsContent);
+    }
+
+    @Test
+    void testCollectionsWithoutOutputAreSkipped(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                collections:
+                  drafts:
+                    output: false
+                  internal:
+                    foo: bar
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertFalse(propsContent.contains("site.collections.drafts"),
+                "Should not have drafts collection: " + propsContent);
+        assertFalse(propsContent.contains("site.collections.internal"),
+                "Should not have internal collection: " + propsContent);
+    }
+
+    @Test
+    void testCollectionsSkipsPosts(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                collections:
+                  posts:
+                    output: true
+                  guides:
+                    output: true
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertFalse(propsContent.contains("site.collections.posts"),
+                "Should not emit posts collection (Roq built-in): " + propsContent);
+        assertTrue(propsContent.contains("site.collections.guides=true"),
+                "Should have guides collection: " + propsContent);
+    }
+
+    @Test
+    void testCollectionWithLayoutGeneratesLayoutProperty(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                collections:
+                  guides:
+                    output: true
+                    layout: guide
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertTrue(propsContent.contains("site.collections.guides=true"),
+                "Should have guides collection: " + propsContent);
+        assertTrue(propsContent.contains("site.collections.guides.layout=guide"),
+                "Should have guides layout: " + propsContent);
+    }
+
+    @Test
+    void testConvertProjectMovesCollectionDirectories(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                collections:
+                  guides:
+                    output: true
+                  versions:
+                    output: true
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        Files.createDirectories(tempDir.resolve("_guides"));
+        Files.writeString(tempDir.resolve("_guides/getting-started.adoc"), "= Getting Started");
+        Files.createDirectories(tempDir.resolve("_versions/main"));
+        Files.writeString(tempDir.resolve("_versions/main/index.md"), "---\ntitle: Main\n---");
+
+        converter.convertProject(tempDir);
+
+        assertTrue(Files.exists(tempDir.resolve("content/guides/getting-started.adoc")),
+                "guides should be moved to content/guides");
+        assertTrue(Files.exists(tempDir.resolve("content/versions/main/index.md")),
+                "versions should be moved to content/versions");
+        assertFalse(Files.exists(tempDir.resolve("_guides")),
+                "_guides should no longer exist");
+        assertFalse(Files.exists(tempDir.resolve("_versions")),
+                "_versions should no longer exist");
+    }
+
+    @Test
+    void testConvertProjectDoesNotMovePostsDirectory(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                collections:
+                  posts:
+                    output: true
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+        Files.createDirectories(tempDir.resolve("_posts"));
+        Files.writeString(tempDir.resolve("_posts/2024-01-01-hello.md"), "---\ntitle: Hello\n---");
+
+        converter.convertProject(tempDir);
+
+        assertTrue(Files.exists(tempDir.resolve("_posts/2024-01-01-hello.md")),
+                "_posts should NOT be moved by the converter (handled by roq-it-jekyll)");
+    }
+
+    @Test
+    void testCollectionLayoutFromDefaults(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                collections:
+                  guides:
+                    output: true
+                  redirects:
+                    output: true
+                  versions:
+                    output: true
+                defaults:
+                  - scope:
+                      type: guides
+                    values:
+                      layout: guides
+                  - scope:
+                      type: versions
+                    values:
+                      layout: guides
+                  - scope:
+                      type: redirects
+                    values:
+                      layout: redirect
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertTrue(propsContent.contains("site.collections.guides.layout=guides"),
+                "Should pick up guides layout from defaults: " + propsContent);
+        assertTrue(propsContent.contains("site.collections.redirects.layout=redirect"),
+                "Should pick up redirect layout from defaults: " + propsContent);
+        assertTrue(propsContent.contains("site.collections.versions.layout=guides"),
+                "Should pick up versions layout from defaults: " + propsContent);
+    }
+
+    @Test
+    void testCollectionLinkFromPermalink(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                collections:
+                  guides:
+                    output: true
+                  versions:
+                    output: true
+                defaults:
+                  - scope:
+                      type: guides
+                    values:
+                      layout: guides
+                      permalink: /guides/:name
+                  - scope:
+                      type: versions
+                    values:
+                      layout: guides
+                      permalink: /version/:path
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertTrue(propsContent.contains("site.collections.guides.link=/guides/:name"),
+                "Should translate guides permalink to link: " + propsContent);
+        assertTrue(propsContent.contains("site.collections.versions.link=/version/:dir[1:]/:name"),
+                "Should translate versions permalink to link with :dir[1:]/:name: " + propsContent);
+    }
+
+    @Test
+    void testCollectionLinkTranslatesJekyllPlaceholders(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                collections:
+                  posts:
+                    output: true
+                defaults:
+                  - scope:
+                      type: posts
+                    values:
+                      layout: post
+                      permalink: /blog/:title/
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertFalse(propsContent.contains("site.collections.posts="),
+                "Posts should not be enabled as a collection: " + propsContent);
+        assertTrue(propsContent.contains("site.collections.posts.link=/blog/:name/"),
+                "Posts permalink should be translated to link: " + propsContent);
+    }
+
+    @Test
+    void testCollectionLayoutFromConfigOverridesDefaults(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                collections:
+                  guides:
+                    output: true
+                    layout: custom
+                defaults:
+                  - scope:
+                      type: guides
+                    values:
+                      layout: guides
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertTrue(propsContent.contains("site.collections.guides.layout=custom"),
+                "Collection-level layout should take precedence over defaults: " + propsContent);
+    }
+
+    @Test
+    void testSiteConfigYamlWithPublication() throws IOException {
+        String configYaml = """
+                title: My Site
+                publication:
+                  group_by: type
+                  sort_by: date
+                  type_names:
+                    article: Article & Blogs
+                    podcast: Podcasts
+                    video: Videos
+                    training: Training
+                    book: Books
+                """;
+
+        String siteConfigYaml = converter.createSiteConfigYaml(configYaml, null);
+
+        assertTrue(siteConfigYaml.contains("publication:"));
+        assertTrue(siteConfigYaml.contains("group_by: \"type\""));
+        assertTrue(siteConfigYaml.contains("type_names:"));
+        assertTrue(siteConfigYaml.contains("article: \"Article & Blogs\""));
+        assertTrue(siteConfigYaml.contains("video: \"Videos\""));
+    }
+
+    @Test
+    void testSiteConfigYamlCopiesUnknownTopLevelKeys() throws IOException {
+        String configYaml = """
+                title: My Site
+                baseurl: /blog
+                custom_setting: some_value
+                nested_custom:
+                  key1: val1
+                  key2: val2
+                """;
+
+        String siteConfigYaml = converter.createSiteConfigYaml(configYaml, null);
+
+        assertTrue(siteConfigYaml.contains("custom_setting: \"some_value\""),
+                "Unknown simple config should be copied: " + siteConfigYaml);
+        assertTrue(siteConfigYaml.contains("nested_custom:"),
+                "Unknown nested config should be copied: " + siteConfigYaml);
+        assertTrue(siteConfigYaml.contains("key1: \"val1\""),
+                "Nested values should be preserved: " + siteConfigYaml);
+    }
+
+    @Test
+    void testSiteConfigYamlDoesNotCopyHandledKeys() throws IOException {
+        String configYaml = """
+                title: My Site
+                url: https://example.com
+                collections:
+                  posts:
+                    output: true
+                plugins:
+                  - jekyll-feed
+                defaults:
+                  - scope:
+                      type: guides
+                    values:
+                      layout: guide
+                description: A site
+                custom: should_be_copied
+                """;
+
+        String siteConfigYaml = converter.createSiteConfigYaml(configYaml, null);
+
+        assertFalse(siteConfigYaml.contains("url:"),
+                "url is handled by application.properties, not siteConfig: " + siteConfigYaml);
+        assertFalse(siteConfigYaml.contains("collections:"),
+                "collections is handled by application.properties: " + siteConfigYaml);
+        assertFalse(siteConfigYaml.contains("plugins:"),
+                "plugins is handled by application.properties: " + siteConfigYaml);
+        assertFalse(siteConfigYaml.contains("defaults:"),
+                "defaults is handled by application.properties: " + siteConfigYaml);
+        assertFalse(siteConfigYaml.contains("description:"),
+                "description goes to index page frontmatter: " + siteConfigYaml);
+        assertTrue(siteConfigYaml.contains("custom: \"should_be_copied\""),
+                "Unknown keys should be copied: " + siteConfigYaml);
+    }
+
+    @Test
+    void testCnameWithWhitespace() throws IOException {
+        String configYaml = """
+                title: Test Site
+                """;
+        String siteConfigYaml = converter.createSiteConfigYaml(configYaml, "  example.com\n");
+        assertTrue(siteConfigYaml.contains("cname: \"example.com\""),
+                "CNAME should be trimmed: " + siteConfigYaml);
+    }
+
+    @Test
+    void testUnsetsShowtitleToPreventDuplicateTitles() {
+        Properties props = converter.createApplicationProperties();
+        assertEquals("true", props.getProperty("quarkus.asciidoc.attributes.\"!showtitle\""),
+                "Should unset showtitle to prevent duplicate title rendering (layout renders page.title, "
+                        + "so the AsciiDoc body must not also render it)");
+    }
+
+    @Test
+    void testAsciidoctorAttributesMappedToQuarkusProperties() throws IOException {
+        String configYaml = """
+                title: Test Site
+                asciidoctor:
+                  base_dir: :docdir
+                  safe: unsafe
+                  attributes:
+                    source-highlighter: highlightjs
+                    sectanchors: ''
+                    icons: font
+                    outfilesuffix: ''
+                """;
+        Properties props = converter.createApplicationProperties(
+                new com.fasterxml.jackson.dataformat.yaml.YAMLMapper().readTree(configYaml));
+        assertEquals("font", props.getProperty("quarkus.asciidoc.attributes.icons"),
+                "Jekyll asciidoctor.attributes.icons should map to quarkus.asciidoc.attributes.icons");
+        assertEquals("highlightjs", props.getProperty("quarkus.asciidoc.attributes.source-highlighter"),
+                "Jekyll asciidoctor.attributes.source-highlighter should map to quarkus.asciidoc.attributes.source-highlighter");
+        assertNull(props.getProperty("quarkus.asciidoc.attributes.sectanchors"),
+                "Empty-string attributes should be skipped (SmallRye Config rejects empty map values)");
+        assertNull(props.getProperty("quarkus.asciidoc.attributes.outfilesuffix"),
+                "Empty-string attributes should be skipped");
+    }
+
+    @Test
+    void testAsciidoctorAttributesNotCopiedToSiteConfig() throws IOException {
+        String configYaml = """
+                title: Test Site
+                asciidoctor:
+                  attributes:
+                    icons: font
+                custom: keep_me
+                """;
+        String siteConfigYaml = converter.createSiteConfigYaml(configYaml, null);
+        assertFalse(siteConfigYaml.contains("asciidoctor"),
+                "asciidoctor config should not appear in siteConfig (handled by application.properties): " + siteConfigYaml);
+        assertTrue(siteConfigYaml.contains("custom: \"keep_me\""),
+                "Other unknown keys should still be copied: " + siteConfigYaml);
+    }
+
+    @Test
     void testComplexNestedConfig() throws IOException {
         String configYaml = """
                 title: Complex Site
@@ -202,6 +764,6 @@ class JekyllConfigConverterTest {
         assertTrue(siteConfigYaml.contains("twitter_username: \"johndoe\""));
         assertTrue(siteConfigYaml.contains("github_username: \"johndoe\""));
         assertTrue(siteConfigYaml.contains("search:"));
-        assertTrue(siteConfigYaml.contains("script-mode: \"defer\""));
+        assertTrue(siteConfigYaml.contains("scriptMode: \"defer\""));
     }
 }

--- a/migration/src/test/java/io/quarkus/tools/JekyllConfigConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/JekyllConfigConverterTest.java
@@ -1,0 +1,207 @@
+package io.quarkus.tools;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JekyllConfigConverterTest {
+
+    private JekyllConfigConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        converter = new JekyllConfigConverter();
+    }
+
+    @Test
+    void testCreateApplicationProperties() {
+        Properties props = converter.createApplicationProperties();
+
+        assertNotNull(props);
+        assertTrue(props.containsKey("quarkus.qute.alt-expr-syntax"));
+        assertTrue(props.containsKey("site.date-format"));
+        assertTrue(props.containsKey("quarkus.qute.strict-rendering"));
+        assertTrue(props.containsKey("quarkus.qute.type-check-excludes"));
+        assertTrue("true".equals(props.getProperty("quarkus.qute.alt-expr-syntax")));
+        assertTrue("yyyy-MM-dd['T'HH:mm:ss][X]".equals(props.getProperty("site.date-format")));
+        assertTrue("false".equals(props.getProperty("quarkus.qute.strict-rendering")));
+        assertTrue(props.getProperty("quarkus.qute.type-check-excludes").contains("java.lang.Object.*"));
+        assertTrue(props.getProperty("quarkus.qute.type-check-excludes")
+                .contains("io.quarkiverse.roq.frontmatter.runtime.model.Page.paginator"));
+    }
+
+    @Test
+    void testSiteConfigYamlBasic() throws IOException {
+        String configYaml = """
+                title: My Jekyll Site
+                baseurl: /blog
+                language: en
+                twitter_username: johndoe
+                """;
+        String cname = "example.com";
+
+        String siteConfigYaml = converter.createSiteConfigYaml(configYaml, cname);
+
+        assertNotNull(siteConfigYaml);
+        assertTrue(siteConfigYaml.contains("cname: \"example.com\""));
+        assertTrue(siteConfigYaml.contains("baseurl: \"/blog\""));
+        assertTrue(siteConfigYaml.contains("language: \"en\""));
+        assertTrue(siteConfigYaml.contains("twitter_username: \"johndoe\""));
+        assertTrue(siteConfigYaml.contains("tags: []"));
+    }
+
+    @Test
+    void testSiteConfigYamlWithNestedSearch() throws IOException {
+        String configYaml = """
+                title: My Site
+                search:
+                  script-mode: defer
+                  host: https://search.example.com
+                  script-path: /search.js
+                  cached-script-file: search-cached.js
+                """;
+
+        String siteConfigYaml = converter.createSiteConfigYaml(configYaml, null);
+
+        assertNotNull(siteConfigYaml);
+        assertTrue(siteConfigYaml.contains("search:"));
+        assertTrue(siteConfigYaml.contains("script-mode: \"defer\""));
+        assertTrue(siteConfigYaml.contains("host: \"https://search.example.com\""));
+        assertTrue(siteConfigYaml.contains("script-path: \"/search.js\""));
+        assertTrue(siteConfigYaml.contains("cached-script-file: \"search-cached.js\""));
+    }
+
+    @Test
+    void testSiteConfigYamlWithoutCname() throws IOException {
+        String configYaml = """
+                title: My Site
+                baseurl: /blog
+                """;
+
+        String siteConfigYaml = converter.createSiteConfigYaml(configYaml, null);
+
+        assertNotNull(siteConfigYaml);
+        assertTrue(siteConfigYaml.contains("cname: \"\""));
+    }
+
+    @Test
+    void testConvertProjectCreatesFiles(@TempDir Path tempDir) throws IOException {
+        // Create _config.yml
+        String configYaml = """
+                title: Test Site
+                description: A test Jekyll site
+                baseurl: /test
+                language: en
+                twitter_username: testuser
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        // Create CNAME
+        Files.writeString(tempDir.resolve("CNAME"), "test.example.com");
+
+        // Run conversion
+        converter.convertProject(tempDir);
+
+        // Verify application.properties was created
+        Path propsFile = tempDir.resolve("config/application.properties");
+        assertTrue(Files.exists(propsFile), "application.properties should be created");
+
+        String propsContent = Files.readString(propsFile);
+        assertTrue(propsContent.contains("quarkus.qute.alt-expr-syntax=true"));
+        assertTrue(propsContent.contains("site.date-format=yyyy-MM-dd['T'HH:mm:ss][X]"));
+        assertTrue(propsContent.contains("quarkus.qute.strict-rendering=false"));
+        assertTrue(propsContent.contains("quarkus.qute.type-check-excludes="));
+
+        // Verify siteConfig.yml was created
+        Path siteConfigFile = tempDir.resolve("data/siteConfig.yml");
+        assertTrue(Files.exists(siteConfigFile), "data/siteConfig.yml should be created");
+
+        String siteConfigContent = Files.readString(siteConfigFile);
+        assertTrue(siteConfigContent.contains("cname: \"test.example.com\""));
+        assertTrue(siteConfigContent.contains("baseurl: \"/test\""));
+        assertTrue(siteConfigContent.contains("language: \"en\""));
+        assertTrue(siteConfigContent.contains("twitter_username: \"testuser\""));
+    }
+
+    @Test
+    void testConvertProjectWithoutCname(@TempDir Path tempDir) throws IOException {
+        // Create _config.yml only
+        String configYaml = """
+                title: Test Site
+                baseurl: /test
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        // Run conversion (no CNAME file)
+        converter.convertProject(tempDir);
+
+        // Verify files were created
+        assertTrue(Files.exists(tempDir.resolve("config/application.properties")));
+        assertTrue(Files.exists(tempDir.resolve("data/siteConfig.yml")));
+
+        // Verify CNAME is empty in siteConfig
+        String siteConfigContent = Files.readString(tempDir.resolve("data/siteConfig.yml"));
+        assertTrue(siteConfigContent.contains("cname: \"\""));
+    }
+
+    @Test
+    void testConvertProjectThrowsExceptionWhenConfigMissing(@TempDir Path tempDir) {
+        // No _config.yml file
+        IOException exception = assertThrows(IOException.class, () -> {
+            converter.convertProject(tempDir);
+        });
+
+        assertTrue(exception.getMessage().contains("_config.yml not found"));
+    }
+
+    @Test
+    void testGithubUsername() throws IOException {
+        String configYaml = """
+                title: My Site
+                github_username: octocat
+                """;
+
+        String siteConfigYaml = converter.createSiteConfigYaml(configYaml, null);
+
+        assertTrue(siteConfigYaml.contains("github_username: \"octocat\""));
+    }
+
+    @Test
+    void testComplexNestedConfig() throws IOException {
+        String configYaml = """
+                title: Complex Site
+                baseurl: /blog
+                url: https://example.com
+                language: en
+                twitter_username: johndoe
+                github_username: johndoe
+                search:
+                  script-mode: defer
+                  host: https://search.example.com
+                  script-path: /search.js
+                  cached-script-file: search-cached.js
+                """;
+        String cname = "blog.example.com";
+
+        String siteConfigYaml = converter.createSiteConfigYaml(configYaml, cname);
+
+        // Verify siteConfig YAML
+        assertTrue(siteConfigYaml.contains("cname: \"blog.example.com\""));
+        assertTrue(siteConfigYaml.contains("baseurl: \"/blog\""));
+        assertTrue(siteConfigYaml.contains("language: \"en\""));
+        assertTrue(siteConfigYaml.contains("twitter_username: \"johndoe\""));
+        assertTrue(siteConfigYaml.contains("github_username: \"johndoe\""));
+        assertTrue(siteConfigYaml.contains("search:"));
+        assertTrue(siteConfigYaml.contains("script-mode: \"defer\""));
+    }
+}


### PR DESCRIPTION
This converter handles taking the Jekyll `_config.yml` and converting it into application.properties (for values which would be Roq config) and the `data/siteConfig.yml` used by the liquid converter.