### PR TITLE
Fix aliases to work with and without trailing slash

### DIFF
--- a/roq-plugin/aliases/deployment/src/main/java/io/quarkiverse/roq/plugin/aliases/deployment/RoqPluginAliasesProcessor.java
+++ b/roq-plugin/aliases/deployment/src/main/java/io/quarkiverse/roq/plugin/aliases/deployment/RoqPluginAliasesProcessor.java
@@ -5,6 +5,7 @@ import static io.quarkiverse.roq.plugin.aliases.runtime.RoqAliasesKeys.REDIRECT_
 import static io.quarkiverse.roq.plugin.aliases.runtime.RoqAliasesKeys.REDIRECT_FROM_HYPHEN;
 import static io.quarkiverse.tools.stringpaths.StringPaths.addTrailingSlash;
 import static io.quarkiverse.tools.stringpaths.StringPaths.prefixWithSlash;
+import static io.quarkiverse.tools.stringpaths.StringPaths.removeTrailingSlash;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -83,8 +84,14 @@ public class RoqPluginAliasesProcessor {
             BuildProducer<RouteBuildItem> routes,
             List<RoqFrontMatterAliasesBuildItem> aliases) {
         for (RoqFrontMatterAliasesBuildItem item : aliases) {
+            String withSlash = prefixWithSlash(addTrailingSlash(item.alias()));
+            String withoutSlash = prefixWithSlash(removeTrailingSlash(item.alias()));
             routes.produce(RouteBuildItem.builder()
-                    .route(prefixWithSlash(item.alias()))
+                    .route(withSlash)
+                    .handler(recorder.sendRedirectPage(item.target()))
+                    .build());
+            routes.produce(RouteBuildItem.builder()
+                    .route(withoutSlash)
                     .handler(recorder.sendRedirectPage(item.target()))
                     .build());
         }

--- a/roq-plugin/aliases/integration-tests/pom.xml
+++ b/roq-plugin/aliases/integration-tests/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.roq</groupId>
+        <artifactId>quarkus-roq-plugin-aliases-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-roq-plugin-aliases-integration-tests</artifactId>
+    <name>Quarkus Roq - Plugin - Aliases - Integration Tests</name>
+
+    <properties>
+        <skipITs>true</skipITs>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.roq</groupId>
+            <artifactId>quarkus-roq</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.roq</groupId>
+            <artifactId>quarkus-roq-plugin-aliases</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <systemPropertyVariables>
+                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <skipITs>false</skipITs>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/roq-plugin/aliases/integration-tests/src/main/resources/content/index.html
+++ b/roq-plugin/aliases/integration-tests/src/main/resources/content/index.html
@@ -1,0 +1,6 @@
+---
+title: Aliases Test Site
+layout: page
+---
+
+Aliases integration test site.

--- a/roq-plugin/aliases/integration-tests/src/main/resources/content/posts/alias-test.md
+++ b/roq-plugin/aliases/integration-tests/src/main/resources/content/posts/alias-test.md
@@ -1,0 +1,11 @@
+---
+title: Alias Test Post
+redirect_from:
+  - /old-post-url
+  - /legacy/nested-path
+aliases:
+  - /another-alias
+date: 2024-01-15
+---
+
+This post has aliases for testing.

--- a/roq-plugin/aliases/integration-tests/src/test/java/io/quarkiverse/roq/RoqAliasesTest.java
+++ b/roq-plugin/aliases/integration-tests/src/test/java/io/quarkiverse/roq/RoqAliasesTest.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.roq;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class RoqAliasesTest {
+
+    @Test
+    public void testAliasWithTrailingSlash() {
+        RestAssured.when().get("/old-post-url/").then().statusCode(200).log().ifValidationFails()
+                .body(containsString("Redirecting"));
+    }
+
+    @Test
+    public void testAliasWithoutTrailingSlash() {
+        RestAssured.when().get("/old-post-url").then().statusCode(200).log().ifValidationFails()
+                .body(containsString("Redirecting"));
+    }
+
+    @Test
+    public void testNestedAliasWithTrailingSlash() {
+        RestAssured.when().get("/legacy/nested-path/").then().statusCode(200).log().ifValidationFails()
+                .body(containsString("Redirecting"));
+    }
+
+    @Test
+    public void testNestedAliasWithoutTrailingSlash() {
+        RestAssured.when().get("/legacy/nested-path").then().statusCode(200).log().ifValidationFails()
+                .body(containsString("Redirecting"));
+    }
+
+    @Test
+    public void testAliasesKeyWithTrailingSlash() {
+        RestAssured.when().get("/another-alias/").then().statusCode(200).log().ifValidationFails()
+                .body(containsString("Redirecting"));
+    }
+
+    @Test
+    public void testAliasesKeyWithoutTrailingSlash() {
+        RestAssured.when().get("/another-alias").then().statusCode(200).log().ifValidationFails()
+                .body(containsString("Redirecting"));
+    }
+}

--- a/roq-plugin/aliases/pom.xml
+++ b/roq-plugin/aliases/pom.xml
@@ -15,5 +15,6 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
+        <module>integration-tests</module>
     </modules>
 </project>


### PR DESCRIPTION
Resolves https://github.com/quarkiverse/quarkus-roq/issues/986. What's in this change:
- Register both /alias/ and /alias routes for each alias so they work regardless of trailing slash. 
- Add integration tests for the aliases

**Diagnosis of the problem**

The reason we only registered the endpoint with a slash is because of `addTrailingSlashIfNoExt`. That's a method in `TemplateLink.linkInternal()` that normalizes page links. It adds a trailing slash to any path that doesn't have a file extension, so an alias like /old-post-url becomes /old-post-url/.

The problem is this normalization happens at build time when constructing the alias key, so by the time the route is registered, it's already  `/old-post-url/` — and only that route exists. A request to `/old-post-url` (without trailing slash) has no matching route and 404s. The normalization baked  in the trailing slash too early, and there was no corresponding handler for the un-normalized form.

This issue only affected aliases, because for normal endpoints, the static site generator produces files like old-post-url/index.html on disk. When a request comes in for /old-post-url (no trailing slash),  the static file serving layer sees the directory exists and serves the index.html from it — or Vert.x issues its 301 redirect to /old-post-url/ which then hits the file.

Aliases don't have actual files on disk; they're purely Vert.x route handlers. So there's no static file fallback, and the only thing that can respond is the registered route, which was only /old-post-url/.

**The fix**

The fix is simple; we just register both routes, with and without the slash. I didn't like how naive that felt, so I experimented with things in the alias-specific route handler to behave more like the normal-handler, but that didn't work so well. To make that option work, it had to give up registering individual aliases, and instead register a single wildcard handler, which seemed too scary. 

The Vert.x HTTP server issues a 301 redirect from /path to /path/ before any route handler runs — it happens at the HTTP server level, not the routing  level. I tried registering a debug handler at Integer.MIN_VALUE order (the lowest possible priority), and it still never saw the  non-trailing-slash request. The 301 had already fired and redirected the client.
     
So if we only register a route for /old-post-url/, a request to /old-post-url never reaches the handler at all. Vert.x intercepts it, sends a 301 to  /old-post-url/, and then the browser follows that redirect and hits my handler on the second request. That works fine when the generator is running (because it produces old-post-url/index.html as a static file), but in plain dev mode without the generator, there's no static file to trigger the redirect — the request just 404s.

I've checked in dev mode and this fixes the issue (although I haven't checked the behaviour at all on github pages, because that's harder). 
