### PR TITLE
Add utilities for converting Jekyll frontmatter to Roq equivalents

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterCommand.java
+++ b/migration/src/main/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterCommand.java
@@ -1,0 +1,51 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS info.picocli:picocli:4.7.5
+//DEPS com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.2
+
+package io.quarkus.tools.migration.jekyll;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "jekyll-frontmatter", mixinStandardHelpOptions = true, version = "1.0",
+        description = "Converts Jekyll frontmatter (pagination, permalinks) to Roq equivalents")
+public class JekyllFrontMatterCommand implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "Jekyll project directory")
+    private Path projectDir;
+
+    private JekyllFrontMatterConverter converter = new JekyllFrontMatterConverter();
+
+    public static void main(String... args) {
+        int exitCode = new CommandLine(new JekyllFrontMatterCommand()).execute(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        if (!Files.exists(projectDir)) {
+            System.err.println("Error: Project directory '" + projectDir + "' does not exist");
+            return 1;
+        }
+
+        if (!Files.isDirectory(projectDir)) {
+            System.err.println("Error: '" + projectDir + "' is not a directory");
+            return 1;
+        }
+
+        try {
+            converter.convertProject(projectDir);
+            System.out.println("✓ Frontmatter conversion complete");
+            return 0;
+        } catch (Exception e) {
+            System.err.println("✗ Error converting frontmatter: " + e.getMessage());
+            e.printStackTrace();
+            return 1;
+        }
+    }
+}

--- a/migration/src/main/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterConverter.java
@@ -1,0 +1,127 @@
+package io.quarkus.tools.migration.jekyll;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
+/**
+ * Converts Jekyll frontmatter in content files to Roq equivalents.
+ * Handles pagination and permalink transformations.
+ */
+public class JekyllFrontMatterConverter {
+
+    private static final Pattern PAGINATION_BLOCK = Pattern.compile(
+            "^pagination:[ \\t]*\\n([ \\t]+.*\\n)*", Pattern.MULTILINE);
+
+    private static final Pattern PERMALINK_LINE = Pattern.compile("^permalink:[ \\t]*(.*)\\n", Pattern.MULTILINE);
+
+    private final YAMLMapper yamlMapper = new YAMLMapper();
+
+    /**
+     * Run all frontmatter conversions on content files in a project directory.
+     */
+    public void convertProject(Path projectDir) throws IOException {
+        Path contentDir = projectDir.resolve("content");
+        if (!Files.isDirectory(contentDir)) {
+            return;
+        }
+
+        Path configFile = projectDir.resolve("_config.yml");
+        JsonNode config = Files.exists(configFile)
+                ? yamlMapper.readTree(Files.readString(configFile))
+                : null;
+
+        convertPermalinks(contentDir);
+        convertPagination(contentDir, config);
+    }
+
+    /**
+     * Convert Jekyll permalink frontmatter to Roq aliases.
+     * If the permalink matches the filename, it's redundant and removed.
+     * Otherwise it becomes an alias.
+     */
+    public void convertPermalinks(Path contentDir) throws IOException {
+        for (Path file : findContentFiles(contentDir)) {
+            String content = Files.readString(file);
+            Matcher matcher = PERMALINK_LINE.matcher(content);
+            if (!matcher.find()) {
+                continue;
+            }
+
+            String permalinkValue = matcher.group(1).trim()
+                    .replaceAll("^['\"]|['\"]$", "");
+            // Strip leading and trailing slashes
+            String normalized = permalinkValue.replaceAll("^/|/$", "");
+
+            String filenameNoExt = stripExtension(file.getFileName().toString());
+
+            if (normalized.equals(filenameNoExt)) {
+                content = PERMALINK_LINE.matcher(content).replaceFirst("");
+            } else {
+                content = PERMALINK_LINE.matcher(content).replaceFirst("aliases: " + Matcher.quoteReplacement(matcher.group(1)) + "\n");
+            }
+
+            Files.writeString(file, content);
+        }
+    }
+
+    /**
+     * Convert Jekyll pagination frontmatter to Roq paginate syntax.
+     * Reads collection and per_page from the Jekyll _config.yml pagination block.
+     * Derives the link pattern from each page's filename.
+     */
+    public void convertPagination(Path contentDir, JsonNode config) throws IOException {
+        String collection = getPaginationConfig(config, "collection", "posts");
+        String size = getPaginationConfig(config, "per_page", "10");
+
+        for (Path file : findContentFiles(contentDir)) {
+            String content = Files.readString(file);
+            if (!PAGINATION_BLOCK.matcher(content).find()) {
+                continue;
+            }
+
+            String pageSlug = stripExtension(file.getFileName().toString());
+            String replacement = "paginate:\n"
+                    + "  collection: " + collection + "\n"
+                    + "  size: " + size + "\n"
+                    + "  link: " + pageSlug + "/page/:page\n";
+
+            content = PAGINATION_BLOCK.matcher(content).replaceFirst(replacement);
+            Files.writeString(file, content);
+        }
+    }
+
+    private String getPaginationConfig(JsonNode config, String key, String defaultValue) {
+        if (config == null || !config.has("pagination")) {
+            return defaultValue;
+        }
+        JsonNode pagination = config.get("pagination");
+        if (!pagination.has(key)) {
+            return defaultValue;
+        }
+        return pagination.get(key).asText();
+    }
+
+    private Path[] findContentFiles(Path contentDir) throws IOException {
+        try (Stream<Path> paths = Files.walk(contentDir)) {
+            return paths
+                    .filter(Files::isRegularFile)
+                    .filter(p -> {
+                        String name = p.getFileName().toString();
+                        return name.endsWith(".md") || name.endsWith(".adoc") || name.endsWith(".asciidoc");
+                    })
+                    .toArray(Path[]::new);
+        }
+    }
+
+    private String stripExtension(String filename) {
+        int dot = filename.lastIndexOf('.');
+        return dot > 0 ? filename.substring(0, dot) : filename;
+    }
+}

--- a/migration/src/test/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterConverterTest.java
@@ -1,0 +1,287 @@
+package io.quarkus.tools.migration.jekyll;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JekyllFrontMatterConverterTest {
+
+    private JekyllFrontMatterConverter converter;
+    private final YAMLMapper yamlMapper = new YAMLMapper();
+
+    @BeforeEach
+    void setUp() {
+        converter = new JekyllFrontMatterConverter();
+    }
+
+    // --- Pagination tests ---
+
+    @Test
+    void testPaginationBasic(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        Files.writeString(contentDir.resolve("blog.md"), """
+                ---
+                layout: blog
+                title: "Blog"
+                pagination:
+                  enabled: true
+                ---
+                """);
+
+        converter.convertPagination(contentDir, null);
+
+        String result = Files.readString(contentDir.resolve("blog.md"));
+        assertTrue(result.contains("paginate:"));
+        assertTrue(result.contains("collection: posts"));
+        assertTrue(result.contains("size: 10"));
+        assertTrue(result.contains("link: blog/page/:page"));
+        assertFalse(result.contains("pagination:"));
+        assertFalse(result.contains("enabled: true"));
+    }
+
+    @Test
+    void testPaginationWithCustomCollection(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        Files.writeString(contentDir.resolve("articles.md"), """
+                ---
+                layout: list
+                pagination:
+                  enabled: true
+                ---
+                """);
+
+        String configYaml = """
+                pagination:
+                  collection: articles
+                  per_page: 5
+                """;
+        JsonNode config = yamlMapper.readTree(configYaml);
+
+        converter.convertPagination(contentDir, config);
+
+        String result = Files.readString(contentDir.resolve("articles.md"));
+        assertTrue(result.contains("collection: articles"));
+        assertTrue(result.contains("size: 5"));
+        assertTrue(result.contains("link: articles/page/:page"));
+    }
+
+    @Test
+    void testPaginationWithCustomPerPage(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        Files.writeString(contentDir.resolve("blog.md"), """
+                ---
+                pagination:
+                  enabled: true
+                ---
+                """);
+
+        String configYaml = """
+                pagination:
+                  per_page: 25
+                """;
+        JsonNode config = yamlMapper.readTree(configYaml);
+
+        converter.convertPagination(contentDir, config);
+
+        String result = Files.readString(contentDir.resolve("blog.md"));
+        assertTrue(result.contains("size: 25"));
+    }
+
+    @Test
+    void testPaginationMultipleFiles(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        Files.writeString(contentDir.resolve("blog.md"), """
+                ---
+                layout: blog
+                pagination:
+                  enabled: true
+                ---
+                """);
+        Files.writeString(contentDir.resolve("author.md"), """
+                ---
+                layout: authors
+                pagination:
+                  enabled: true
+                ---
+                """);
+
+        converter.convertPagination(contentDir, null);
+
+        String blog = Files.readString(contentDir.resolve("blog.md"));
+        assertTrue(blog.contains("link: blog/page/:page"));
+
+        String author = Files.readString(contentDir.resolve("author.md"));
+        assertTrue(author.contains("link: author/page/:page"));
+    }
+
+    @Test
+    void testPaginationNoConfig(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        Files.writeString(contentDir.resolve("blog.md"), """
+                ---
+                pagination:
+                  enabled: true
+                ---
+                """);
+
+        converter.convertPagination(contentDir, null);
+
+        String result = Files.readString(contentDir.resolve("blog.md"));
+        assertTrue(result.contains("collection: posts"));
+        assertTrue(result.contains("size: 10"));
+    }
+
+    @Test
+    void testPaginationLeavesNonPaginatedFilesAlone(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        String original = """
+                ---
+                layout: page
+                title: "About"
+                ---
+                Some content.
+                """;
+        Files.writeString(contentDir.resolve("about.md"), original);
+
+        converter.convertPagination(contentDir, null);
+
+        assertEquals(original, Files.readString(contentDir.resolve("about.md")));
+    }
+
+    // --- Permalink tests ---
+
+    @Test
+    void testPermalinkMatchingFilename(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        Files.writeString(contentDir.resolve("about.md"), """
+                ---
+                layout: page
+                permalink: /about/
+                title: "About"
+                ---
+                """);
+
+        converter.convertPermalinks(contentDir);
+
+        String result = Files.readString(contentDir.resolve("about.md"));
+        assertFalse(result.contains("permalink:"));
+        assertFalse(result.contains("aliases:"));
+        assertTrue(result.contains("layout: page"));
+        assertTrue(result.contains("title: \"About\""));
+    }
+
+    @Test
+    void testPermalinkRemovalLeavesNoBlankLine(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        Files.writeString(contentDir.resolve("about.md"), """
+                ---
+                layout: page
+                permalink: /about/
+                title: "About"
+                ---
+                """);
+
+        converter.convertPermalinks(contentDir);
+
+        String result = Files.readString(contentDir.resolve("about.md"));
+        assertFalse(result.contains("\n\n"), "Should not have blank lines in frontmatter");
+    }
+
+    @Test
+    void testPermalinkDifferentFromFilename(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        Files.writeString(contentDir.resolve("events.md"), """
+                ---
+                layout: page
+                permalink: /community/events/
+                ---
+                """);
+
+        converter.convertPermalinks(contentDir);
+
+        String result = Files.readString(contentDir.resolve("events.md"));
+        assertTrue(result.contains("aliases: /community/events/"));
+        assertFalse(result.contains("permalink:"));
+    }
+
+    @Test
+    void testPermalinkAbsent(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        String original = """
+                ---
+                layout: page
+                title: "About"
+                ---
+                """;
+        Files.writeString(contentDir.resolve("about.md"), original);
+
+        converter.convertPermalinks(contentDir);
+
+        assertEquals(original, Files.readString(contentDir.resolve("about.md")));
+    }
+
+    @Test
+    void testPermalinkWithoutSlashes(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        Files.writeString(contentDir.resolve("about.md"), """
+                ---
+                permalink: about
+                ---
+                """);
+
+        converter.convertPermalinks(contentDir);
+
+        String result = Files.readString(contentDir.resolve("about.md"));
+        assertFalse(result.contains("permalink:"));
+        assertFalse(result.contains("aliases:"));
+    }
+
+    // --- Integration test ---
+
+    @Test
+    void testConvertProjectRunsBothTransforms(@TempDir Path tempDir) throws IOException {
+        Files.createDirectories(tempDir.resolve("content"));
+        Files.writeString(tempDir.resolve("_config.yml"), """
+                pagination:
+                  collection: posts
+                  per_page: 10
+                """);
+        Files.writeString(tempDir.resolve("content/blog.md"), """
+                ---
+                layout: blog
+                permalink: /blog/
+                pagination:
+                  enabled: true
+                ---
+                """);
+
+        converter.convertProject(tempDir);
+
+        String result = Files.readString(tempDir.resolve("content/blog.md"));
+        assertFalse(result.contains("permalink:"));
+        assertTrue(result.contains("paginate:"));
+        assertTrue(result.contains("link: blog/page/:page"));
+    }
+}


### PR DESCRIPTION
To get permalinks converted to aliases, and to convert pagination instructions from Jekyll format to Roq format, we need some conversion utilities. 