### PR TITLE
Evaluate (sort of) conditional directives in asciidoc before yupiik header parsing

### DIFF
--- a/roq-plugin/asciidoc-common/deployment/pom.xml
+++ b/roq-plugin/asciidoc-common/deployment/pom.xml
@@ -26,6 +26,17 @@
             <artifactId>asciidoc-java</artifactId>
             <version>${asciidoc-java.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/roq-plugin/asciidoc-common/deployment/src/main/java/io/quarkiverse/roq/plugin/asciidoc/common/deployment/AsciidocHeaderParser.java
+++ b/roq-plugin/asciidoc-common/deployment/src/main/java/io/quarkiverse/roq/plugin/asciidoc/common/deployment/AsciidocHeaderParser.java
@@ -57,9 +57,9 @@ public class AsciidocHeaderParser {
     public static RoqFrontMatterHeaderParserBuildItem createBuildItem(boolean qute, Predicate<TemplateContext> isApplicable) {
         return new RoqFrontMatterHeaderParserBuildItem(isApplicable, templateContext -> {
             Parser parser = new Parser();
-            String content = templateContext.content();
+            String content = stripFrontMatter(templateContext.content());
             if (SIMPLE_CONDITIONAL.matcher(content).find()) {
-                content = stripConditionalDirectives(stripFrontMatter(content));
+                content = stripConditionalDirectives(content);
             }
 
             ContentResolver contentResolver = new PathContentResolver(templateContext.sourceFile().getParent());

--- a/roq-plugin/asciidoc-common/deployment/src/main/java/io/quarkiverse/roq/plugin/asciidoc/common/deployment/AsciidocHeaderParser.java
+++ b/roq-plugin/asciidoc-common/deployment/src/main/java/io/quarkiverse/roq/plugin/asciidoc/common/deployment/AsciidocHeaderParser.java
@@ -9,12 +9,19 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.jboss.logging.Logger;
 
@@ -33,10 +40,21 @@ public class AsciidocHeaderParser {
     private static final ContentResolver EMPTY_CONTENT_RESOLVER = (ref, encoding) -> Optional.empty();
     private static final String QUTE_KEY = "qute";
 
+    // Mirrors Asciidoctor's ConditionalDirectiveRx — one pattern for all conditional directives.
+    // group 1: leading backslash (escaped directive, treat as literal text)
+    // group 2: directive name (ifdef, ifndef, ifeval, endif)
+    // group 3: target attributes (may be empty for endif/ifeval)
+    // group 4: bracket content (null for empty brackets = block form, non-null = inline form)
+    private static final Pattern CONDITIONAL_DIRECTIVE = Pattern
+            .compile("^(\\\\)?(ifdef|ifndef|ifeval|endif)::(\\S*?)\\[(.+)?\\]\\s*$");
+
+    // Matches attribute entries: :name: value, :!name: (unset), :name!: (unset)
+    private static final Pattern ATTRIBUTE_ENTRY = Pattern.compile("^:(!?\\w[^:]*):(?:[ \\t]+(.*))?$");
+
     public static RoqFrontMatterHeaderParserBuildItem createBuildItem(boolean qute, Predicate<TemplateContext> isApplicable) {
         return new RoqFrontMatterHeaderParserBuildItem(isApplicable, templateContext -> {
             Parser parser = new Parser();
-            String content = stripFrontMatter(templateContext.content());
+            String content = stripConditionalDirectives(stripFrontMatter(templateContext.content()));
             ContentResolver contentResolver = new PathContentResolver(templateContext.sourceFile().getParent());
             Header header = parser.parseHeader(new Reader(content.lines().toList()),
                     new Parser.ParserContext(contentResolver));
@@ -104,6 +122,113 @@ public class AsciidocHeaderParser {
         }
 
         return result;
+    }
+
+    // Pre-process ifdef/ifndef/endif/ifeval directives, evaluating conditions against
+    // attributes defined so far in the header. This mirrors (in simplified form) what the
+    // reference Asciidoctor preprocessor does before header parsing.
+    // NOTE: attributes set externally (e.g. via quarkus.asciidoc.attributes in the pom or
+    // environment variables) are not yet available here — only attributes defined within the
+    // document header itself are tracked. Supporting external attributes would require threading
+    // the configured attribute map from AsciidoctorJConfig into the header parser.
+    // Environment attributes (env-github, env-browser, env-vscode, env-site) are set by external
+    // rendering tools, not by AsciiDoc itself. Roq is its own SSG so none of these apply — they
+    // will always be undefined here, which is correct.
+    static String stripConditionalDirectives(String content) {
+        List<String> result = new ArrayList<>();
+        Deque<Boolean> includeStack = new ArrayDeque<>();
+        Set<String> definedAttributes = new HashSet<>();
+
+        for (String line : (Iterable<String>) content.lines()::iterator) {
+            Matcher m = CONDITIONAL_DIRECTIVE.matcher(line);
+            if (m.matches()) {
+                if (m.group(1) != null) {
+                    // Escaped directive (\ifdef::...) — pass through as literal text without the backslash
+                    if (isIncluding(includeStack)) {
+                        result.add(line.substring(1));
+                    }
+                    continue;
+                }
+
+                LOGGER.debugf("Stripping conditional directive from AsciiDoc header: '%s'", line);
+                String directive = m.group(2);
+                String target = m.group(3);
+                String bracketContent = m.group(4);
+
+                switch (directive) {
+                    case "ifdef", "ifndef" -> {
+                        if (bracketContent == null) {
+                            // Block form: ifdef::attr[] ... endif::[]
+                            boolean include = isIncluding(includeStack)
+                                    && evaluateCondition(directive, target, definedAttributes);
+                            includeStack.push(include);
+                        } else {
+                            // Inline form: ifdef::attr[content]
+                            if (isIncluding(includeStack)
+                                    && evaluateCondition(directive, target, definedAttributes)) {
+                                result.add(bracketContent);
+                                trackAttribute(bracketContent, definedAttributes);
+                            }
+                        }
+                    }
+                    case "endif" -> {
+                        if (!includeStack.isEmpty()) {
+                            includeStack.pop();
+                        }
+                    }
+                    case "ifeval" -> includeStack.push(isIncluding(includeStack));
+                }
+                continue;
+            }
+
+            if (isIncluding(includeStack)) {
+                result.add(line);
+                trackAttribute(line, definedAttributes);
+            }
+        }
+
+        return String.join("\n", result);
+    }
+
+    private static boolean isIncluding(Deque<Boolean> includeStack) {
+        return !includeStack.contains(false);
+    }
+
+    // Evaluates an ifdef/ifndef condition against the set of currently defined attributes.
+    // Supports comma-separated (OR) and plus-separated (AND) attribute lists.
+    // ifdef: include if condition is true; ifndef: include if condition is false.
+    private static final Pattern COMMA = Pattern.compile(",");
+    private static final Pattern PLUS = Pattern.compile("\\+");
+
+    static boolean evaluateCondition(String directive, String attributes, Set<String> definedAttributes) {
+        boolean defined;
+        if (attributes.contains(",")) {
+            defined = COMMA.splitAsStream(attributes)
+                    .map(String::trim)
+                    .anyMatch(definedAttributes::contains);
+        } else if (attributes.contains("+")) {
+            defined = PLUS.splitAsStream(attributes)
+                    .map(String::trim)
+                    .allMatch(definedAttributes::contains);
+        } else {
+            defined = definedAttributes.contains(attributes.trim());
+        }
+
+        return "ifdef".equals(directive) ? defined : !defined;
+    }
+
+    private static void trackAttribute(String line, Set<String> definedAttributes) {
+        Matcher attr = ATTRIBUTE_ENTRY.matcher(line);
+        if (attr.matches()) {
+            String raw = attr.group(1);
+            boolean unset = raw.startsWith("!") || raw.endsWith("!");
+            String name = unset ? raw.replace("!", "") : raw;
+            if (unset) {
+                definedAttributes.remove(name);
+            } else {
+                definedAttributes.add(name);
+            }
+        }
     }
 
     static class PathContentResolver implements RelativeContentResolver {

--- a/roq-plugin/asciidoc-common/deployment/src/main/java/io/quarkiverse/roq/plugin/asciidoc/common/deployment/AsciidocHeaderParser.java
+++ b/roq-plugin/asciidoc-common/deployment/src/main/java/io/quarkiverse/roq/plugin/asciidoc/common/deployment/AsciidocHeaderParser.java
@@ -37,8 +37,11 @@ import io.yupiik.asciidoc.parser.resolver.RelativeContentResolver;
 public class AsciidocHeaderParser {
     private static final Logger LOGGER = org.jboss.logging.Logger.getLogger(AsciidocHeaderParser.class);
 
-    private static final ContentResolver EMPTY_CONTENT_RESOLVER = (ref, encoding) -> Optional.empty();
     private static final String QUTE_KEY = "qute";
+
+    // Pattern used to short-circuit more complex evaluation
+    private static final Pattern SIMPLE_CONDITIONAL = Pattern
+            .compile("ifn?(?:def|eval)");
 
     // Mirrors Asciidoctor's ConditionalDirectiveRx — one pattern for all conditional directives.
     // group 1: leading backslash (escaped directive, treat as literal text)
@@ -54,7 +57,11 @@ public class AsciidocHeaderParser {
     public static RoqFrontMatterHeaderParserBuildItem createBuildItem(boolean qute, Predicate<TemplateContext> isApplicable) {
         return new RoqFrontMatterHeaderParserBuildItem(isApplicable, templateContext -> {
             Parser parser = new Parser();
-            String content = stripConditionalDirectives(stripFrontMatter(templateContext.content()));
+            String content = templateContext.content();
+            if (SIMPLE_CONDITIONAL.matcher(content).find()) {
+                content = stripConditionalDirectives(stripFrontMatter(content));
+            }
+
             ContentResolver contentResolver = new PathContentResolver(templateContext.sourceFile().getParent());
             Header header = parser.parseHeader(new Reader(content.lines().toList()),
                     new Parser.ParserContext(contentResolver));

--- a/roq-plugin/asciidoc-common/deployment/src/test/java/io/quarkiverse/roq/plugin/asciidoc/common/deployment/AsciidocHeaderParserTest.java
+++ b/roq-plugin/asciidoc-common/deployment/src/test/java/io/quarkiverse/roq/plugin/asciidoc/common/deployment/AsciidocHeaderParserTest.java
@@ -59,6 +59,23 @@ class AsciidocHeaderParserTest {
     }
 
     @Test
+    void shouldParseHeaderWithFrontmatterAndNoConditionals() {
+        String content = """
+                ---
+                layout: post
+                ---
+                = My Title
+                :page-layout: post
+
+                Some content here.
+                """;
+
+        JsonObject result = parse(content);
+        assertThat(result.getString("title")).isEqualTo("My Title");
+        assertThat(result.getString("layout")).isEqualTo("post");
+    }
+
+    @Test
     void shouldParseHeaderWithIfdefContainingInclude() {
         String content = """
                 = My Title

--- a/roq-plugin/asciidoc-common/deployment/src/test/java/io/quarkiverse/roq/plugin/asciidoc/common/deployment/AsciidocHeaderParserTest.java
+++ b/roq-plugin/asciidoc-common/deployment/src/test/java/io/quarkiverse/roq/plugin/asciidoc/common/deployment/AsciidocHeaderParserTest.java
@@ -1,0 +1,739 @@
+package io.quarkiverse.roq.plugin.asciidoc.common.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.roq.frontmatter.deployment.items.scan.RoqFrontMatterHeaderParserBuildItem;
+import io.quarkiverse.roq.frontmatter.deployment.items.scan.TemplateContext;
+import io.vertx.core.json.JsonObject;
+
+class AsciidocHeaderParserTest {
+
+    private final RoqFrontMatterHeaderParserBuildItem buildItem = AsciidocHeaderParser.createBuildItem(false,
+            ctx -> true);
+
+    private JsonObject parse(String content) {
+        TemplateContext ctx = new TemplateContext(Path.of("/tmp/test.adoc"), "test.adoc", content);
+        return buildItem.parse().apply(ctx);
+    }
+
+    // --- Original reproducer tests (crash prevention) ---
+
+    @Test
+    void shouldParseHeaderWithIfdefInAttributes() {
+        String content = """
+                = My Title
+                :page-layout: post
+                ifdef::backend-html5[]
+                :page-foo: bar
+                endif::[]
+
+                Some content here.
+                """;
+
+        JsonObject result = parse(content);
+        assertThat(result.getString("title")).isEqualTo("My Title");
+        assertThat(result.getString("layout")).isEqualTo("post");
+    }
+
+    @Test
+    void shouldParseHeaderWithFrontmatterAndIfdef() {
+        String content = """
+                ---
+                layout: post
+                ---
+                = My Title
+                ifdef::backend-html5[]
+                :icons: font
+                endif::[]
+
+                Some content here.
+                """;
+
+        JsonObject result = parse(content);
+        assertThat(result.getString("title")).isEqualTo("My Title");
+    }
+
+    @Test
+    void shouldParseHeaderWithIfdefContainingInclude() {
+        String content = """
+                = My Title
+                :page-layout: post
+                ifdef::env-github[]
+                include::_attributes.adoc[]
+                endif::[]
+
+                Some content here.
+                """;
+
+        JsonObject result = parse(content);
+        assertThat(result.getString("title")).isEqualTo("My Title");
+        assertThat(result.getString("layout")).isEqualTo("post");
+    }
+
+    @Test
+    void shouldParseHeaderWithInlineIfdef() {
+        String content = """
+                = My Title
+                ifdef::env-github,env-browser,env-vscode[:imagesdir: ../assets/images/posts]
+
+                Some content here.
+                """;
+
+        JsonObject result = parse(content);
+        assertThat(result.getString("title")).isEqualTo("My Title");
+    }
+
+    @Test
+    void shouldParseHeaderWithMultipleInlineIfdefs() {
+        String content = """
+                = My Title
+                :page-layout: post
+                ifdef::env-github[:tip-caption: :bulb:]
+                ifdef::env-browser[:icons: font]
+
+                Some content here.
+                """;
+
+        JsonObject result = parse(content);
+        assertThat(result.getString("title")).isEqualTo("My Title");
+        assertThat(result.getString("layout")).isEqualTo("post");
+    }
+
+    // --- Condition evaluation tests ---
+
+    @Nested
+    class IfdefWithDefinedAttribute {
+
+        @Test
+        void shouldIncludeBlockContentWhenAttributeIsDefined() {
+            String content = """
+                    = My Title
+                    :my-flag:
+                    ifdef::my-flag[]
+                    :page-included: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+
+        @Test
+        void shouldIncludeInlineContentWhenAttributeIsDefined() {
+            String content = """
+                    = My Title
+                    :my-flag:
+                    ifdef::my-flag[:page-included: yes]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+    }
+
+    @Nested
+    class IfdefWithUndefinedAttribute {
+
+        @Test
+        void shouldExcludeBlockContentWhenAttributeIsNotDefined() {
+            String content = """
+                    = My Title
+                    ifdef::not-defined[]
+                    :page-excluded: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+        }
+
+        @Test
+        void shouldExcludeInlineContentWhenAttributeIsNotDefined() {
+            String content = """
+                    = My Title
+                    ifdef::not-defined[:page-excluded: yes]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+        }
+    }
+
+    @Nested
+    class IfndefWithDefinedAttribute {
+
+        @Test
+        void shouldExcludeBlockContentWhenAttributeIsDefined() {
+            String content = """
+                    = My Title
+                    :my-flag:
+                    ifndef::my-flag[]
+                    :page-excluded: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+        }
+
+        @Test
+        void shouldExcludeInlineContentWhenAttributeIsDefined() {
+            String content = """
+                    = My Title
+                    :my-flag:
+                    ifndef::my-flag[:page-excluded: yes]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+        }
+    }
+
+    @Nested
+    class IfndefWithUndefinedAttribute {
+
+        @Test
+        void shouldIncludeBlockContentWhenAttributeIsNotDefined() {
+            String content = """
+                    = My Title
+                    ifndef::not-defined[]
+                    :page-included: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+
+        @Test
+        void shouldIncludeInlineContentWhenAttributeIsNotDefined() {
+            String content = """
+                    = My Title
+                    ifndef::not-defined[:page-included: yes]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+    }
+
+    @Nested
+    class MultiAttributeConditions {
+
+        @Test
+        void ifdefOrShouldIncludeWhenAnyAttributeIsDefined() {
+            String content = """
+                    = My Title
+                    :flag-a:
+                    ifdef::flag-a,flag-b[]
+                    :page-included: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+
+        @Test
+        void ifdefOrShouldExcludeWhenNoAttributeIsDefined() {
+            String content = """
+                    = My Title
+                    ifdef::flag-a,flag-b[]
+                    :page-excluded: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+        }
+
+        @Test
+        void ifdefAndShouldIncludeWhenAllAttributesAreDefined() {
+            String content = """
+                    = My Title
+                    :flag-a:
+                    :flag-b:
+                    ifdef::flag-a+flag-b[]
+                    :page-included: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+
+        @Test
+        void ifdefAndShouldExcludeWhenNotAllAttributesAreDefined() {
+            String content = """
+                    = My Title
+                    :flag-a:
+                    ifdef::flag-a+flag-b[]
+                    :page-excluded: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+        }
+
+        @Test
+        void ifndefOrShouldIncludeWhenNoAttributeIsDefined() {
+            // ifndef with comma = NOR: include only if NONE are defined
+            String content = """
+                    = My Title
+                    ifndef::flag-a,flag-b[]
+                    :page-included: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+
+        @Test
+        void ifndefOrShouldExcludeWhenAnyAttributeIsDefined() {
+            String content = """
+                    = My Title
+                    :flag-a:
+                    ifndef::flag-a,flag-b[]
+                    :page-excluded: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+        }
+
+        @Test
+        void ifndefAndShouldIncludeWhenNotAllAttributesAreDefined() {
+            // ifndef with plus = NAND: include if NOT ALL are defined
+            String content = """
+                    = My Title
+                    :flag-a:
+                    ifndef::flag-a+flag-b[]
+                    :page-included: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+
+        @Test
+        void ifndefAndShouldExcludeWhenAllAttributesAreDefined() {
+            String content = """
+                    = My Title
+                    :flag-a:
+                    :flag-b:
+                    ifndef::flag-a+flag-b[]
+                    :page-excluded: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+        }
+
+        @Test
+        void inlineIfdefOrShouldIncludeWhenAnyDefined() {
+            String content = """
+                    = My Title
+                    :flag-a:
+                    ifdef::flag-a,flag-b[:page-included: yes]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+
+        @Test
+        void inlineIfdefAndShouldExcludeWhenNotAllDefined() {
+            String content = """
+                    = My Title
+                    :flag-a:
+                    ifdef::flag-a+flag-b[:page-excluded: yes]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+        }
+    }
+
+    @Nested
+    class Nesting {
+
+        @Test
+        void shouldIncludeContentWhenBothOuterAndInnerAreTrue() {
+            String content = """
+                    = My Title
+                    :outer:
+                    :inner:
+                    ifdef::outer[]
+                    ifdef::inner[]
+                    :page-included: yes
+                    endif::[]
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+
+        @Test
+        void shouldExcludeContentWhenOuterIsFalse() {
+            String content = """
+                    = My Title
+                    :inner:
+                    ifdef::outer[]
+                    ifdef::inner[]
+                    :page-excluded: yes
+                    endif::[]
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+        }
+
+        @Test
+        void shouldExcludeContentWhenInnerIsFalse() {
+            String content = """
+                    = My Title
+                    :outer:
+                    ifdef::outer[]
+                    ifdef::inner[]
+                    :page-excluded: yes
+                    endif::[]
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+        }
+
+        @Test
+        void shouldNotDefineAttributesInsideExcludedBlock() {
+            String content = """
+                    = My Title
+                    ifdef::not-defined[]
+                    :sneaky-attr:
+                    endif::[]
+                    ifdef::sneaky-attr[]
+                    :page-excluded: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+        }
+    }
+
+    @Nested
+    class AttributeTracking {
+
+        @Test
+        void shouldTrackAttributeWithValue() {
+            String content = """
+                    = My Title
+                    :backend: html5
+                    ifdef::backend[]
+                    :page-included: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+
+        @Test
+        void shouldTrackAttributeWithEmptyValue() {
+            String content = """
+                    = My Title
+                    :my-flag:
+                    ifdef::my-flag[]
+                    :page-included: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+
+        @Test
+        void shouldUnsetAttributeWithLeadingBang() {
+            String content = """
+                    = My Title
+                    :my-flag:
+                    :!my-flag:
+                    ifdef::my-flag[]
+                    :page-excluded: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+        }
+
+        @Test
+        void shouldUnsetAttributeWithTrailingBang() {
+            String content = """
+                    = My Title
+                    :my-flag:
+                    :my-flag!:
+                    ifdef::my-flag[]
+                    :page-excluded: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+        }
+
+        @Test
+        void shouldTrackAttributeDefinedInsideIncludedBlock() {
+            String content = """
+                    = My Title
+                    :first:
+                    ifdef::first[]
+                    :second:
+                    endif::[]
+                    ifdef::second[]
+                    :page-included: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+
+        @Test
+        void shouldTrackAttributeDefinedByInlineIfdef() {
+            String content = """
+                    = My Title
+                    :first:
+                    ifdef::first[:second:]
+                    ifdef::second[]
+                    :page-included: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+    }
+
+    @Nested
+    class IfdefBeforeTitle {
+
+        @Test
+        void shouldParseTitleWhenIfdefBeforeTitleEvaluatesToFalse() {
+            // When the condition is false, the orphan content is stripped
+            // and the title is found correctly
+            String content = """
+                    ifdef::env-github[]
+                    :tip-caption: :bulb:
+                    endif::[]
+                    = My Title
+                    :page-layout: post
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("title")).isEqualTo("My Title");
+            assertThat(result.getString("layout")).isEqualTo("post");
+        }
+    }
+
+    @Nested
+    class EnvironmentAttributes {
+
+        // env-* attributes (env-github, env-browser, env-vscode, env-site) are set by
+        // external rendering environments, not by the document itself. Since Roq is its
+        // own SSG, none of these apply — they are always undefined.
+
+        @Test
+        void envAttributesAreUndefined() {
+            String content = """
+                    = My Title
+                    ifdef::env-github,env-browser,env-vscode[:page-excluded: yes]
+                    ifndef::env-github[]
+                    :page-included: yes
+                    endif::[]
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("excluded")).isNull();
+            assertThat(result.getString("included")).isEqualTo("yes");
+        }
+    }
+
+    // --- stripConditionalDirectives unit tests ---
+
+    @Nested
+    class StripConditionalDirectives {
+
+        @Test
+        void shouldPassThroughContentWithNoDirectives() {
+            String content = """
+                    = My Title
+                    :page-layout: post
+
+                    Body.""";
+
+            String result = AsciidocHeaderParser.stripConditionalDirectives(content);
+            assertThat(result).contains("= My Title");
+            assertThat(result).contains(":page-layout: post");
+        }
+
+        @Test
+        void shouldStripIfeval() {
+            String content = """
+                    = My Title
+                    ifeval::["{backend}" == "html5"]
+                    :page-foo: bar
+                    endif::[]
+
+                    Body.""";
+
+            String result = AsciidocHeaderParser.stripConditionalDirectives(content);
+            assertThat(result).doesNotContain("ifeval");
+            assertThat(result).contains("= My Title");
+        }
+
+        @Test
+        void shouldNotLetIfevalEndifStealEnclosingIfdefEntry() {
+            String content = """
+                    = My Title
+                    :my-flag:
+                    ifdef::my-flag[]
+                    ifeval::["{backend}" == "html5"]
+                    :page-inner: yes
+                    endif::[]
+                    :page-outer: yes
+                    endif::[]
+
+                    Body.""";
+
+            String result = AsciidocHeaderParser.stripConditionalDirectives(content);
+            assertThat(result).contains(":page-inner: yes");
+            assertThat(result).contains(":page-outer: yes");
+            assertThat(result).doesNotContain("ifdef");
+            assertThat(result).doesNotContain("endif");
+        }
+
+        @Test
+        void shouldExcludeIfevalContentWhenInsideExcludedIfdef() {
+            String content = """
+                    = My Title
+                    ifdef::not-defined[]
+                    ifeval::["{backend}" == "html5"]
+                    :page-excluded: yes
+                    endif::[]
+                    :page-also-excluded: yes
+                    endif::[]
+
+                    Body.""";
+
+            String result = AsciidocHeaderParser.stripConditionalDirectives(content);
+            assertThat(result).doesNotContain(":page-excluded:");
+            assertThat(result).doesNotContain(":page-also-excluded:");
+        }
+
+        @Test
+        void shouldPassThroughEscapedDirective() {
+            String content = """
+                    = My Title
+                    \\ifdef::some-attr[]
+                    :page-included: yes
+                    endif::[]
+
+                    Body.""";
+
+            String result = AsciidocHeaderParser.stripConditionalDirectives(content);
+            assertThat(result).contains("ifdef::some-attr[]");
+            assertThat(result).doesNotContain("\\ifdef");
+            assertThat(result).contains(":page-included: yes");
+        }
+
+        @Test
+        void shouldHandleEndifWithAttributeName() {
+            String content = """
+                    = My Title
+                    :my-flag:
+                    ifdef::my-flag[]
+                    :page-included: yes
+                    endif::my-flag[]
+
+                    Body.""";
+
+            String result = AsciidocHeaderParser.stripConditionalDirectives(content);
+            assertThat(result).doesNotContain("ifdef");
+            assertThat(result).doesNotContain("endif");
+            assertThat(result).contains(":page-included: yes");
+        }
+    }
+}


### PR DESCRIPTION
I noticed that even if I use the asciidoc-jruby plugin, ifdefs in asciidoc headers cause crashes. 

```
  java.lang.IllegalArgumentException: Unknown line: 'ifdef::env-github,env-browser,env-vscode[:imagesdir: ../assets/images/posts]'
      at io.yupiik.asciidoc.parser.Parser.readAttributes(Parser.java:1634)
      at io.yupiik.asciidoc.parser.Parser.parseHeader(Parser.java:209)
```

It turns out that the `AsciidocHeaderParser` in `asciidoc-common` uses yupiik under the covers, and yupiik can't handle conditionals. How asciidoc handles this is to strip out the conditionals before doing the parsing. I've mirrored this approach, in a slightly simplified way. Most `env-` attributes would always be false inside a Roq environment (it's not github, or vscode, or ...), so I've just defaulted those to false. Attributes passed in via build configuration *could* be true, but we don't have access to them so I've also cheated and defaulted them to false. I did add some code which reads the rest of the header and honours any attributes defined there, because it would look silly not to. 

My first implementation used several regexes. I felt a bit uneasy about doing so much parsing just with regular expressions, but I checked, and asciidoc also uses good old-fashioned regexes for its parsing. They have a single regex, which makes maintenance easier, if not readability. I borrowed the asciidoc regex on the basis that it must be correct. :) 

We didn't seem to have tests for asciidoc-common, so I've added the dependencies and tests for these cases in the header parser.