### PR TITLE
Support deeply nested data directories as grouped CDI beans

### DIFF
--- a/roq-data/deployment/src/main/java/io/quarkiverse/roq/data/deployment/RoqDataReaderProcessor.java
+++ b/roq-data/deployment/src/main/java/io/quarkiverse/roq/data/deployment/RoqDataReaderProcessor.java
@@ -185,19 +185,21 @@ public class RoqDataReaderProcessor {
             }
         }
 
-        // Produce grouped RoqDataJsonBuildItem for untyped directories
-        for (Map.Entry<String, TreeMap<String, RoqDataBuildItem>> entry : allDirFiles.entrySet()) {
-            if (!producedJsonNames.contains(entry.getKey()) && !dirAnnotationNames.contains(entry.getKey())) {
-                TreeMap<String, Object> grouped = new TreeMap<>();
-                for (Map.Entry<String, RoqDataBuildItem> fileEntry : entry.getValue().entrySet()) {
-                    Object converted = convertedData.get(entry.getKey() + "/" + fileEntry.getKey());
-                    if (converted != null) {
-                        grouped.put(fileEntry.getKey(), converted);
-                    }
-                }
-                if (!grouped.isEmpty()) {
-                    dataJsonProducer.produce(new RoqDataJsonBuildItem(entry.getKey(), new JsonObject(grouped)));
-                }
+        // Produce grouped RoqDataJsonBuildItem for directories (including deeply nested)
+        Map<String, TreeMap<String, Object>> topDirs = new TreeMap<>();
+        for (Map.Entry<String, Object> e : convertedData.entrySet()) {
+            String name = e.getKey();
+            int firstSlash = name.indexOf('/');
+            if (firstSlash > 0) {
+                String topDir = name.substring(0, firstSlash);
+                String rest = name.substring(firstSlash + 1);
+                topDirs.computeIfAbsent(topDir, k -> new TreeMap<>()).put(rest, e.getValue());
+            }
+        }
+        for (Map.Entry<String, TreeMap<String, Object>> e : topDirs.entrySet()) {
+            String dirName = e.getKey();
+            if (!producedJsonNames.contains(dirName) && !dirAnnotationNames.contains(dirName)) {
+                dataJsonProducer.produce(new RoqDataJsonBuildItem(dirName, buildNestedJsonObject(e.getValue())));
             }
         }
 
@@ -349,6 +351,29 @@ public class RoqDataReaderProcessor {
         }
     }
 
+    private static JsonObject buildNestedJsonObject(Map<String, Object> flatMap) {
+        Map<String, Object> result = new TreeMap<>();
+        Map<String, TreeMap<String, Object>> subDirs = new TreeMap<>();
+
+        for (Map.Entry<String, Object> entry : flatMap.entrySet()) {
+            String key = entry.getKey();
+            int slashIdx = key.indexOf('/');
+            if (slashIdx > 0) {
+                String dir = key.substring(0, slashIdx);
+                String rest = key.substring(slashIdx + 1);
+                subDirs.computeIfAbsent(dir, k -> new TreeMap<>()).put(rest, entry.getValue());
+            } else {
+                result.put(key, entry.getValue());
+            }
+        }
+
+        for (Map.Entry<String, TreeMap<String, Object>> subDir : subDirs.entrySet()) {
+            result.put(subDir.getKey(), buildNestedJsonObject(subDir.getValue()));
+        }
+
+        return new JsonObject(result);
+    }
+
     private static Map<String, TreeMap<String, RoqDataBuildItem>> collectDirectoryFiles(
             List<RoqDataBuildItem> items) {
         Map<String, TreeMap<String, RoqDataBuildItem>> result = new HashMap<>();
@@ -360,8 +385,6 @@ public class RoqDataReaderProcessor {
                     String dirName = name.substring(0, slashIdx);
                     String fileKey = name.substring(slashIdx + 1);
                     result.computeIfAbsent(dirName, k -> new TreeMap<>()).put(fileKey, item);
-                } else {
-                    LOG.debugf("Deeply nested data files are not grouped: %s", name);
                 }
             }
         }

--- a/roq-data/deployment/src/test/java/io/quarkiverse/roq/data/test/RoqDataDeepNestingTest.java
+++ b/roq-data/deployment/src/test/java/io/quarkiverse/roq/data/test/RoqDataDeepNestingTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.roq.data.test;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vertx.core.json.JsonObject;
+
+public class RoqDataDeepNestingTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .add(new StringAsset("quarkus.roq.dir=src/test/roq"),
+                            "application.properties"));
+
+    @Inject
+    @Named("worlds")
+    JsonObject worlds;
+
+    @Test
+    public void testDeepNestedGrouping() {
+        Assertions.assertNotNull(worlds);
+        JsonObject earth = worlds.getJsonObject("earth");
+        Assertions.assertNotNull(earth, "Expected 'earth' key in worlds");
+        JsonObject earthHeroes = earth.getJsonObject("heroes");
+        Assertions.assertNotNull(earthHeroes, "Expected 'heroes' key in earth");
+        Assertions.assertEquals("Shadowcat", earthHeroes.getJsonObject("shadowcat").getString("name"));
+        Assertions.assertEquals("Storm", earthHeroes.getJsonObject("storm").getString("name"));
+    }
+
+    @Test
+    public void testDeepNestedMultipleSubdirs() {
+        JsonObject krypton = worlds.getJsonObject("krypton");
+        Assertions.assertNotNull(krypton, "Expected 'krypton' key in worlds");
+        JsonObject kryptonHeroes = krypton.getJsonObject("heroes");
+        Assertions.assertNotNull(kryptonHeroes, "Expected 'heroes' key in krypton");
+        Assertions.assertEquals("Supergirl", kryptonHeroes.getJsonObject("supergirl").getString("name"));
+    }
+}

--- a/roq-data/deployment/src/test/roq/data/worlds/earth/heroes/shadowcat.yaml
+++ b/roq-data/deployment/src/test/roq/data/worlds/earth/heroes/shadowcat.yaml
@@ -1,0 +1,2 @@
+name: Shadowcat
+world: Earth

--- a/roq-data/deployment/src/test/roq/data/worlds/earth/heroes/storm.yaml
+++ b/roq-data/deployment/src/test/roq/data/worlds/earth/heroes/storm.yaml
@@ -1,0 +1,2 @@
+name: Storm
+world: Earth

--- a/roq-data/deployment/src/test/roq/data/worlds/krypton/heroes/supergirl.yaml
+++ b/roq-data/deployment/src/test/roq/data/worlds/krypton/heroes/supergirl.yaml
@@ -1,0 +1,2 @@
+name: Supergirl
+world: Krypton


### PR DESCRIPTION
This is needed for quarkus.io, but I think it will be more generally useful, too; it doesn't fix a todo, but it does fix a debug log. The quarkusio.github.io guides listing page uses data files with several levels of nesting, such as `data/versioned/latest/index/quarkus.yaml`. The template accesses this as cdi:versioned.get('latest').index.quarkus.

Roq's data processor only grouped single-level directories (e.g. `data/heroes/batman.yaml` → `cdi:heroes.batman`). Anything deeper was skipped with a debug log. So `cdi:versioned` was never produced as a CDI bean. This was bad. :)

With the fix, data files in nested subdirectories are now grouped into a single CDI bean named after the top-level directory, with the directory structure preserved as nested `JsonObject`s.
