### PR TITLE
Trivial formatting - tidy missing line break in root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.version>3.35.1</quarkus.version>
         <quarkus-qute-web.version>3.4.5</quarkus-qute-web.version>
-        <asciidoctorj.version>3.0.1</asciidoctorj.version><asciidoctorj-diagram.version>3.2.1</asciidoctorj-diagram.version>
+        <asciidoctorj.version>3.0.1</asciidoctorj.version>
+        <asciidoctorj-diagram.version>3.2.1</asciidoctorj-diagram.version>
         <quarkus-web-bundler.version>2.3.2</quarkus-web-bundler.version>
         <asciidoc-java.version>1.2.14</asciidoc-java.version>
         <jandex.version>3.6.0</jandex.version>


### PR DESCRIPTION
There's a missing line break in the pom.xml, which makes it hard to read (and harder for automated tools using naive parsing to process). 