### PR TITLE
Add :dir placeholder to support slug overrides and nested paths

### DIFF
--- a/blog/content/docs/advanced.adoc
+++ b/blog/content/docs/advanced.adoc
@@ -250,6 +250,11 @@ TIP: Those links are also available in the Qute data to allow <<roq-url>>.
 | The raw file path of the page without the extension.
 | `My$`, `my car` or `été/2024`
 
+| All
+| `:dir`
+| The directory portion of the page’s file path, slugified. For index files (directory pages), this is the grandparent directory (since the slug already captures the directory name). Empty for files at the content root.
+| `posts`, `posts/v2/guides`, or empty
+
 
 | All
 | `:slug`

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterAssembleUtils.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterAssembleUtils.java
@@ -1,7 +1,8 @@
 package io.quarkiverse.roq.frontmatter.deployment.util;
 
-import static io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterLayoutUtils.*;
-import static io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterTemplateUtils.*;
+import static io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterLayoutUtils.resolveDefaultLayout;
+import static io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterTemplateUtils.applyContentTransforms;
+import static io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterTemplateUtils.getMarkup;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.ESCAPE;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.LAYOUT;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.THEME_LAYOUT;

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/util/TemplateLinkTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/util/TemplateLinkTest.java
@@ -153,6 +153,7 @@ class TemplateLinkTest {
         assertDoesNotThrow(() -> pageLink("", "/:year/:month/:day/:slug", data));
         assertDoesNotThrow(() -> pageLink("", "/:path:ext", data));
         assertDoesNotThrow(() -> pageLink("", "/:name/:Slug", data));
+        assertDoesNotThrow(() -> pageLink("", "/:dir/:slug", data));
     }
 
     @Test
@@ -207,6 +208,44 @@ class TemplateLinkTest {
         PageLinkData data = new PageLinkData(templateSource, null, frontMatter);
 
         assertEquals("2024/08/27/my-first/", pageLink("", ":year/:month/:day/:name~2", data));
+    }
+
+    // --- :dir placeholder tests ---
+
+    @Test
+    void testDirPlaceholderSimple() {
+        JsonObject frontMatter = new JsonObject().put("title", "My Post");
+        final PageSource templateSource = createPageSource("posts/my-post.md", true, false);
+        PageLinkData data = new PageLinkData(templateSource, null, frontMatter);
+
+        assertEquals("posts/my-post/", pageLink("", ":dir/:slug", data));
+    }
+
+    @Test
+    void testDirPlaceholderNested() {
+        JsonObject frontMatter = new JsonObject().put("title", "AMQP Dev Services");
+        final PageSource templateSource = createPageSource("posts/v2/guides/amqp.md", true, false);
+        PageLinkData data = new PageLinkData(templateSource, "posts", frontMatter);
+
+        assertEquals("posts/v2/guides/amqp-dev-services/", pageLink("", ":dir/:slug", data));
+    }
+
+    @Test
+    void testDirPlaceholderNoDirectory() {
+        JsonObject frontMatter = new JsonObject().put("title", "Root File");
+        final PageSource templateSource = createPageSource("myfile.md", true, false);
+        PageLinkData data = new PageLinkData(templateSource, null, frontMatter);
+
+        assertEquals("root-file/", pageLink("", ":dir/:slug", data));
+    }
+
+    @Test
+    void testDirPlaceholderIndex() {
+        JsonObject frontMatter = new JsonObject().put("title", "My Dir");
+        final PageSource templateSource = createPageSource("posts/my-dir/index.md", true, true);
+        PageLinkData data = new PageLinkData(templateSource, "posts", frontMatter);
+
+        assertEquals("posts/my-dir/", pageLink("", ":dir/:slug", data));
     }
 
     // --- :path with explicit slug tests ---

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/utils/TemplateLink.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/utils/TemplateLink.java
@@ -7,7 +7,6 @@ import static io.quarkiverse.tools.stringpaths.StringPaths.addTrailingSlashIfNoE
 import static io.quarkiverse.tools.stringpaths.StringPaths.removeExtension;
 import static io.quarkiverse.tools.stringpaths.StringPaths.removeLeadingSlash;
 
-import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
@@ -68,6 +67,19 @@ public class TemplateLink {
                         () -> Optional.ofNullable(data.pageSource().date()).orElse(ZonedDateTime.now()).format(MONTH_FORMAT)),
                 Map.entry(":day",
                         () -> Optional.ofNullable(data.pageSource().date()).orElse(ZonedDateTime.now()).format(DAY_FORMAT)),
+                Map.entry(":dir", () -> {
+                    String path = removeExtension(data.pageSource().path());
+                    int lastSlash = path.lastIndexOf('/');
+                    if (lastSlash < 0) {
+                        return "";
+                    }
+                    String dir = path.substring(0, lastSlash);
+                    if (data.pageSource().isIndex()) {
+                        int parentSlash = dir.lastIndexOf('/');
+                        dir = parentSlash >= 0 ? dir.substring(0, parentSlash) : "";
+                    }
+                    return dir.isEmpty() ? "" : StringPaths.slugify(removeDate(dir), true, true).toLowerCase();
+                }),
                 Map.entry(":raw-path", () -> removeExtension(data.pageSource().path())),
                 Map.entry(":path", () -> {
                     String explicitSlug = data.data().getString(SLUG);
@@ -102,8 +114,9 @@ public class TemplateLink {
     public static String resolveName(PageSource pageSource) {
         final String name;
         if (pageSource.isIndex()) {
-            final Path parent = Path.of(pageSource.path()).getParent();
-            name = parent != null ? parent.getFileName().toString() : "not-available";
+            String path = pageSource.path();
+            int lastSlash = path.lastIndexOf('/');
+            name = lastSlash >= 0 ? StringPaths.fileName(path.substring(0, lastSlash)) : "not-available";
         } else {
             name = pageSource.baseFileName();
         }
@@ -149,9 +162,11 @@ public class TemplateLink {
             LinkData data, Map<String, Supplier<String>> mapping) {
         String link = template;
         link = resolvePlaceholders(link, mapping, template, data);
+        link = link.replaceAll("//+", "/");
 
-        if (link.endsWith("index") || link.endsWith("index.html")) {
-            link = link.replaceAll("index(\\.html)?", "");
+        if (link.endsWith("/index") || link.endsWith("/index.html")
+                || link.equals("index") || link.equals("index.html")) {
+            link = link.replaceFirst("index(\\.html)?$", "");
         }
         return addTrailingSlashIfNoExt(removeLeadingSlash(StringPaths.join(basePath, link)));
     }


### PR DESCRIPTION

Resolves #1005 

This adds a `:dir` placeholder which can be used to support non-collapsed collection paths. It is not used in the default, to continue to allow internal sorting patterns like `posts/2025` to work. 

The `:dir` placeholder strips `/draft/` segments, consistent with other placeholders. 

Ideally the path parsing would use utilities in `StringPath`, but the right utilities don't exist yet, so I didn't want to let that block this.