### PR TITLE
Allow link defaults to be configured globally

### DIFF
--- a/blog/content/docs/advanced.adoc
+++ b/blog/content/docs/advanced.adoc
@@ -312,11 +312,27 @@ NOTE: The slug derivation replaces all non-alphanumeric characters by `-` to mak
 
 Default link value:
 
-* for pages: `/:path:ext`.
-* for documents: `/:collection/:slug/`.
+* for pages: `/:path:ext` (configurable via `site.page-link`).
+* for documents in collections: `/:collection/:slug/` (configurable via `site.collections.<name>.link`).
 * for paginated page: `/:collection/page:page/`.
 
-TIP: You can define `link` in a layout to affect all the pages using that layout.
+[#global-link-config]
+=== Global link template configuration
+
+Instead of setting `link` in the frontmatter of every page, you can configure default link templates globally in `application.properties`:
+
+[source,properties]
+----
+# Default link template for non-collection pages
+site.page-link=/:slug/
+
+# Default link template for a specific collection
+site.collections.posts.link=/:collection/:year/:month/:name/
+----
+
+These global defaults apply to all pages or collection documents that don't have an explicit `link` in their frontmatter or layout. A frontmatter `link` always takes precedence over the global configuration.
+
+TIP: You can also define `link` in a layout to affect all the pages using that layout.
 
 [#roq-url]
 === Creating links between your pages

--- a/blog/includes/configs/quarkus-roq-frontmatter.adoc
+++ b/blog/includes/configs/quarkus-roq-frontmatter.adoc
@@ -514,6 +514,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-collections-collections-map-link]] [.property-path]##link:#quarkus-roq-frontmatter_site-collections-collections-map-link[`+++site.collections."collections-map".link+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++site.collections."collections-map".link+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Default link template for documents in this collection. Can be overridden per-page using the frontmatter `link` key. Supports placeholders: `:collection`, `:slug`, `:name`, `:ext`, etc.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++SITE_COLLECTIONS__COLLECTIONS_MAP__LINK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++SITE_COLLECTIONS__COLLECTIONS_MAP__LINK+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++/:collection/:slug/+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-collections-collections-map-from-data-id-key]] [.property-path]##link:#quarkus-roq-frontmatter_site-collections-collections-map-from-data-id-key[`+++site.collections."collections-map".from-data.id-key+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++site.collections."collections-map".from-data.id-key+++[]
@@ -599,6 +620,27 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-page-link]] [.property-path]##link:#quarkus-roq-frontmatter_site-page-link[`+++site.page-link+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++site.page-link+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Default link template for non-collection pages. Can be overridden per-page using the frontmatter `link` key. Supports placeholders: `:path`, `:slug`, `:name`, `:ext`, etc.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++SITE_PAGE_LINK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++SITE_PAGE_LINK+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++/:path:ext+++`
 
 |===
 

--- a/blog/includes/configs/quarkus-roq-frontmatter_site.adoc
+++ b/blog/includes/configs/quarkus-roq-frontmatter_site.adoc
@@ -514,6 +514,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-collections-collections-map-link]] [.property-path]##link:#quarkus-roq-frontmatter_site-collections-collections-map-link[`+++site.collections."collections-map".link+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++site.collections."collections-map".link+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Default link template for documents in this collection. Can be overridden per-page using the frontmatter `link` key. Supports placeholders: `:collection`, `:slug`, `:name`, `:ext`, etc.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++SITE_COLLECTIONS__COLLECTIONS_MAP__LINK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++SITE_COLLECTIONS__COLLECTIONS_MAP__LINK+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++/:collection/:slug/+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-collections-collections-map-from-data-id-key]] [.property-path]##link:#quarkus-roq-frontmatter_site-collections-collections-map-from-data-id-key[`+++site.collections."collections-map".from-data.id-key+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++site.collections."collections-map".from-data.id-key+++[]
@@ -599,6 +620,27 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-page-link]] [.property-path]##link:#quarkus-roq-frontmatter_site-page-link[`+++site.page-link+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++site.page-link+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Default link template for non-collection pages. Can be overridden per-page using the frontmatter `link` key. Supports placeholders: `:path`, `:slug`, `:name`, `:ext`, etc.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++SITE_PAGE_LINK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++SITE_PAGE_LINK+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++/:path:ext+++`
 
 |===
 

--- a/docs/modules/ROOT/pages/_includes/quarkus-roq-frontmatter.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-roq-frontmatter.adoc
@@ -514,6 +514,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-collections-collections-map-link]] [.property-path]##link:#quarkus-roq-frontmatter_site-collections-collections-map-link[`+++site.collections."collections-map".link+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++site.collections."collections-map".link+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Default link template for documents in this collection. Can be overridden per-page using the frontmatter `link` key. Supports placeholders: `:collection`, `:slug`, `:name`, `:ext`, etc.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++SITE_COLLECTIONS__COLLECTIONS_MAP__LINK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++SITE_COLLECTIONS__COLLECTIONS_MAP__LINK+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++/:collection/:slug/+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-collections-collections-map-from-data-id-key]] [.property-path]##link:#quarkus-roq-frontmatter_site-collections-collections-map-from-data-id-key[`+++site.collections."collections-map".from-data.id-key+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++site.collections."collections-map".from-data.id-key+++[]
@@ -599,6 +620,27 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-page-link]] [.property-path]##link:#quarkus-roq-frontmatter_site-page-link[`+++site.page-link+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++site.page-link+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Default link template for non-collection pages. Can be overridden per-page using the frontmatter `link` key. Supports placeholders: `:path`, `:slug`, `:name`, `:ext`, etc.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++SITE_PAGE_LINK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++SITE_PAGE_LINK+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++/:path:ext+++`
 
 |===
 

--- a/docs/modules/ROOT/pages/_includes/quarkus-roq-frontmatter_site.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-roq-frontmatter_site.adoc
@@ -514,6 +514,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-collections-collections-map-link]] [.property-path]##link:#quarkus-roq-frontmatter_site-collections-collections-map-link[`+++site.collections."collections-map".link+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++site.collections."collections-map".link+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Default link template for documents in this collection. Can be overridden per-page using the frontmatter `link` key. Supports placeholders: `:collection`, `:slug`, `:name`, `:ext`, etc.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++SITE_COLLECTIONS__COLLECTIONS_MAP__LINK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++SITE_COLLECTIONS__COLLECTIONS_MAP__LINK+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++/:collection/:slug/+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-collections-collections-map-from-data-id-key]] [.property-path]##link:#quarkus-roq-frontmatter_site-collections-collections-map-from-data-id-key[`+++site.collections."collections-map".from-data.id-key+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++site.collections."collections-map".from-data.id-key+++[]
@@ -599,6 +620,27 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |
+
+a|icon:lock[title=Fixed at build time] [[quarkus-roq-frontmatter_site-page-link]] [.property-path]##link:#quarkus-roq-frontmatter_site-page-link[`+++site.page-link+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++site.page-link+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Default link template for non-collection pages. Can be overridden per-page using the frontmatter `link` key. Supports placeholders: `:path`, `:slug`, `:name`, `:ext`, etc.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++SITE_PAGE_LINK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++SITE_PAGE_LINK+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++/:path:ext+++`
 
 |===
 

--- a/roq-editor/deployment/src/test/java/io/quarkiverse/roq/editor/deployment/git/GitSyncServiceTest.java
+++ b/roq-editor/deployment/src/test/java/io/quarkiverse/roq/editor/deployment/git/GitSyncServiceTest.java
@@ -721,6 +721,11 @@ class GitSyncServiceTest {
             public Optional<String> pathPrefix() {
                 return Optional.empty();
             }
+
+            @Override
+            public String pageLink() {
+                return "/:path:ext";
+            }
         };
     }
 

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep3DataProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep3DataProcessor.java
@@ -135,8 +135,12 @@ public class RoqFrontMatterStep3DataProcessor {
                             config.slugifyFiles())
                     : null;
             final PageSource pageSource = new PageSource(item.templateSource(), draft, dateString, files, false);
+            String linkTemplate = data.getString(LINK);
+            if (linkTemplate == null) {
+                linkTemplate = item.collection() != null ? item.collection().link() : config.pageLink();
+            }
             final String link = TemplateLink.pageLink(config.pathPrefixOrEmpty(),
-                    data.getString(LINK),
+                    linkTemplate,
                     new TemplateLink.PageLinkData(pageSource, item.collectionId(), data));
             RoqUrl url = rootUrl.resolve(link);
 

--- a/roq-frontmatter/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/roq-frontmatter/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -165,7 +165,7 @@ The layout template accesses data fields via `page.data`:
 
 **File naming**: Documents in collection directories use date-based names: `YYYY-MM-DD-slug.md` (e.g. `2024-08-29-welcome-to-roq.md`). The date is extracted from the filename.
 
-**Default URL resolution**: Page URLs are derived from the title (slugified), not from the filename. For example, a file `content/posts/2024-08-29-my-post.md` with `title: "My First Post"` will be served at `/posts/my-first-post`. Standalone pages in `content/` use their filename as the path (e.g. `content/about.md` becomes `/about`).
+**Default URL resolution**: Page URLs are derived from the title (slugified), not from the filename. For example, a file `content/posts/2024-08-29-my-post.md` with `title: "My First Post"` will be served at `/posts/my-first-post`. Standalone pages in `content/` use their filename as the path (e.g. `content/about.md` becomes `/about`). Default link templates can be configured globally: `site.page-link` for non-collection pages (default `/:path:ext`) and `site.collections.<name>.link` for collection documents (default `/:collection/:slug/`). These are overridden by an explicit `link` in the page's frontmatter or layout.
 
 **Iterating**:
 ```html

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterLinkConfigTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterLinkConfigTest.java
@@ -1,0 +1,67 @@
+package io.quarkiverse.roq.frontmatter.deployment.apptest;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+/**
+ * Site: {@code routing-site} (resource)
+ * <p>
+ * Config: custom page-link and collection link templates
+ * <p>
+ * Features tested: global link template configuration via
+ * {@code site.page-link} and {@code site.collections.<name>.link}.
+ */
+@DisplayName("Roq FrontMatter - Global link template configuration")
+public class RoqFrontMatterLinkConfigTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+            .overrideConfigKey("quarkus.roq.resource-dir", "routing-site")
+            .overrideConfigKey("site.page-link", "/:slug/")
+            .overrideConfigKey("site.collections.posts.link", "/:collection/:name/")
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("routing-site"));
+
+    @Test
+    @DisplayName("Post uses collection link config (/:collection/:name/) instead of default")
+    public void testPostUsesCollectionLinkConfig() {
+        // awesome-post.html has slug: awesome-post-1, but :name = awesome-post (filename)
+        RestAssured.when().get("/posts/awesome-post").then().statusCode(200).log().ifValidationFails()
+                .body("html.head.title", equalTo("My Cool Post"));
+    }
+
+    @Test
+    @DisplayName("Post is NOT served at default slug-based URL")
+    public void testPostNotAtDefaultUrl() {
+        // With /:collection/:name/, the slug-based URL should not exist
+        RestAssured.when().get("/posts/awesome-post-1").then().statusCode(404);
+    }
+
+    @Test
+    @DisplayName("Page without explicit link uses site page-link config (/:slug/)")
+    public void testPageUsesPageLinkConfig() {
+        // about.html has title "About Us", no explicit link → uses site.page-link = /:slug/
+        RestAssured.when().get("/about-us").then().statusCode(200).log().ifValidationFails()
+                .body("html.head.title", equalTo("About Us"));
+    }
+
+    @Test
+    @DisplayName("Page without explicit link is NOT served at default path-based URL")
+    public void testPageNotAtDefaultUrl() {
+        RestAssured.when().get("/pages/about").then().statusCode(404);
+    }
+
+    @Test
+    @DisplayName("Page with explicit frontmatter link ignores site page-link config")
+    public void testExplicitLinkOverridesConfig() {
+        // cool-page.html has explicit link: /my-cool-page — config doesn't affect it
+        RestAssured.when().get("/my-cool-page").then().statusCode(200).log().ifValidationFails()
+                .body("html.head.title", equalTo("My Cool Page"));
+    }
+}

--- a/roq-frontmatter/deployment/src/test/resources/routing-site/content/pages/about.html
+++ b/roq-frontmatter/deployment/src/test/resources/routing-site/content/pages/about.html
@@ -1,0 +1,6 @@
+---
+layout: page
+title: About Us
+---
+
+<h1>{page.title}</h1>

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/config/ConfiguredCollection.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/config/ConfiguredCollection.java
@@ -10,6 +10,7 @@ public record ConfiguredCollection(
         boolean hidden,
         boolean future,
         String layout,
+        String link,
         Optional<CollectionFromData> fromData) {
 
     public ConfiguredCollection {

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/config/RoqSiteConfig.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/config/RoqSiteConfig.java
@@ -24,8 +24,12 @@ public interface RoqSiteConfig {
     String PUBLIC_DIR = "public";
     String IGNORED_FILES = "**/_**,_**";
 
+    String DEFAULT_PAGE_LINK = "/:path:ext";
+    String DEFAULT_COLLECTION_LINK = "/:collection/:slug/";
+
     List<ConfiguredCollection> DEFAULT_COLLECTIONS = List
-            .of(new ConfiguredCollection("posts", false, false, false, "post", Optional.empty()));
+            .of(new ConfiguredCollection("posts", false, false, false, "post", DEFAULT_COLLECTION_LINK,
+                    Optional.empty()));
 
     /**
      * the base hostname & protocol for your site, e.g. http://example.com
@@ -215,6 +219,7 @@ public interface RoqSiteConfig {
                                 e.getValue().hidden(),
                                 e.getValue().future(),
                                 e.getValue().layout().orElse(null),
+                                e.getValue().link(),
                                 e.getValue().fromData()
                                         .map(value -> new ConfiguredCollection.CollectionFromData(
                                                 value.idKey(),
@@ -236,6 +241,14 @@ public interface RoqSiteConfig {
     default String pathPrefixOrEmpty() {
         return pathPrefix().orElse("");
     }
+
+    /**
+     * Default link template for non-collection pages.
+     * Can be overridden per-page using the frontmatter {@code link} key.
+     * Supports placeholders: {@code :path}, {@code :slug}, {@code :name}, {@code :ext}, etc.
+     */
+    @WithDefault(DEFAULT_PAGE_LINK)
+    String pageLink();
 
     interface CollectionConfig {
         /**
@@ -264,6 +277,14 @@ public interface RoqSiteConfig {
          * Resolves local layout first, then theme layout as fallback.
          */
         Optional<String> layout();
+
+        /**
+         * Default link template for documents in this collection.
+         * Can be overridden per-page using the frontmatter {@code link} key.
+         * Supports placeholders: {@code :collection}, {@code :slug}, {@code :name}, {@code :ext}, etc.
+         */
+        @WithDefault(DEFAULT_COLLECTION_LINK)
+        String link();
 
         /**
          * If present, documents for this collection will be created for the data (array or dir) with the same name as the

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/utils/TemplateLink.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/utils/TemplateLink.java
@@ -25,8 +25,6 @@ import io.quarkiverse.tools.stringpaths.StringPaths;
 import io.vertx.core.json.JsonObject;
 
 public class TemplateLink {
-    public static final String DEFAULT_PAGE_LINK_TEMPLATE = "/:path:ext";
-    public static final String DEFAULT_DOC_LINK_TEMPLATE = "/:collection/:slug/";
     public static final String DEFAULT_PAGINATE_LINK_TEMPLATE = "/:collection/page:page/";
     private static final DateTimeFormatter YEAR_FORMAT = DateTimeFormatter.ofPattern("yyyy");
     private static final DateTimeFormatter MONTH_FORMAT = DateTimeFormatter.ofPattern("MM");
@@ -118,24 +116,25 @@ public class TemplateLink {
     }
 
     public static String pageLink(String basePath, String template, PageLinkData data) {
-        return linkInternal(basePath, template,
-                data.collection == null ? DEFAULT_PAGE_LINK_TEMPLATE : DEFAULT_DOC_LINK_TEMPLATE, data,
-                withBasePlaceHolders(data, null));
+        return linkInternal(basePath, template, data, withBasePlaceHolders(data, null));
     }
 
     public static String paginateLink(String basePath, String template, PaginateLinkData data) {
-        return linkInternal(basePath, template, DEFAULT_PAGINATE_LINK_TEMPLATE, data, withBasePlaceHolders(data, Map.of(
-                ":page", () -> Objects.requireNonNull(data.page(), "page index is required to build the link"))));
+        return linkInternal(basePath, template != null ? template : DEFAULT_PAGINATE_LINK_TEMPLATE, data,
+                withBasePlaceHolders(data, Map.of(
+                        ":page",
+                        () -> Objects.requireNonNull(data.page(), "page index is required to build the link"))));
     }
 
     public static String link(String basePath, String template, String defaultTemplate, LinkData data,
             Map<String, Supplier<String>> placeHolders) {
-        return linkInternal(basePath, template, defaultTemplate, data, withBasePlaceHolders(data, placeHolders));
+        return linkInternal(basePath, template != null ? template : defaultTemplate, data,
+                withBasePlaceHolders(data, placeHolders));
     }
 
-    private static String linkInternal(String basePath, String template, String defaultTemplate,
+    private static String linkInternal(String basePath, String template,
             LinkData data, Map<String, Supplier<String>> mapping) {
-        String link = template != null ? template : defaultTemplate;
+        String link = template;
         link = resolvePlaceholders(link, mapping, template, data);
 
         if (link.endsWith("index") || link.endsWith("index.html")) {

--- a/roq-plugin/tagging/deployment/src/main/java/io/quarkiverse/roq/plugin/tagging/deployment/RoqPluginTaggingProcessor.java
+++ b/roq-plugin/tagging/deployment/src/main/java/io/quarkiverse/roq/plugin/tagging/deployment/RoqPluginTaggingProcessor.java
@@ -111,6 +111,7 @@ public class RoqPluginTaggingProcessor {
                         collection.hidden(),
                         collection.future(),
                         collection.layout(),
+                        collection.link(),
                         Optional.empty());
                 derivedCollectionProducer
                         .produce(new RoqFrontMatterPublishDerivedCollectionBuildItem(configuredCollection, e.getValue(), data));


### PR DESCRIPTION
At the moment link defaults are hardcoded in `LinkTemplate`, but it would be nicer if they were configurable. It would also make some of the decisions in #1013 easier, because users can make global changes if the default we choose is wrong for them. 

This is a 'prequel' to #1013, and I'm assuming it will merge first. So it just replicates the current defaults and doesn't change them. It does change quite a few files, which is mostly documentation. I did (with some umming and erring) change the internalLink method to not accept a fallback. Half the callers still use a fallback, but the other half don't, and the extra useless argument just seemed kind of awkward.