### PR TITLE
Add list:whereExp filter for Jekyll where_exp migration

### DIFF
--- a/migration/pom.xml
+++ b/migration/pom.xml
@@ -38,6 +38,18 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
 
+        <!-- Qute template extensions -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-qute</artifactId>
+        </dependency>
+
+        <!-- Vert.x JSON (JsonObject, JsonArray) -->
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/migration/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
+++ b/migration/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
@@ -1,12 +1,14 @@
 package io.quarkus.tools.migration;
 
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import io.quarkus.qute.RawString;
 import io.quarkus.qute.TemplateExtension;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 @TemplateExtension
 public class JekyllFiltersExtension {
@@ -74,8 +76,10 @@ public class JekyllFiltersExtension {
      * Usage in Qute: {myString.truncate(280)}
      */
     static String truncate(String str, int length) {
-        if (str == null) return "";
-        if (str.length() <= length) return str;
+        if (str == null)
+            return "";
+        if (str.length() <= length)
+            return str;
         return str.substring(0, length) + "...";
     }
 
@@ -91,11 +95,111 @@ public class JekyllFiltersExtension {
         sorted.sort((a, b) -> {
             String va = extractProperty(a, property);
             String vb = extractProperty(b, property);
-            if (va == null) return vb == null ? 0 : 1;
-            if (vb == null) return -1;
+            if (va == null)
+                return vb == null ? 0 : 1;
+            if (vb == null)
+                return -1;
             return va.compareToIgnoreCase(vb);
         });
         return sorted;
+    }
+
+    @TemplateExtension(namespace = "list")
+    static Object whereExp(Iterable<?> items, String loopVar, Object conditionsObj) {
+        if (items == null) {
+            return new ArrayList<>();
+        }
+
+        List<String> conditions;
+        if (conditionsObj instanceof String s) {
+            conditions = List.of(s);
+        } else if (conditionsObj instanceof Iterable<?> iter) {
+            conditions = new ArrayList<>();
+            for (Object o : iter) {
+                conditions.add(o.toString());
+            }
+        } else {
+            conditions = List.of(conditionsObj.toString());
+        }
+
+        String prefix = loopVar + ".";
+        boolean isJsonArray = items instanceof JsonArray;
+        List<Object> result = isJsonArray ? new JsonArray().getList() : new ArrayList<>();
+
+        for (Object item : items) {
+            boolean matches = true;
+            for (String condition : conditions) {
+                if (!evaluateCondition(item, prefix, condition)) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) {
+                result.add(item);
+            }
+        }
+        return isJsonArray ? new JsonArray(result) : result;
+    }
+
+    private static boolean evaluateCondition(Object item, String prefix, String condition) {
+        String[] operators = { ">=", "<=", "!=", "==", ">", "<", "contains" };
+
+        for (String op : operators) {
+            int idx = condition.indexOf(" " + op + " ");
+            if (idx >= 0) {
+                String left = condition.substring(0, idx).trim();
+                String right = condition.substring(idx + op.length() + 2).trim();
+
+                String property = left.startsWith(prefix) ? left.substring(prefix.length()) : left;
+
+                if ((right.startsWith("'") && right.endsWith("'"))
+                        || (right.startsWith("\"") && right.endsWith("\""))) {
+                    right = right.substring(1, right.length() - 1);
+                }
+
+                Object propValue = getProperty(item, property);
+                String propStr = propValue != null ? propValue.toString() : null;
+
+                return compareValues(propStr, op, right);
+            }
+        }
+        return false;
+    }
+
+    private static boolean compareValues(String left, String op, String right) {
+        if (left == null)
+            return false;
+        int cmp = left.compareTo(right);
+        return switch (op) {
+            case "==" -> cmp == 0;
+            case "!=" -> cmp != 0;
+            case ">" -> cmp > 0;
+            case ">=" -> cmp >= 0;
+            case "<" -> cmp < 0;
+            case "<=" -> cmp <= 0;
+            case "contains" -> left.contains(right);
+            default -> false;
+        };
+    }
+
+    private static Object getProperty(Object obj, String property) {
+        if (obj instanceof JsonObject json) {
+            return json.getValue(property);
+        }
+        if (obj instanceof java.util.Map<?, ?> map) {
+            return map.get(property);
+        }
+        Class<?> clazz = obj.getClass();
+        for (String p : new String[] { "get", "is", "" }) {
+            String methodName = p.isEmpty() ? property
+                    : p + Character.toUpperCase(property.charAt(0)) + property.substring(1);
+            try {
+                Method m = clazz.getMethod(methodName);
+                return m.invoke(obj);
+            } catch (Exception ignored) {
+            }
+        }
+        return null;
     }
 
     private static String extractProperty(Object obj, String property) {
@@ -126,7 +230,8 @@ public class JekyllFiltersExtension {
      * Usage in Qute: {=myString.raw}
      */
     static RawString raw(String str) {
-        if (str == null) return new RawString("");
+        if (str == null)
+            return new RawString("");
         return new RawString(str);
     }
 

--- a/migration/src/test/java/io/quarkus/tools/migration/JekyllFiltersExtensionTest.java
+++ b/migration/src/test/java/io/quarkus/tools/migration/JekyllFiltersExtensionTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.tools.migration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+class JekyllFiltersExtensionTest {
+
+    @Test
+    void testWhereExpSingleConditionGreaterThan() {
+        var items = List.of(
+                Map.of("urldate", "2021-09-14", "title", "A"),
+                Map.of("urldate", "2021-10-01", "title", "B"),
+                Map.of("urldate", "2021-08-01", "title", "C"));
+        var result = (List<?>) JekyllFiltersExtension.whereExp(items, "pub", "pub.urldate > '2021-09-01'");
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void testWhereExpSingleConditionLessThanOrEqual() {
+        var items = List.of(
+                Map.of("urldate", "2021-09-14", "title", "A"),
+                Map.of("urldate", "2021-10-01", "title", "B"));
+        var result = (List<?>) JekyllFiltersExtension.whereExp(items, "pub", "pub.urldate <= '2021-09-14'");
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void testWhereExpMultipleConditions() {
+        var items = List.of(
+                Map.of("urldate", "2021-08-01"),
+                Map.of("urldate", "2021-09-14"),
+                Map.of("urldate", "2021-10-01"),
+                Map.of("urldate", "2021-11-01"));
+        var result = (List<?>) JekyllFiltersExtension.whereExp(items, "pub",
+                List.of("pub.urldate > '2021-09-01'", "pub.urldate <= '2021-10-01'"));
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void testWhereExpNullItems() {
+        var result = (List<?>) JekyllFiltersExtension.whereExp(null, "pub", "pub.date > '2021-01-01'");
+        assertEquals(List.of(), result);
+    }
+
+    @Test
+    void testWhereExpEquals() {
+        var items = List.of(
+                Map.of("type", "article"),
+                Map.of("type", "video"),
+                Map.of("type", "article"));
+        var result = (List<?>) JekyllFiltersExtension.whereExp(items, "item", "item.type == 'article'");
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void testWhereExpGreaterThanOrEqual() {
+        var items = List.of(
+                Map.of("urldate", "2021-09-01"),
+                Map.of("urldate", "2021-09-14"),
+                Map.of("urldate", "2021-08-01"));
+        var result = (List<?>) JekyllFiltersExtension.whereExp(items, "pub", "pub.urldate >= '2021-09-01'");
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void testWhereExpJsonArrayReturnsJsonArray() {
+        var items = new JsonArray()
+                .add(new JsonObject().put("urldate", "2021-09-14"))
+                .add(new JsonObject().put("urldate", "2021-08-01"));
+        var result = JekyllFiltersExtension.whereExp(items, "pub", "pub.urldate > '2021-09-01'");
+        assertInstanceOf(JsonArray.class, result);
+        assertEquals(1, ((JsonArray) result).size());
+    }
+}


### PR DESCRIPTION
See discussion in https://github.com/quarkusio/quarkus/issues/54720

- Adds `list:whereExp` Qute template extension to handle Jekyll's `where_exp` filter, supporting comparison operators (`==`, `!=`, `>`, `>=`, `<`, `<=`, `contains`) with single or multiple conditions (AND logic)
- Preserves `JsonArray` return type so downstream methods like `.groupBy()` resolve correctly
- Makes `JekyllFiltersExtension` compilable, so that we can run tests (which this adds). To make it work, I also added Qute and Vert.x dependencies in the migration pom
