### PR TITLE
Honour slug in frontmatter with sneaky path conditional

### DIFF
--- a/blog/content/docs/advanced.adoc
+++ b/blog/content/docs/advanced.adoc
@@ -242,7 +242,7 @@ TIP: Those links are also available in the Qute data to allow <<roq-url>>.
 
 | All
 | `:path`
-| The file path of the page, slugified (converted to a URL-friendly format) without the extension.
+| The file path of the page, slugified (converted to a URL-friendly format) without the extension. If a `slug` is set in frontmatter, it replaces the filename portion while preserving the directory structure.
 | `my-page`, `search` or `docs/my-doc`
 
 | All

--- a/roq-frontmatter/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/roq-frontmatter/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -41,6 +41,7 @@ Pages in `content/` use YAML frontmatter between `---` delimiters. Supported for
 title: "My Page Title"
 description: "Page description for SEO"
 layout: page
+slug: custom-url-slug
 image: photo.jpg
 date: 2024-08-29 13:32:20 +0200
 tags: [blogging, quarkus]
@@ -60,6 +61,7 @@ Key fields:
 - **title** — Page title (falls back to source path if missing)
 - **description** — Used for SEO meta tags
 - **layout** — Qute layout template to wrap this page. Resolves local first, then theme fallback (e.g. `page`, `post`). Use `theme-layout:` to explicitly target a theme layout
+- **slug** — Custom URL slug. Used by the `:slug` placeholder (used in the default collection link template `/:collection/:slug/`) and also by `:path` (used in the default page link template `/:path:ext`). If not set, `:slug` falls back to the title, then filename; `:path` uses the filename
 - **image** — Page image. Can be a full URL, a filename from `public/images/`, or an attached file name (for directory pages). Do NOT include the `images/` prefix, just use the filename (e.g. `image: photo.jpg`, not `image: images/photo.jpg`)
 - **date** — Page date. For collection documents, can also be parsed from filename (`YYYY-MM-DD-slug.md`)
 - **tags** — String or array of tags
@@ -167,7 +169,7 @@ The layout template accesses data fields via `page.data`:
 
 **File naming**: Documents in collection directories use date-based names: `YYYY-MM-DD-slug.md` (e.g. `2024-08-29-welcome-to-roq.md`). The date is extracted from the filename.
 
-**Default URL resolution**: Page URLs are derived from the title (slugified), not from the filename. For example, a file `content/posts/2024-08-29-my-post.md` with `title: "My First Post"` will be served at `/posts/my-first-post`. Standalone pages in `content/` use their filename as the path (e.g. `content/about.md` becomes `/about`). Default link templates can be configured globally: `site.page-link` for non-collection pages (default `/:path:ext`) and `site.collections.<name>.link` for collection documents (default `/:collection/:slug/`). These are overridden by an explicit `link` in the page's frontmatter or layout.
+**Default URL resolution**: For collection documents, URLs are derived from the `slug` frontmatter field (if set), then the `title` (slugified), then the filename. For example, a file `content/posts/2024-08-29-my-post.md` with `title: "My First Post"` will be served at `/posts/my-first-post`. Standalone pages in `content/` use their filename as the path (e.g. `content/about.md` becomes `/about`); if a `slug` is set in frontmatter, `:path` will use it in place of the filename while preserving the directory structure. Default link templates can be configured globally: `site.page-link` for non-collection pages (default `/:path:ext`) and `site.collections.<name>.link` for collection documents (default `/:collection/:slug/`). These are overridden by an explicit `link` in the page's frontmatter or layout.
 
 **Iterating**:
 ```html

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/util/TemplateLinkTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/util/TemplateLinkTest.java
@@ -209,6 +209,71 @@ class TemplateLinkTest {
         assertEquals("2024/08/27/my-first/", pageLink("", ":year/:month/:day/:name~2", data));
     }
 
+    // --- :path with explicit slug tests ---
+
+    @Test
+    void testPathHonoursExplicitSlug() {
+        JsonObject frontMatter = new JsonObject().put("title", "Some Title").put("slug", "custom-slug");
+        final PageSource templateSource = createPageSource("posts/my-post.md", true, false);
+        PageLinkData data = new PageLinkData(templateSource, "posts", frontMatter);
+
+        assertEquals("posts/custom-slug/", pageLink("", ":path", data));
+    }
+
+    @Test
+    void testPathIgnoresTitle() {
+        JsonObject frontMatter = new JsonObject().put("title", "A Different Title");
+        final PageSource templateSource = createPageSource("posts/my-post.md", true, false);
+        PageLinkData data = new PageLinkData(templateSource, "posts", frontMatter);
+
+        assertEquals("posts/my-post/", pageLink("", ":path", data));
+    }
+
+    @Test
+    void testPathExplicitSlugNoDirectory() {
+        JsonObject frontMatter = new JsonObject().put("slug", "custom-slug");
+        final PageSource templateSource = createPageSource("myfile.md", true, false);
+        PageLinkData data = new PageLinkData(templateSource, null, frontMatter);
+
+        assertEquals("custom-slug/", pageLink("", ":path", data));
+    }
+
+    @Test
+    void testPathExplicitSlugNestedDirectory() {
+        JsonObject frontMatter = new JsonObject().put("slug", "my-guide");
+        final PageSource templateSource = createPageSource("posts/v2/guides/getting-started.md", true, false);
+        PageLinkData data = new PageLinkData(templateSource, "posts", frontMatter);
+
+        assertEquals("posts/v2/guides/my-guide/", pageLink("", ":path", data));
+    }
+
+    @Test
+    void testPathWithoutSlugUnchanged() {
+        JsonObject frontMatter = new JsonObject().put("title", "Whatever");
+        final PageSource templateSource = createPageSource("posts/2024-03-02-My-First-Blog-Post.md", true, false);
+        PageLinkData data = new PageLinkData(templateSource, "posts", frontMatter);
+
+        assertEquals("posts/2024-03-02-my-first-blog-post/", pageLink("", ":path", data));
+    }
+
+    @Test
+    void testPathExplicitSlugIsSlugified() {
+        JsonObject frontMatter = new JsonObject().put("slug", "My Custom Slug!");
+        final PageSource templateSource = createPageSource("posts/my-post.md", true, false);
+        PageLinkData data = new PageLinkData(templateSource, "posts", frontMatter);
+
+        assertEquals("posts/my-custom-slug/", pageLink("", ":path", data));
+    }
+
+    @Test
+    void testPathExplicitSlugIndexPage() {
+        JsonObject frontMatter = new JsonObject().put("slug", "custom-slug");
+        final PageSource templateSource = createPageSource("posts/my-dir/index.md", true, true);
+        PageLinkData data = new PageLinkData(templateSource, "posts", frontMatter);
+
+        assertEquals("posts/custom-slug/", pageLink("", ":path", data));
+    }
+
     @Test
     void testNoColonNoException() {
         JsonObject frontMatter = new JsonObject().put("title", "My First Blog Post");

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/utils/TemplateLink.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/utils/TemplateLink.java
@@ -69,8 +69,21 @@ public class TemplateLink {
                 Map.entry(":day",
                         () -> Optional.ofNullable(data.pageSource().date()).orElse(ZonedDateTime.now()).format(DAY_FORMAT)),
                 Map.entry(":raw-path", () -> removeExtension(data.pageSource().path())),
-                Map.entry(":path",
-                        () -> StringPaths.slugify(removeExtension(data.pageSource().path()), true, false).toLowerCase()),
+                Map.entry(":path", () -> {
+                    String explicitSlug = data.data().getString(SLUG);
+                    if (explicitSlug != null && !explicitSlug.isBlank()) {
+                        String path = removeExtension(data.pageSource().path());
+                        int lastSlash = path.lastIndexOf('/');
+                        String dir = lastSlash >= 0 ? path.substring(0, lastSlash) : "";
+                        if (data.pageSource().isIndex()) {
+                            int parentSlash = dir.lastIndexOf('/');
+                            dir = parentSlash >= 0 ? dir.substring(0, parentSlash) : "";
+                        }
+                        dir = dir.isEmpty() ? "" : StringPaths.slugify(dir, true, false).toLowerCase();
+                        return StringPaths.join(dir, slugify(explicitSlug).toLowerCase());
+                    }
+                    return StringPaths.slugify(removeExtension(data.pageSource().path()), true, false).toLowerCase();
+                }),
                 Map.entry(":ext",
                         () -> data.pageSource().isTargetHtml() ? ""
                                 : "." + data.pageSource().extension()),


### PR DESCRIPTION
Resolves #1009. 

I've gone for the option of putting the condition in the `:path` resolution. Where there's an index file, the slug replaces the last folder, not the `index` file part (which isn't used in `:path`). 


