### PR TITLE
Update Jekyll frontmatter converter for pagination and permalink migration

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterConverter.java
@@ -3,6 +3,10 @@ package io.quarkus.tools.migration.jekyll;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -37,16 +41,57 @@ public class JekyllFrontMatterConverter {
                 ? yamlMapper.readTree(Files.readString(configFile))
                 : null;
 
+        prefixIncludeTargets(contentDir);
+
+        // Merge redirect duplicates in content/ and in pre-move _<collection> dirs
+        mergeRedirectDuplicates(contentDir);
+        try (Stream<Path> dirs = Files.list(projectDir)) {
+            dirs.filter(Files::isDirectory)
+                    .filter(p -> p.getFileName().toString().startsWith("_"))
+                    .forEach(p -> {
+                        try {
+                            mergeRedirectDuplicates(p);
+                        } catch (IOException e) {
+                            System.err.println("Warning: could not deduplicate redirects in " + p + ": " + e.getMessage());
+                        }
+                    });
+        }
         convertPermalinks(contentDir);
+        // Also convert permalinks in pre-move _<collection> dirs.
+        // Pass the collection name as a path prefix so that e.g. _guides/guides.md
+        // compares against "guides/guides" (its post-move path), not just "guides".
+        try (Stream<Path> collDirs = Files.list(projectDir)) {
+            collDirs.filter(Files::isDirectory)
+                    .filter(p -> p.getFileName().toString().startsWith("_"))
+                    .filter(p -> !p.getFileName().toString().equals("_posts"))
+                    .forEach(p -> {
+                        try {
+                            String collectionName = p.getFileName().toString().substring(1);
+                            convertPermalinks(p, collectionName);
+                        } catch (IOException e) {
+                            System.err.println("Warning: could not convert permalinks in " + p + ": " + e.getMessage());
+                        }
+                    });
+        }
         convertPagination(contentDir, config);
     }
 
     /**
      * Convert Jekyll permalink frontmatter to Roq aliases.
-     * If the permalink matches the filename, it's redundant and removed.
+     * If the permalink matches the file's effective path, it's redundant and removed.
      * Otherwise it becomes an alias.
      */
     public void convertPermalinks(Path contentDir) throws IOException {
+        convertPermalinks(contentDir, "");
+    }
+
+    /**
+     * Convert Jekyll permalink frontmatter to Roq aliases.
+     *
+     * @param pathPrefix prepended to the relative path for comparison — used for
+     *        pre-move collection dirs where _foo/bar.md will become content/foo/bar.md
+     */
+    public void convertPermalinks(Path contentDir, String pathPrefix) throws IOException {
         for (Path file : findContentFiles(contentDir)) {
             String content = Files.readString(file);
             Matcher matcher = PERMALINK_LINE.matcher(content);
@@ -56,16 +101,19 @@ public class JekyllFrontMatterConverter {
 
             String permalinkValue = matcher.group(1).trim()
                     .replaceAll("^['\"]|['\"]$", "");
-            // Strip leading and trailing slashes
             String normalized = permalinkValue.replaceAll("^/|/$", "");
 
-            String filenameNoExt = stripExtension(file.getFileName().toString());
+            String relativePathNoExt = stripExtension(
+                    contentDir.relativize(file).toString());
+            String effectivePath = pathPrefix.isEmpty()
+                    ? relativePathNoExt
+                    : pathPrefix + "/" + relativePathNoExt;
 
-            if (normalized.equals(filenameNoExt)) {
+            if (normalized.equals(effectivePath)) {
                 content = PERMALINK_LINE.matcher(content).replaceFirst("");
             } else {
                 content = PERMALINK_LINE.matcher(content)
-                        .replaceFirst("aliases: " + Matcher.quoteReplacement(matcher.group(1)) + "\n");
+                        .replaceFirst("link: " + Matcher.quoteReplacement(matcher.group(1)) + "\n");
             }
 
             Files.writeString(file, content);
@@ -98,6 +146,104 @@ public class JekyllFrontMatterConverter {
         }
     }
 
+    /**
+     * Merge duplicate redirect files where both foo.html and foo.md exist.
+     * Jekyll redirect collections often have pairs covering both /foo.html and /foo/index.html URLs.
+     * In Roq, .md compiles to .html, causing duplicate template errors.
+     * Merges the .md permalink into the .html file as a YAML list of aliases, then deletes the .md.
+     */
+    public void mergeRedirectDuplicates(Path contentDir) throws IOException {
+        try (Stream<Path> paths = Files.walk(contentDir)) {
+            Map<String, Path> htmlFiles = new HashMap<>();
+            paths.filter(Files::isRegularFile)
+                    .filter(p -> p.getFileName().toString().endsWith(".html"))
+                    .forEach(p -> htmlFiles.put(stripExtension(p.getFileName().toString()), p));
+
+            for (Map.Entry<String, Path> entry : htmlFiles.entrySet()) {
+                Path mdFile = entry.getValue().getParent().resolve(entry.getKey() + ".md");
+                if (!Files.exists(mdFile)) {
+                    continue;
+                }
+
+                String htmlContent = Files.readString(entry.getValue());
+                String mdContent = Files.readString(mdFile);
+
+                Matcher htmlPermalink = PERMALINK_LINE.matcher(htmlContent);
+                Matcher mdPermalink = PERMALINK_LINE.matcher(mdContent);
+
+                if (!htmlPermalink.find() || !mdPermalink.find()) {
+                    continue;
+                }
+
+                String htmlPl = htmlPermalink.group(1).trim().replaceAll("^['\"]|['\"]$", "");
+                String mdPl = mdPermalink.group(1).trim().replaceAll("^['\"]|['\"]$", "");
+
+                String merged = PERMALINK_LINE.matcher(htmlContent)
+                        .replaceFirst("aliases:\n  - " + htmlPl + "\n  - " + mdPl + "\n");
+
+                Files.writeString(entry.getValue(), merged);
+                Files.delete(mdFile);
+            }
+        }
+    }
+
+    /**
+     * Rename content files without frontmatter that are AsciiDoc include targets.
+     * Adds a {@code _} prefix so Roq ignores them, and updates include directives in sibling files.
+     */
+    public void prefixIncludeTargets(Path contentDir) throws IOException {
+        if (!Files.isDirectory(contentDir)) {
+            return;
+        }
+
+        Path[] allFiles = findContentFiles(contentDir);
+        List<Path> noFrontmatter = new ArrayList<>();
+
+        for (Path file : allFiles) {
+            String name = file.getFileName().toString();
+            if (name.startsWith("_")) {
+                continue;
+            }
+            String firstLine = Files.readString(file).lines().findFirst().orElse("");
+            if (!"---".equals(firstLine.trim())) {
+                noFrontmatter.add(file);
+            }
+        }
+
+        for (Path file : noFrontmatter) {
+            String basename = file.getFileName().toString();
+            Path dir = file.getParent();
+            boolean included = false;
+
+            for (Path sibling : allFiles) {
+                if (sibling.equals(file) || !sibling.getParent().equals(dir) || !Files.exists(sibling)) {
+                    continue;
+                }
+                String content = Files.readString(sibling);
+                if (content.contains("include::" + basename + "[")) {
+                    included = true;
+                    break;
+                }
+            }
+
+            if (included) {
+                String prefixed = "_" + basename;
+                Files.move(file, dir.resolve(prefixed));
+                for (Path sibling : allFiles) {
+                    if (sibling.equals(file) || !sibling.getParent().equals(dir) || !Files.exists(sibling)) {
+                        continue;
+                    }
+                    String content = Files.readString(sibling);
+                    if (content.contains("include::" + basename + "[")) {
+                        content = content.replace("include::" + basename + "[", "include::" + prefixed + "[");
+                        Files.writeString(sibling, content);
+                    }
+                }
+                System.out.println("  [PREFIX] " + basename + " → " + prefixed);
+            }
+        }
+    }
+
     private String getPaginationConfig(JsonNode config, String key, String defaultValue) {
         if (config == null || !config.has("pagination")) {
             return defaultValue;
@@ -121,7 +267,7 @@ public class JekyllFrontMatterConverter {
         }
     }
 
-    private String stripExtension(String filename) {
+    private static String stripExtension(String filename) {
         int dot = filename.lastIndexOf('.');
         return dot > 0 ? filename.substring(0, dot) : filename;
     }

--- a/migration/src/test/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterConverterTest.java
@@ -183,9 +183,29 @@ class JekyllFrontMatterConverterTest {
 
         String result = Files.readString(contentDir.resolve("about.md"));
         assertFalse(result.contains("permalink:"));
-        assertFalse(result.contains("aliases:"));
+        assertFalse(result.contains("link:"));
         assertTrue(result.contains("layout: page"));
         assertTrue(result.contains("title: \"About\""));
+    }
+
+    @Test
+    void testPermalinkInSubdirNotStrippedWhenDifferentFromRelativePath(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Path guidesDir = contentDir.resolve("guides");
+        Files.createDirectories(guidesDir);
+        Files.writeString(guidesDir.resolve("guides.md"), """
+                ---
+                layout: documentation
+                permalink: /guides/
+                ---
+                """);
+
+        converter.convertPermalinks(contentDir);
+
+        String result = Files.readString(guidesDir.resolve("guides.md"));
+        assertTrue(result.contains("link: /guides/"),
+                "permalink /guides/ should become link because relative path is guides/guides, not guides");
+        assertFalse(result.contains("permalink:"));
     }
 
     @Test
@@ -220,7 +240,7 @@ class JekyllFrontMatterConverterTest {
         converter.convertPermalinks(contentDir);
 
         String result = Files.readString(contentDir.resolve("events.md"));
-        assertTrue(result.contains("aliases: /community/events/"));
+        assertTrue(result.contains("link: /community/events/"));
         assertFalse(result.contains("permalink:"));
     }
 
@@ -255,7 +275,230 @@ class JekyllFrontMatterConverterTest {
 
         String result = Files.readString(contentDir.resolve("about.md"));
         assertFalse(result.contains("permalink:"));
-        assertFalse(result.contains("aliases:"));
+        assertFalse(result.contains("link:"));
+    }
+
+    // --- Redirect deduplication tests ---
+
+    @Test
+    void testMergeRedirectDuplicates(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Path redirectsDir = contentDir.resolve("redirects/guides");
+        Files.createDirectories(redirectsDir);
+
+        Files.writeString(redirectsDir.resolve("foo-guide.html"), """
+                ---
+                permalink: /guides/foo-guide.html
+                newUrl: /guides/foo
+                ---
+                """);
+        Files.writeString(redirectsDir.resolve("foo-guide.md"), """
+                ---
+                permalink: /guides/foo-guide/index.html
+                newUrl: /guides/foo
+                ---
+                """);
+
+        converter.mergeRedirectDuplicates(contentDir);
+
+        assertTrue(Files.exists(redirectsDir.resolve("foo-guide.html")));
+        assertFalse(Files.exists(redirectsDir.resolve("foo-guide.md")));
+
+        String result = Files.readString(redirectsDir.resolve("foo-guide.html"));
+        assertTrue(result.contains("/guides/foo-guide.html"));
+        assertTrue(result.contains("/guides/foo-guide/index.html"));
+        assertTrue(result.contains("newUrl: /guides/foo"));
+    }
+
+    @Test
+    void testMergeRedirectDuplicatesNoMatch(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Path redirectsDir = contentDir.resolve("redirects/guides");
+        Files.createDirectories(redirectsDir);
+
+        Files.writeString(redirectsDir.resolve("only-md.md"), """
+                ---
+                permalink: /guides/only-md/index.html
+                newUrl: /guides/something
+                ---
+                """);
+        Files.writeString(redirectsDir.resolve("only-html.html"), """
+                ---
+                permalink: /guides/only-html.html
+                newUrl: /guides/other
+                ---
+                """);
+
+        converter.mergeRedirectDuplicates(contentDir);
+
+        assertTrue(Files.exists(redirectsDir.resolve("only-md.md")));
+        assertTrue(Files.exists(redirectsDir.resolve("only-html.html")));
+    }
+
+    @Test
+    void testConvertProjectMergesRedirectsInCollectionDir(@TempDir Path tempDir) throws IOException {
+        Files.createDirectories(tempDir.resolve("content"));
+        Files.writeString(tempDir.resolve("_config.yml"), "title: Test\n");
+
+        Path redirectsDir = tempDir.resolve("_redirects/guides");
+        Files.createDirectories(redirectsDir);
+        Files.writeString(redirectsDir.resolve("bar-guide.html"), """
+                ---
+                permalink: /guides/bar-guide.html
+                newUrl: /guides/bar
+                ---
+                """);
+        Files.writeString(redirectsDir.resolve("bar-guide.md"), """
+                ---
+                permalink: /guides/bar-guide/index.html
+                newUrl: /guides/bar
+                ---
+                """);
+
+        converter.convertProject(tempDir);
+
+        assertTrue(Files.exists(redirectsDir.resolve("bar-guide.html")));
+        assertFalse(Files.exists(redirectsDir.resolve("bar-guide.md")));
+
+        String result = Files.readString(redirectsDir.resolve("bar-guide.html"));
+        assertTrue(result.contains("/guides/bar-guide.html"));
+        assertTrue(result.contains("/guides/bar-guide/index.html"));
+    }
+
+    @Test
+    void testConvertProjectConvertsPermalinksInCollectionDirs(@TempDir Path tempDir) throws IOException {
+        Files.createDirectories(tempDir.resolve("content"));
+        Files.writeString(tempDir.resolve("_config.yml"), "title: Test\n");
+
+        Path guidesDir = tempDir.resolve("_guides");
+        Files.createDirectories(guidesDir);
+        Files.writeString(guidesDir.resolve("guides.md"), """
+                ---
+                layout: documentation
+                permalink: /guides/
+                ---
+                """);
+
+        converter.convertProject(tempDir);
+
+        String result = Files.readString(guidesDir.resolve("guides.md"));
+        assertTrue(result.contains("link: /guides/"),
+                "permalink /guides/ in _guides/guides.md should become link because " +
+                        "post-move path guides/guides != guides");
+        assertFalse(result.contains("permalink:"));
+    }
+
+    @Test
+    void testConvertProjectStripsRedundantPermalinkInCollectionDir(@TempDir Path tempDir) throws IOException {
+        Files.createDirectories(tempDir.resolve("content"));
+        Files.writeString(tempDir.resolve("_config.yml"), "title: Test\n");
+
+        Path guidesDir = tempDir.resolve("_guides");
+        Files.createDirectories(guidesDir);
+        Files.writeString(guidesDir.resolve("foo.md"), """
+                ---
+                permalink: /guides/foo/
+                ---
+                """);
+
+        converter.convertProject(tempDir);
+
+        String result = Files.readString(guidesDir.resolve("foo.md"));
+        assertFalse(result.contains("permalink:"), "redundant permalink should be stripped");
+        assertFalse(result.contains("link:"), "redundant permalink should not become link");
+    }
+
+    // --- Include target prefix tests ---
+
+    @Test
+    void testPrefixIncludeTargetsRenamesFileAndUpdatesInclude(@TempDir Path tempDir) throws IOException {
+        Path postsDir = tempDir.resolve("content/posts");
+        Files.createDirectories(postsDir);
+
+        Files.writeString(postsDir.resolve("transcription.adoc"),
+                "Some content with no frontmatter\n");
+        Files.writeString(postsDir.resolve("2020-04-30-insights.adoc"), """
+                ---
+                title: Insights
+                ---
+                Here is the transcript:
+                include::transcription.adoc[]
+                """);
+
+        converter.prefixIncludeTargets(tempDir.resolve("content"));
+
+        assertFalse(Files.exists(postsDir.resolve("transcription.adoc")),
+                "Original file should be renamed");
+        assertTrue(Files.exists(postsDir.resolve("_transcription.adoc")),
+                "File should be prefixed with _");
+
+        String parentContent = Files.readString(postsDir.resolve("2020-04-30-insights.adoc"));
+        assertTrue(parentContent.contains("include::_transcription.adoc[]"),
+                "Include directive should reference the renamed file");
+        assertFalse(parentContent.contains("include::transcription.adoc[]"),
+                "Old include reference should be gone");
+    }
+
+    @Test
+    void testPrefixIncludeTargetsSkipsFilesWithFrontmatter(@TempDir Path tempDir) throws IOException {
+        Path postsDir = tempDir.resolve("content/posts");
+        Files.createDirectories(postsDir);
+
+        Files.writeString(postsDir.resolve("real-post.adoc"), """
+                ---
+                title: A real post
+                ---
+                Post content
+                """);
+
+        converter.prefixIncludeTargets(tempDir.resolve("content"));
+
+        assertTrue(Files.exists(postsDir.resolve("real-post.adoc")),
+                "File with frontmatter should not be renamed");
+        assertFalse(Files.exists(postsDir.resolve("_real-post.adoc")));
+    }
+
+    @Test
+    void testPrefixIncludeTargetsMultipleFiles(@TempDir Path tempDir) throws IOException {
+        Path postsDir = tempDir.resolve("content/posts");
+        Files.createDirectories(postsDir);
+
+        Files.writeString(postsDir.resolve("transcription_0.adoc"),
+                "First transcript\n");
+        Files.writeString(postsDir.resolve("transcription_1.adoc"),
+                "Second transcript\n");
+        Files.writeString(postsDir.resolve("2020-04-30-insights.adoc"), """
+                ---
+                title: Insights
+                ---
+                include::transcription_0.adoc[]
+                include::transcription_1.adoc[]
+                """);
+
+        converter.prefixIncludeTargets(tempDir.resolve("content"));
+
+        assertFalse(Files.exists(postsDir.resolve("transcription_0.adoc")));
+        assertFalse(Files.exists(postsDir.resolve("transcription_1.adoc")));
+        assertTrue(Files.exists(postsDir.resolve("_transcription_0.adoc")));
+        assertTrue(Files.exists(postsDir.resolve("_transcription_1.adoc")));
+
+        String parentContent = Files.readString(postsDir.resolve("2020-04-30-insights.adoc"));
+        assertTrue(parentContent.contains("include::_transcription_0.adoc[]"));
+        assertTrue(parentContent.contains("include::_transcription_1.adoc[]"));
+    }
+
+    @Test
+    void testPrefixIncludeTargetsSkipsAlreadyPrefixed(@TempDir Path tempDir) throws IOException {
+        Path postsDir = tempDir.resolve("content/posts");
+        Files.createDirectories(postsDir);
+
+        Files.writeString(postsDir.resolve("_already-prefixed.adoc"),
+                "Some content\n");
+
+        converter.prefixIncludeTargets(tempDir.resolve("content"));
+
+        assertTrue(Files.exists(postsDir.resolve("_already-prefixed.adoc")),
+                "Already-prefixed file should stay as-is");
     }
 
     // --- Integration test ---


### PR DESCRIPTION
Better handling of permalinks and redirects than before. 

Also resolves #985.