### PR TITLE
Add qute: false alias, CLI --version, alert styling, and collapsible sections

### DIFF
--- a/blog/content/docs/basics.adoc
+++ b/blog/content/docs/basics.adoc
@@ -141,7 +141,7 @@ bar: |
 If you don't need Markdown, you can disable it by excluding the Markdown plugin from the Roq extension in your `pom.xml`.
 ====
 
-
+TIP: See the link:/markups/markdown/[Markdown markup test] page for example usage of all supported Markdown features.
 
 ==== AsciiDoc
 
@@ -149,6 +149,8 @@ AsciiDoc is also fully supported in Roq via the link:/plugin/asciidoc/[AsciiDoc 
 Once installed, to write pages or documents in AsciiDoc, simply use the `.adoc` or `.asciidoc` file extension.
 
 TIP: When using Qute expressions as link targets in AsciiDoc, use the explicit `link:` macro. AsciiDoc only auto-detects links for known URL schemes (http, https, ...), so `\{page.url}[Click here]` won't render as a link. Use `link:\{page.url}[Click here]` instead.
+
+TIP: See the link:/markups/asciidoc/[AsciiDoc markup test] page for example usage of all supported AsciiDoc features.
 
 [#collections]
 === Collections

--- a/blog/content/marketplace/plugins/asciidoc.md
+++ b/blog/content/marketplace/plugins/asciidoc.md
@@ -55,6 +55,30 @@ AsciiDoc headers are parsed by Roq and used as page data:
 | `{page-path}` | The page path (e.g. `/blog/about`) |
 |}
 
+### Collapsible sections
+
+Use the `%collapsible` option on an example block to create collapsible content. The default theme styles them automatically.
+
+```asciidoc
+.Click to expand
+[%collapsible]
+====
+Hidden content here.
+====
+```
+
+Add the `.result` role for a distinct output/result look:
+
+```asciidoc
+.Show result
+[%collapsible.result]
+====
+Result content with a background.
+====
+```
+
+See the [AsciiDoc markup test](/markups/asciidoc/#_collapsible_blocks) for a live example.
+
 ### AsciiDoc attributes configuration
 
 Attributes can be configured globally:

--- a/blog/content/marketplace/plugins/markdown.md
+++ b/blog/content/marketplace/plugins/markdown.md
@@ -14,3 +14,18 @@ Process `.md` and `.markdown` files using [CommonMark Java](https://github.com/c
 > Markdown plugin is already included in Quarkus Roq extension. No separate installation needed unless you removed it.
 
 Every file with `.md` or `.markdown` extension will be processed.
+
+### Collapsible sections
+
+Use standard HTML `<details>` and `<summary>` tags in your Markdown files for collapsible content. The default theme styles them automatically.
+
+```markdown
+<details>
+<summary>Click to reveal</summary>
+
+Hidden content with **Markdown formatting**.
+
+</details>
+```
+
+See the [Markdown markup test](/markups/markdown/#collapsible-sections) for a live example.

--- a/blog/content/markups/asciidoc.adoc
+++ b/blog/content/markups/asciidoc.adoc
@@ -4,6 +4,8 @@
 :page-content-toc-levels: 2
 :description: All AsciiDoc content types to verify theme styling
 
+pass:[<i class="fa-brands fa-github"></i>] https://github.com/quarkiverse/quarkus-roq/blob/main/blog/content/markups/asciidoc.adoc[View source on GitHub]
+
 This is a paragraph under heading 1. It contains *strong text*, _emphasized text_, and `inline code`.
 
 == Heading 2
@@ -234,6 +236,22 @@ Term 2:: Definition 2
 Term 3:: Definition 3
 +
 With additional paragraph.
+
+=== Collapsible Blocks
+
+.Click to expand
+[%collapsible]
+====
+This is hidden content inside a collapsible block.
+
+It supports *bold*, _italic_, and `code`.
+====
+
+.Show result
+[%collapsible.result]
+====
+This is a result block with a distinct background style.
+====
 
 === Checklist
 

--- a/blog/content/markups/markdown.md
+++ b/blog/content/markups/markdown.md
@@ -4,6 +4,8 @@ description: All Markdown content types to verify theme styling
 content-toc: true
 ---
 
+<i class="fa-brands fa-github"></i> [View source on GitHub](https://github.com/quarkiverse/quarkus-roq/blob/main/blog/content/markups/markdown.md)
+
 # Heading 1
 This is a paragraph under heading 1. It contains **strong text**, *emphasized text*, and `inline code`.
 
@@ -140,3 +142,27 @@ This heading has inline code: `variable = value`
 ### Code in Blockquotes
 
 > This blockquote contains `inline code` and shows how code is styled within quotes.
+
+## Collapsible Sections
+
+<details>
+<summary>Click to expand</summary>
+
+This is hidden content inside a collapsible section.
+
+It supports **bold**, *italic*, and `code`.
+
+</details>
+
+<details>
+<summary>With a code block</summary>
+
+```java
+public class Hello {
+    public static void main(String[] args) {
+        System.out.println("Hello!");
+    }
+}
+```
+
+</details>

--- a/blog/content/posts/2026-07-01-collapsible-sections/index.md
+++ b/blog/content/posts/2026-07-01-collapsible-sections/index.md
@@ -1,0 +1,117 @@
+---
+title: "Collapsible Sections: Hide and Reveal Content in Your Posts"
+description: The Roq default theme now styles HTML collapsible sections out of the box, in both Markdown and AsciiDoc content. Perfect for tutorials with hints, FAQs, and long reference sections.
+image: https://images.unsplash.com/photo-1563261438-73168c06ae56?q=80&w=1200&auto=format&fit=crop
+tags: new-feature, cool-stuff
+---
+
+The Roq default theme now includes styled **collapsible sections** using the standard HTML `<details>` and `<summary>` elements. They work in both Markdown and AsciiDoc content, with a pill-shaped toggle that expands on open, an animated arrow, and a fade-in effect.
+
+## In Markdown
+
+Use standard HTML `<details>` and `<summary>` tags directly in your `.md` files:
+
+```markdown
+<details>
+<summary>Click to reveal</summary>
+
+Your hidden content here. **Markdown formatting** works inside.
+
+</details>
+```
+
+Here is how it looks:
+
+<details>
+<summary>Click to reveal</summary>
+
+Your hidden content here. **Markdown formatting** works inside.
+
+</details>
+
+## Tutorial hints and solutions
+
+Collapsible sections are a great fit for tutorials where you want to give readers a chance to try on their own before revealing the answer:
+
+<details>
+<summary>Hint</summary>
+
+Use the `@Path` and `@GET` annotations on a resource class. Return a plain `String`.
+
+</details>
+
+<details>
+<summary>Solution</summary>
+
+```java
+@Path("/hello")
+public class GreetingResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "Hello from Roq!";
+    }
+}
+```
+
+</details>
+
+## Step-by-step instructions
+
+Multiple consecutive collapsible sections stack with a small gap between them:
+
+<details>
+<summary>Step 1: Create the project</summary>
+
+```bash
+quarkus create app my-app
+```
+
+</details>
+
+<details>
+<summary>Step 2: Add an extension</summary>
+
+```bash
+quarkus ext add rest-jackson
+```
+
+</details>
+
+<details>
+<summary>Step 3: Start dev mode</summary>
+
+```bash
+quarkus dev
+```
+
+Open [http://localhost:8080/hello](http://localhost:8080/hello) to see your endpoint.
+
+</details>
+
+## In AsciiDoc
+
+AsciiDoc content has its own collapsible styling using the `%collapsible` option on an example block:
+
+```asciidoc
+.Click to expand
+[%collapsible]
+====
+Hidden content here.
+====
+```
+
+Add the `.result` role for a distinct output/result look:
+
+```asciidoc
+.Show result
+[%collapsible.result]
+====
+Result content with a background.
+====
+```
+
+Both Markdown and AsciiDoc collapsible sections are styled by the default theme with no extra configuration needed.
+
+See them in action on the [Markdown markup test](/markups/markdown/#collapsible-sections) and [AsciiDoc markup test](/markups/asciidoc/#_collapsible_blocks) pages.

--- a/roq-cli/pom.xml
+++ b/roq-cli/pom.xml
@@ -60,6 +60,22 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>application.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>application.properties</exclude>
+                </excludes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqMain.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqMain.java
@@ -18,7 +18,8 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @QuarkusMain
-@Command(name = "roq", mixinStandardHelpOptions = true, subcommands = { StartCommand.class, ServeCommand.class,
+@Command(name = "roq", mixinStandardHelpOptions = true, versionProvider = RoqVersionProvider.class, subcommands = {
+        StartCommand.class, ServeCommand.class,
         CreateCommand.class, AddCommand.class, UpdateCommand.class, GenerateCommand.class, BlogCommand.class })
 public class RoqMain implements QuarkusApplication, Callable<Integer>, OutputProvider {
 

--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqVersionProvider.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqVersionProvider.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.roq.cli;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import picocli.CommandLine;
+
+public class RoqVersionProvider implements CommandLine.IVersionProvider {
+
+    @Override
+    public String[] getVersion() {
+        String version = ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.application.version", String.class)
+                .orElse("dev");
+        return new String[] { "roq " + version };
+    }
+}

--- a/roq-cli/src/main/resources/application.properties
+++ b/roq-cli/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+quarkus.application.version=${project.version}
 quarkus.log.level=WARN
 quarkus.log.category."io.quarkus.config".level=ERROR
 quarkus.banner.enabled=false

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep0SetupProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep0SetupProcessor.java
@@ -5,6 +5,7 @@ import static io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterConst
 import static io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterTemplateUtils.*;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.DRAFT;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.ESCAPE;
+import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.QUTE;
 import static io.quarkiverse.tools.stringpaths.StringPaths.addTrailingSlash;
 
 import java.nio.file.Path;
@@ -38,7 +39,7 @@ public class RoqFrontMatterStep0SetupProcessor {
         // Mark pages matching the "escaped-pages" glob patterns so their Qute expressions
         // are wrapped in escape delimiters (useful for pages containing code samples with { })
         dataModificationProducer.produce(new RoqFrontMatterDataModificationBuildItem(sourceData -> {
-            if (sourceData.isPage() && !sourceData.fm().containsKey(ESCAPE)
+            if (sourceData.isPage() && !sourceData.fm().containsKey(ESCAPE) && !sourceData.fm().containsKey(QUTE)
                     && isPageEscaped(config).test(sourceData.relativePath())) {
                 sourceData.fm().put(ESCAPE, true);
             }

--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterAssembleUtils.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterAssembleUtils.java
@@ -5,6 +5,7 @@ import static io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterTempl
 import static io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterTemplateUtils.getMarkup;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.ESCAPE;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.LAYOUT;
+import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.QUTE;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.THEME_LAYOUT;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqTemplates.THEME_LAYOUTS_DIR;
 
@@ -65,7 +66,8 @@ public final class RoqFrontMatterAssembleUtils {
                             metadata.filePath(), metadata.referencePath(), collection, isPage, data));
         }
 
-        boolean escaped = Boolean.parseBoolean(data.getString(ESCAPE, "false"));
+        boolean escaped = Boolean.parseBoolean(data.getString(ESCAPE, "false"))
+                || "false".equals(data.getString(QUTE));
         TransformedContent transformed = applyContentTransforms(content, escaped, metadata.markup(), layoutId, isPage);
 
         TemplateSource source = TemplateSource.create(

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqFrontMatterKeys.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqFrontMatterKeys.java
@@ -163,4 +163,13 @@ public interface RoqFrontMatterKeys {
      * ▸ Access: {@code page.data.getBoolean("escape")}
      */
     String ESCAPE = "escape";
+
+    /**
+     * Enable/disable Qute processing — e.g. {@code qute: false} (reversed alias for {@code escape: true})
+     * <br>
+     * ▸ Scope: page / document
+     * <br>
+     * ▸ Access: {@code page.data.getBoolean("qute")}
+     */
+    String QUTE = "qute";
 }

--- a/roq-theme/default/runtime/src/main/resources/web/_alerts.css
+++ b/roq-theme/default/runtime/src/main/resources/web/_alerts.css
@@ -1,7 +1,7 @@
 @layer components {
 
 .markdown-alert {
-@apply p-4 my-4 rounded-lg border-l-4;
+@apply p-4 my-4 rounded-r-lg border-l-4;
 }
 
 .markdown-alert-title {

--- a/roq-theme/default/runtime/src/main/resources/web/_details.css
+++ b/roq-theme/default/runtime/src/main/resources/web/_details.css
@@ -1,0 +1,48 @@
+@layer components {
+
+    .content-prose details {
+        @apply my-4;
+
+        > summary {
+            @apply inline-flex items-center gap-1.5 text-sm font-medium cursor-pointer select-none;
+            @apply px-3 py-1 rounded-full;
+            @apply bg-pop-100 text-pop-700 dark:bg-pop-900 dark:text-pop-300;
+            transition: background-color 0.2s, padding 0.2s, border-radius 0.2s;
+
+            &::-webkit-details-marker { @apply hidden; }
+
+            &::before {
+                content: "\276f";
+                font-size: 0.75em;
+                color: var(--color-neutral-400);
+                transition: transform 0.25s, color 0.25s;
+            }
+
+            &:hover {
+                @apply bg-pop-200 dark:bg-pop-800;
+                &::before { color: var(--color-pop-500); }
+            }
+        }
+
+        &[open] > summary {
+            @apply mb-2 px-4 py-1.5 rounded-md w-full;
+            @apply bg-pop-50 text-pop-800 dark:bg-pop-950 dark:text-pop-200;
+            &::before { transform: rotate(90deg); }
+        }
+
+        &[open] > :not(summary) {
+            @apply pl-4;
+            animation: detailsFadeIn 0.3s ease;
+        }
+
+        &[open] > :not(summary):first-of-type { @apply mt-0; }
+    }
+
+    .content-prose details + details { @apply mt-3; }
+
+    @keyframes detailsFadeIn {
+        from { opacity: 0; transform: translateY(-4px); }
+        to { opacity: 1; transform: translateY(0); }
+    }
+
+}

--- a/roq-theme/default/runtime/src/main/resources/web/roq.css
+++ b/roq-theme/default/runtime/src/main/resources/web/roq.css
@@ -42,6 +42,7 @@
 /* Typography */
 @import "./_prose.css";
 @import "./_content-prose.css";
+@import "./_details.css";
 
 /* Responsive Styles */
 @import "./_responsive.css";

--- a/roq-theme/default/runtime/src/main/resources/web/toc.js
+++ b/roq-theme/default/runtime/src/main/resources/web/toc.js
@@ -40,6 +40,7 @@
     if (!headings.length) return sidebar.parentNode.removeChild(sidebar)
 
     var lastActiveFragment
+    var clickedAt = 0
     var links = {}
     var list = headings.reduce(function (accum, heading) {
         var link = document.createElement('a')
@@ -73,52 +74,42 @@
         window.addEventListener('scroll', onScroll)
     })
 
+    function setActive (fragment) {
+        if (fragment === lastActiveFragment) return
+        if (lastActiveFragment) links[lastActiveFragment].classList.remove('is-active')
+        if (fragment && links[fragment]) {
+            links[fragment].classList.add('is-active')
+            if (list.scrollHeight > list.offsetHeight) {
+                list.scrollTop = Math.max(0, links[fragment].offsetTop + links[fragment].offsetHeight - list.offsetHeight)
+            }
+        }
+        lastActiveFragment = fragment
+    }
+
     function onScroll () {
-        var scrolledBy = window.pageYOffset
+        if (Date.now() - clickedAt < 500) return
         var buffer = getNumericStyleVal(document.documentElement, 'fontSize') * 1.15
         var ceil = article.offsetTop
-        if (scrolledBy && window.innerHeight + scrolledBy + 2 >= document.documentElement.scrollHeight) {
-            lastActiveFragment = Array.isArray(lastActiveFragment) ? lastActiveFragment : Array(lastActiveFragment || 0)
-            var activeFragments = []
-            var lastIdx = headings.length - 1
-            headings.forEach(function (heading, idx) {
-                var fragment = '#' + heading.id
-                if (idx === lastIdx || heading.getBoundingClientRect().top + getNumericStyleVal(heading, 'paddingTop') > ceil) {
-                    activeFragments.push(fragment)
-                    if (lastActiveFragment.indexOf(fragment) < 0) links[fragment].classList.add('is-active')
-                } else if (~lastActiveFragment.indexOf(fragment)) {
-                    links[lastActiveFragment.shift()].classList.remove('is-active')
-                }
-            })
-            list.scrollTop = list.scrollHeight - list.offsetHeight
-            lastActiveFragment = activeFragments.length > 1 ? activeFragments : activeFragments[0]
-            return
-        }
-        if (Array.isArray(lastActiveFragment)) {
-            lastActiveFragment.forEach(function (fragment) {
-                links[fragment].classList.remove('is-active')
-            })
-            lastActiveFragment = undefined
-        }
         var activeFragment
         headings.some(function (heading) {
             if (heading.getBoundingClientRect().top + getNumericStyleVal(heading, 'paddingTop') - buffer > ceil) return true
             activeFragment = '#' + heading.id
         })
-        if (activeFragment) {
-            if (activeFragment === lastActiveFragment) return
-            if (lastActiveFragment) links[lastActiveFragment].classList.remove('is-active')
-            var activeLink = links[activeFragment]
-            activeLink.classList.add('is-active')
-            if (list.scrollHeight > list.offsetHeight) {
-                list.scrollTop = Math.max(0, activeLink.offsetTop + activeLink.offsetHeight - list.offsetHeight)
-            }
-            lastActiveFragment = activeFragment
-        } else if (lastActiveFragment) {
-            links[lastActiveFragment].classList.remove('is-active')
-            lastActiveFragment = undefined
+        if (!activeFragment && headings.length) {
+            activeFragment = '#' + headings[headings.length - 1].id
         }
+        setActive(activeFragment)
     }
+
+    list.addEventListener('click', function (e) {
+        var link = e.target.closest('a')
+        if (!link) return
+        var fragment = link.getAttribute('href')
+        if (fragment) {
+            clickedAt = Date.now()
+            setActive(fragment)
+        }
+    })
 
     function find (selector, from) {
         return [].slice.call((from || document).querySelectorAll(selector))


### PR DESCRIPTION
## Summary

- **`qute: false` frontmatter alias**: reversed alias for `escape: true` in YAML frontmatter, consistent with the existing `:qute:` AsciiDoc attribute
- **CLI `--version`**: `roq --version` now prints the version via a `RoqVersionProvider` with Maven resource filtering
- **Alert styling**: use `rounded-r-lg` instead of `rounded-lg` for markdown alert boxes (straight left border edge, rounded right corners)
- **Collapsible sections**: styled `<details>/<summary>` elements and TOC navigation fix