### PR TITLE
ci: windows preview

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -9,9 +9,41 @@ on:
       - '*.md'
       - '*.txt'
       - '.all-contributorsrc'
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  test:
+    name: Test on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Prepare git
+        run: git config --global core.autocrlf false
+        if: startsWith(matrix.os, 'windows')
+
+      - uses: actions/checkout@v6
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: 'maven'
+
+      - name: Test Roq
+        run: mvn -B clean install --file pom.xml -Dno-format
+
   build-website:
     name: Build Website
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Closes: #1035

The only explicit normalization in our codebase so far is this: [here](https://github.com/quarkiverse/quarkus-roq/blob/157abfa80be81ac3ffcb526a9b6c82dffe152135/roq-editor/deployment/src/main/java/io/quarkiverse/roq/editor/deployment/git/GitContentFilter.java#L77)

I haven't seen any more `File.separator` instances so far.