### PR TITLE
Publish comments tutorials

### DIFF
--- a/blog/content/posts/2026-07-07-add-comments-hybrid/index.md
+++ b/blog/content/posts/2026-07-07-add-comments-hybrid/index.md
@@ -27,15 +27,15 @@ In about 30 minutes, you'll add a comment system to your blog with an H2 databas
 
 Roq's hybrid plugin makes pages render dynamically per request instead of being pre-generated at build time. Each page can choose its caching strategy via frontmatter.
 
-Add these dependencies to your `pom.xml`:
+Add the hybrid plugin:
+
+```shell
+roq add plugin:hybrid
+```
+
+Then add the backend dependencies to your `pom.xml`:
 
 ```xml
-<!-- Hybrid mode: dynamic page rendering -->
-<dependency>
-    <groupId>io.quarkiverse.roq</groupId>
-    <artifactId>quarkus-roq-plugin-hybrid</artifactId>
-</dependency>
-
 <!-- Database: Hibernate ORM Panache + H2 -->
 <dependency>
     <groupId>io.quarkus</groupId>
@@ -62,7 +62,7 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 🚀 Restart dev mode. The app should start with no errors.
 
-🚀🔑 With the hybrid plugin active, every page is now served dynamically. By default, pages use `cache: lazy` caching (rendered on first request, cached for subsequent ones). We'll set `cache: false` on the post layout so comments are always fresh.
+🚀🔑 With the hybrid plugin active, every page is now served dynamically. By default, pages use `cache: lazy` caching (rendered on first request, cached for subsequent ones). We'll set `cache: lazy` with a short TTL on the post layout so comments stay fresh.
 
 
 ## 2. Create the Comment entity
@@ -162,16 +162,16 @@ public class CommentService {
 
 ## 4. Set post pages to dynamic rendering
 
-For comments to show up in real time, the post layout must render on every request instead of serving a cached version.
+For comments to show up, the post layout must render dynamically instead of being pre-generated at build time. We'll use `cache: lazy` with a short TTL so pages are cached but refresh every 30 seconds. This is a good balance: most visitors see a fast cached page, and new comments appear within half a minute.
 
 **››› CODING TIME**
 
-Edit your post layout and add `cache: false` to the frontmatter.
+Edit your post layout and add `cache: lazy` with `cache-ttl: 30s` to the frontmatter.
 
 <details>
 <summary>See hint</summary>
 
-If you used the default theme (Tutorial 1a), you need to override the post layout by creating `templates/layouts/post.html` with `theme-layout: post` and `cache: false`. If you built from scratch (Tutorial 1b), just add `cache: false` to your existing `templates/layouts/post.html`.
+If you used the default theme (Tutorial 1a), you need to override the post layout by creating `templates/layouts/post.html` with `theme-layout: post`, `cache: lazy`, and `cache-ttl: 30s`. If you built from scratch (Tutorial 1b), just add those fields to your existing `templates/layouts/post.html`.
 
 </details>
 
@@ -183,64 +183,57 @@ Create `templates/layouts/post.html` to override the theme:
 ```html
 ---
 theme-layout: post
-cache: false
+cache: lazy
+cache-ttl: 30s
 ---
 
 {#insert /}
 ```
-
-This extends the default theme's post layout but disables caching so comments are live.
 
 </details>
 
 <details>
 <summary>See solution (from-scratch theme)</summary>
 
-Edit `templates/layouts/post.html` and add `cache: false` to the frontmatter:
+Edit `templates/layouts/post.html` and add caching to the frontmatter:
 
 ```yaml
 ---
 layout: default
-cache: false
+cache: lazy
+cache-ttl: 30s
 ---
 ```
 
 </details>
 
-🚀🔑 `cache: false` means this page renders fresh on every request. Qute re-evaluates all expressions, including our `cdi:comments` bean, so new comments appear immediately without a rebuild or cache flush.
+🚀🔑 `cache: lazy` renders the page on first request, then caches it for the duration of `cache-ttl`. After 30 seconds, the next request gets a fresh render with the latest comments. For development, you can use `cache: false` to see changes instantly.
 
 > [!NOTE]
-> Other cache options: `cache: lazy` (render once, cache until TTL expires) and `cache: startup` (pre-render at startup, cache forever). Use `lazy` with a `cache-ttl: 30s` for pages that can tolerate slightly stale data.
+> Other cache options: `cache: false` (render fresh on every request, good for development) and `cache: startup` (pre-render at startup, cache forever, good for pages that never change).
 
 
 ## 5. Add the comment form and list
 
-Now let's display comments and a submission form on every post.
+Now let's display comments and a submission form on every post. We'll create a reusable partial so the comments section can be included in any layout.
 
 **››› CODING TIME**
 
-Add a comments section to your post layout: a list of existing comments (fetched via `cdi:comments.forPost(page.slug)`) and a form that posts to `/api/comments`.
+Create a `templates/partials/comments.html` partial with a list of existing comments and a form that posts to `/api/comments`. Then include it in your post layout.
 
 <details>
 <summary>See hint</summary>
 
-Use `{#for comment in cdi:comments.forPost(page.slug)}` to iterate over comments for the current post. The `page.slug` gives you the post's slug from its URL. The form should use `method="POST"` with `action="/api/comments"` and include hidden field `postSlug` with the current page's slug. Fields: `author` (text), `content` (textarea).
+Use `{#for comment in cdi:comments.forPost(page.slug)}` to iterate over comments for the current post. The form should use `method="POST"` with `action="/api/comments"` and include hidden fields `postSlug` and `redirectUrl`. Then include the partial in `post.html` with `{#include partials/comments /}`.
 
 </details>
 
 <details>
-<summary>See solution (default theme)</summary>
+<summary>See solution</summary>
 
-Replace `templates/layouts/post.html`:
+Create `templates/partials/comments.html`:
 
 ```html
----
-theme-layout: post
-cache: false
----
-
-{#insert /}
-
 <!-- Comments section -->
 <section class="mt-12 border-t border-slate-200 dark:border-slate-700 pt-8">
   <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-6">
@@ -253,7 +246,7 @@ cache: false
     <div class="p-4 rounded-lg bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700">
       <div class="flex items-center justify-between mb-2">
         <span class="font-medium text-sm text-slate-800 dark:text-slate-200">{comment.author}</span>
-        <time class="text-xs text-slate-500 dark:text-slate-400">{comment.createdAt}</time>
+        <time class="text-xs text-slate-500 dark:text-slate-400">{comment.createdAt.format('MMM d, yyyy HH:mm')}</time>
       </div>
       <p class="text-sm text-slate-700 dark:text-slate-300">{comment.content}</p>
     </div>
@@ -283,6 +276,21 @@ cache: false
   </form>
 </section>
 ```
+
+Then update `templates/layouts/post.html` (default theme):
+
+```html
+---
+theme-layout: post
+cache: lazy
+cache-ttl: 30s
+---
+
+{#insert /}
+{#include partials/comments /}
+```
+
+Or for the from-scratch theme, add `{#include partials/comments /}` after your post content in `templates/layouts/post.html`.
 
 </details>
 
@@ -348,7 +356,7 @@ public class CommentResource {
 
 🚀 Go to a blog post, fill in the form, and click "Post comment". The page should reload and show your comment!
 
-🤩 You just added dynamic comments to a static site generator. The post page renders on every request (`cache: false`), queries the database for comments, and displays them. The form saves to H2 via Panache, and the redirect brings you right back to the post.
+🤩 You just added dynamic comments to a static site generator. The post page renders dynamically with `cache: lazy`, queries the database for comments, and displays them. The form saves to H2 via Panache, and the redirect brings you right back to the post.
 
 
 ## 7. Add sample data for development
@@ -417,7 +425,7 @@ public class SampleData {
 ## What you've learned
 
 - **Hybrid mode** turns Roq from a static site generator into a dynamic server with smart caching
-- **`cache: false`** makes a page render fresh on every request, with full CDI access
+- **`cache: lazy`** with `cache-ttl` renders pages dynamically with smart caching
 - **Panache entities** give you a database model with zero boilerplate
 - **`@Named` beans** make Java services available in Qute templates via `cdi:` prefix
 - **POST/redirect/GET** is the standard pattern for form handling in server-rendered apps
@@ -428,4 +436,4 @@ public class SampleData {
 - **Add HTMX**: replace the full page reload with `hx-post` for instant comment submission (see the [Quarkus Web Lab](https://github.com/quarkusio/quarkus-web-lab) for HTMX patterns)
 - **Switch to PostgreSQL**: replace H2 with `quarkus-jdbc-postgresql` for production
 - **Add moderation**: add an `approved` boolean field and only show approved comments
-- **Use `cache: lazy` with TTL**: for better performance, try `cache-ttl: 30s` instead of `cache: false`
+- **Try `cache: false`**: for instant comment visibility during development, switch to `cache: false` (renders fresh on every request)

--- a/blog/content/posts/2026-07-07-add-comments-hybrid/index.md
+++ b/blog/content/posts/2026-07-07-add-comments-hybrid/index.md
@@ -5,7 +5,6 @@ description: "Step-by-step tutorial: add dynamic comments to your Roq blog using
 author: ia3andy
 tags: [tutorial]
 series: roq-blog-lab
-draft: true
 date: 2026-07-05 13:00
 image: https://images.unsplash.com/photo-1516321318423-f06f85e504b3?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
 qute: false

--- a/blog/content/posts/2026-07-07-add-comments-web-component/index.md
+++ b/blog/content/posts/2026-07-07-add-comments-web-component/index.md
@@ -5,7 +5,6 @@ description: "Step-by-step tutorial: build a Lit web component for comments back
 author: ia3andy
 tags: [tutorial]
 series: roq-blog-lab
-draft: true
 date: 2026-07-05 14:00
 image: https://images.unsplash.com/photo-1555421689-491a97ff2040?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
 qute: false

--- a/blog/content/posts/2026-07-07-add-comments-web-component/index.md
+++ b/blog/content/posts/2026-07-07-add-comments-web-component/index.md
@@ -43,13 +43,14 @@ Then configure the app in `src/main/resources/application.properties`:
 
 ```properties
 quarkus.http.port=7070
+quarkus.web-bundler.bundle-redirect=true
 quarkus.datasource.db-kind=h2
 quarkus.hibernate-orm.database.generation=drop-and-create
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=http://localhost:8080,http://localhost:7070
 ```
 
-The comments app runs on port 7070 so it doesn't conflict with your blog. CORS is enabled so the blog (on port 8080) can load the web component script and call the API.
+The comments app runs on port 7070 so it doesn't conflict with your blog. CORS is enabled so the blog can load the web component script and call the API. If your blog runs on a different port, adjust the `cors.origins` accordingly.
 
 If you don't have the Quarkus CLI yet, install it with JBang (same as Roq):
 
@@ -76,7 +77,7 @@ Just like in the hybrid tutorial, we need a database model for comments. Panache
 
 **››› CODING TIME**
 
-Create `src/main/java/io/acme/Comment.java` as a Panache entity with `author`, `content`, `createdAt`, and `postSlug` fields. Add a query method to find comments by post slug, and a method that persists a new comment and returns the updated list.
+Create `src/main/java/org/acme/Comment.java` as a Panache entity with `author`, `content`, `createdAt`, and `postSlug` fields. Add a query method to find comments by post slug, and a method that persists a new comment and returns the updated list.
 
 <details>
 <summary>See hint</summary>
@@ -88,10 +89,10 @@ Extend `PanacheEntity` for a free `id` field and CRUD methods. Use `@Entity` fro
 <details>
 <summary>See solution</summary>
 
-Create `src/main/java/io/acme/Comment.java`:
+Create `src/main/java/org/acme/Comment.java`:
 
 ```java
-package io.acme;
+package org.acme;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -124,7 +125,7 @@ The web component will talk to a REST API. We need two endpoints: GET to fetch c
 
 **››› CODING TIME**
 
-Create `src/main/java/io/acme/CommentResource.java` with a GET endpoint at `/api/comments/{postSlug}` and a POST endpoint at `/api/comments`. The POST should return the updated list of comments so the web component can refresh immediately.
+Create `src/main/java/org/acme/CommentResource.java` with a GET endpoint at `/api/comments/{postSlug}` and a POST endpoint at `/api/comments`. The POST should return the updated list of comments so the web component can refresh immediately.
 
 <details>
 <summary>See hint</summary>
@@ -136,10 +137,10 @@ Use `@Path("/api/comments")`, `@GET` with `@Path("{postSlug}")` for fetching, an
 <details>
 <summary>See solution</summary>
 
-Create `src/main/java/io/acme/CommentResource.java`:
+Create `src/main/java/org/acme/CommentResource.java`:
 
 ```java
-package io.acme;
+package org.acme;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -192,7 +193,7 @@ This is where it gets fun. We'll create a custom HTML element `<comments-section
 
 **››› CODING TIME**
 
-Create `web/comments-section.js` as a Lit component. It should:
+Create `src/main/resources/web/comments-section.js` as a Lit component. It should:
 - Accept a `post-slug` attribute to know which post's comments to load
 - Fetch comments from `/api/comments/{postSlug}` when connected to the DOM
 - Render a list of existing comments (author, date, content)
@@ -209,7 +210,7 @@ Import `LitElement`, `html`, and `css` from `lit`. Define a class that extends `
 <details>
 <summary>See solution</summary>
 
-Create `web/comments-section.js`:
+Create `src/main/resources/web/comments-section.js`:
 
 ```javascript
 import { LitElement, html, css } from 'lit';
@@ -362,7 +363,7 @@ class CommentsSection extends LitElement {
             <div class="comment-card">
               <div class="comment-meta">
                 <strong>${c.author}</strong>
-                <span>${c.createdAt}</span>
+                <span>${new Date(c.createdAt).toLocaleString()}</span>
               </div>
               <div class="comment-body">${c.content}</div>
             </div>
@@ -394,7 +395,7 @@ customElements.define('comments-section', CommentsSection);
 🚀🔑 This is a **web component**. It's a custom HTML element (`<comments-section>`) that encapsulates its own rendering, styles, and behavior. The styles inside `static styles` are scoped to the component (Shadow DOM), so they won't leak into the rest of your page. Lit makes reactive updates automatic: change `this.comments` and the list re-renders.
 
 > [!NOTE]
-> The file lives in `web/` because Roq's Web Bundler automatically picks up all JS files there and bundles them via esbuild. The `{#bundle /}` tag in your layout includes the bundled output. No extra configuration needed.
+> The file lives in `src/main/resources/web/` because Web Bundler automatically picks up all JS files there and bundles them via esbuild. No extra configuration needed.
 
 
 ## 5. Embed the component in the blog
@@ -424,7 +425,7 @@ theme-layout: post
 
 {#insert /}
 
-<script crossorigin src="http://localhost:7070/static/bundle/main.js" type="module"></script>
+<script crossorigin src="http://localhost:7070/static/bundle/app.js" type="module"></script>
 <comments-section post-slug="{page.slug}" server-url="http://localhost:7070"></comments-section>
 ```
 
@@ -436,7 +437,7 @@ theme-layout: post
 In your existing `templates/layouts/post.html`, add the script and component after the article content:
 
 ```html
-<script crossorigin src="http://localhost:7070/static/bundle/main.js" type="module"></script>
+<script crossorigin src="http://localhost:7070/static/bundle/app.js" type="module"></script>
 <comments-section post-slug="{page.slug}" server-url="http://localhost:7070"></comments-section>
 ```
 
@@ -465,10 +466,10 @@ Use a CDI bean with `@Observes StartupEvent`, check `LaunchMode.DEVELOPMENT`, an
 <details>
 <summary>See solution</summary>
 
-Create `src/main/java/io/acme/SampleData.java`:
+Create `src/main/java/org/acme/SampleData.java`:
 
 ```java
-package io.acme;
+package org.acme;
 
 import java.time.LocalDateTime;
 


### PR DESCRIPTION
## Summary

- Remove `draft: true` from the hybrid mode and web component comments tutorials
- Both tutorials are now visible on the blog