### PR TITLE
Fix bunch of issues from #1068

### DIFF
--- a/blog/content/docs/advanced.adoc
+++ b/blog/content/docs/advanced.adoc
@@ -701,6 +701,97 @@ public class QuteWebSiteTest {
 
 In this case the RestAssured port will automatically use the Quarkus dynamic test server, running on port 8081 by default.
 
+== CLI Reference
+
+The Roq CLI wraps common Quarkus commands with Roq-specific defaults. See the xref:getting-started.adoc#install[Getting Started guide] for installation instructions.
+
+=== `roq create`
+
+Create a new Roq site:
+
+[source,shell]
+----
+roq create my-site
+roq create my-site -x theme:base
+roq create my-site -x plugin:tagging,plugin:sitemap
+----
+
+[cols="1,3"]
+|===
+| Option | Description
+
+| `-x`, `--extension`
+| Extensions to add, comma-separated. Prefixes: `theme:`, `plugin:`, `web:` for Roq/Web Bundler extensions, or any Quarkus extension name (e.g. `rest-jackson`) or full GAV.
+
+| `-g`, `--group-id`
+| Maven group ID (default: `io.acme`)
+
+| `--no-code`
+| Skip example content from codestarts
+
+| `--gradle`
+| Use Gradle instead of Maven
+
+| `--roq-version`
+| Pin a specific Roq version
+|===
+
+=== `roq start`
+
+Start dev mode with live reload:
+
+[source,shell]
+----
+roq start
+roq start -p 8081
+----
+
+[cols="1,3"]
+|===
+| Option | Description
+
+| `-p`, `--port`
+| HTTP port (default: 8080, use `-p` without a value for a random port)
+|===
+
+Press `w` to open the browser, `s` to force a restart, `m` to open the editor.
+
+=== `roq add`
+
+Add extensions to an existing project:
+
+[source,shell]
+----
+roq add plugin:tagging plugin:sitemap
+roq add theme:resume
+roq add web:sass
+roq add rest-jackson
+----
+
+Extension prefixes: `plugin:` for Roq plugins, `theme:` for Roq themes, `web:` for Web Bundler extensions. Any other value is passed through as a Quarkus extension name.
+
+=== `roq generate`
+
+Generate the static site output:
+
+[source,shell]
+----
+roq generate
+----
+
+=== `roq serve`
+
+Serve a previously generated static site directory:
+
+[source,shell]
+----
+roq serve
+----
+
+=== `roq update`
+
+Update the Quarkus and Roq versions. See <<Updating Roq>>.
+
 == Updating Roq
 
 Run the update command from your project directory:

--- a/blog/content/docs/advanced.adoc
+++ b/blog/content/docs/advanced.adoc
@@ -532,7 +532,9 @@ public record HeroMap(Map<String, Hero> map) {
 
 === Collections from data
 
-Generate collection pages from data files instead of writing individual content files. Each entry in the data produces a page rendered with the specified layout.
+While plain xref:basics.adoc#_data[data files] let you display a list of items in an existing page, a data collection goes further: it generates a dedicated page for each entry in the data, rendered with a specified layout.
+
+This is useful when each item deserves its own URL (e.g. one page per event, per team member, or per link-tree).
 
 .From a single data file (`data/events.yml`)
 [source,yaml]

--- a/blog/content/docs/advanced.adoc
+++ b/blog/content/docs/advanced.adoc
@@ -764,11 +764,31 @@ Add extensions to an existing project:
 ----
 roq add plugin:tagging plugin:sitemap
 roq add theme:resume
-roq add web:sass
+roq add web:tailwindcss
 roq add rest-jackson
 ----
 
-Extension prefixes: `plugin:` for Roq plugins, `theme:` for Roq themes, `web:` for Web Bundler extensions. Any other value is passed through as a Quarkus extension name.
+Extension prefixes:
+
+[cols="1,3"]
+|===
+| Prefix | Description
+
+| `plugin:<name>`
+| Roq plugin (e.g. `tagging`, `sitemap`, `aliases`, `series`)
+
+| `theme:<name>`
+| Roq theme (e.g. `default`, `resume`, `base`)
+
+| `web:<name>`
+| Web Bundler extension (e.g. `tailwindcss`)
+
+| `<name>`
+| Any Quarkus extension (e.g. `rest-jackson`, `hibernate-orm`)
+
+| `<group:artifact>`
+| Full GAV coordinate
+|===
 
 === `roq generate`
 

--- a/blog/content/docs/advanced.adoc
+++ b/blog/content/docs/advanced.adoc
@@ -701,7 +701,7 @@ public class QuteWebSiteTest {
 
 In this case the RestAssured port will automatically use the Quarkus dynamic test server, running on port 8081 by default.
 
-== CLI Reference
+== Roq CLI
 
 The Roq CLI wraps common Quarkus commands with Roq-specific defaults. See the xref:getting-started.adoc#install[Getting Started guide] for installation instructions.
 
@@ -790,27 +790,11 @@ Extension prefixes:
 | Full GAV coordinate
 |===
 
-=== `roq generate`
+=== Other commands
 
-Generate the static site output:
-
-[source,shell]
-----
-roq generate
-----
-
-=== `roq serve`
-
-Serve a previously generated static site directory:
-
-[source,shell]
-----
-roq serve
-----
-
-=== `roq update`
-
-Update the Quarkus and Roq versions. See <<Updating Roq>>.
+* `roq generate` -- Generate the static site output.
+* `roq serve` -- Serve a previously generated static site directory.
+* `roq update` -- Update the Quarkus and Roq versions. See <<Updating Roq>>.
 
 == Updating Roq
 

--- a/blog/content/docs/basics.adoc
+++ b/blog/content/docs/basics.adoc
@@ -625,6 +625,65 @@ To exclude a specific page, set `llmstxt: false` in its frontmatter.
 
 You can give your AI coding assistant full context about Roq by pointing it to https://iamroq.dev/llms.txt (or `/llms-full.txt` for complete content). This provides the project structure, quick start instructions, template syntax, and links to detailed skill files.
 
+=== Locale and date formatting
+
+Roq uses the site locale to format dates in templates. Set the default locale in your `config/application.properties`:
+
+[source,properties]
+----
+site.default-locale=fr
+----
+
+This affects all locale-aware date extensions such as `shortDate`, `longDate`, and `dateStyle`. For example, with `site.default-locale=fr`, `{page.date.longDate}` renders "9 octobre 2024" instead of "October 9, 2024".
+
+You can also override the locale per page using frontmatter:
+
+[source,yaml]
+----
+---
+locale: fr
+---
+----
+
+The locale is resolved in this order: page frontmatter `locale`, browser `Accept-Language` header (in dev mode), then `site.default-locale` (defaults to `en`).
+
+==== Date format style
+
+Date extensions use Java's `FormatStyle` for locale-aware formatting. The available extensions on `page.date` are:
+
+[cols="2,2,2"]
+|===
+| Extension | Style | Example (en)
+
+| `shortDate`
+| MEDIUM
+| Oct 9, 2024
+
+| `longDate`
+| LONG
+| October 9, 2024
+
+| `style('short')`
+| SHORT
+| 10/9/24
+
+| `style('medium')`
+| MEDIUM
+| Oct 9, 2024
+
+| `style('long')`
+| LONG
+| October 9, 2024
+
+| `style('full')`
+| FULL
+| Wednesday, October 9, 2024
+|===
+
+The `style` extension also accepts a custom date pattern: `\{page.date.style('yyyy, MMM dd')}`.
+
+NOTE: Roq does not yet support i18n collections (generating the same content in multiple languages with locale-specific URLs). The locale setting only affects date and number formatting in templates.
+
 [#variables]
 == Variables
 

--- a/blog/content/docs/basics.adoc
+++ b/blog/content/docs/basics.adoc
@@ -767,6 +767,8 @@ You can use Qute to access site and pages data. For this use the `site` and `pag
 
 Place JSON or YAML files in the `data/` directory. Each file becomes a named CDI bean, accessible in any Qute template.
 
+Data is enough to display a list of items in an existing page (e.g. a list of team members in your about page). If you need Roq to generate a dedicated page for each item in the data (e.g. one page per team member), use a xref:advanced.adoc#_collections_from_data[data collection] instead.
+
 NOTE: Supported extensions: `.json`, `.yml`, `.yaml`.
 
 === Accessing data in templates

--- a/blog/content/marketplace/themes/default-theme/index.md
+++ b/blog/content/marketplace/themes/default-theme/index.md
@@ -147,6 +147,7 @@ Frontmatter keys available to control page behavior per layout.
 | `show-header` | Show the page header | `true` |
 | `show-header-date` | Show the date in the header | `true` |
 | `show-header-intro` | Show the description in the header | `true` |
+| `post-date-style` | Date format style: `short`, `medium`, `long`, or `full` (uses Java's `FormatStyle`, locale-aware) | `medium` |
 | `content-toc` | Enable table of contents | `false` |
 | `content-toc-title` | TOC section title | `Contents` |
 | `content-toc-levels` | Heading levels to include in TOC | `2` |

--- a/blog/content/posts/2026-07-07-create-a-blog-from-scratch-with-roq/index.md
+++ b/blog/content/posts/2026-07-07-create-a-blog-from-scratch-with-roq/index.md
@@ -169,6 +169,9 @@ Edit `web/app.css`:
 
 </details>
 
+> [!NOTE]
+> Replacing the CSS will break the look of the initial content from the codestart. That's expected: we build our own design in the following steps.
+
 🚀 Save and verify the page still loads with Tailwind classes applied.
 
 

--- a/blog/content/posts/2026-07-07-create-a-link-tree-with-roq/index.md
+++ b/blog/content/posts/2026-07-07-create-a-link-tree-with-roq/index.md
@@ -299,7 +299,7 @@ Add this block after the profile `</div>` and before the closing `</div>` tags i
 
 ## 7. Create the links data
 
-Now for the main event: the links. We'll store them in a YAML file inside a `data/trees/` directory. This structure lets you have multiple link-trees later.
+Now for the main event: the links. We'll store them in a YAML file inside a `data/trees/` directory. Why a directory instead of a single file? Because you might want multiple link-trees: one for personal links, one for work, one for a specific event or conference. Each YAML file in `data/trees/` becomes its own page with its own QR code (we'll set that up in steps 10 and 11).
 
 **››› CODING TIME**
 

--- a/blog/content/posts/2026-07-07-create-a-link-tree-with-roq/index.md
+++ b/blog/content/posts/2026-07-07-create-a-link-tree-with-roq/index.md
@@ -94,6 +94,9 @@ body {
 }
 ```
 
+> [!NOTE]
+> Replacing the CSS will break the look of the initial content from the codestart. That's expected: we build our own design in the following steps.
+
 🚀 Refresh your browser. The page should now have a light gray background (slate-100) and sans-serif text. Dark mode works automatically based on your system preference.
 
 🚀🔑 The `{#bundle /}` tag is the magic glue. It tells Roq's Web Bundler to compile everything in `web/` (CSS, JS, npm packages) and inject it into the page. Tailwind is processed at build time, so only the classes you actually use end up in the final CSS.

--- a/blog/web/create.js
+++ b/blog/web/create.js
@@ -33,8 +33,10 @@
   function projectParams(extra) {
     const params = new URLSearchParams();
     params.set('a', state.name);
-    params.set('ndf', 'true');
-    params.set('nw', 'true');
+    if (!state.plugins.includes('hybrid')) {
+      params.set('ndf', 'true');
+    }
+    params.set('nw', 'false');
     params.append('ec', 'roq-project-codestart');
     const ids = extensionIds();
     if (!ids.some(id => id.includes('roq-theme-'))) {

--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/AddCommand.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/AddCommand.java
@@ -19,10 +19,19 @@ public class AddCommand extends BuildToolDelegatingCommand {
         List<String> params = context.getParams();
         if (params.isEmpty()) {
             System.err.println("Usage: roq add <extension> [extension...]");
-            System.err.println("  e.g. roq add plugin:tagging plugin:sitemap");
-            System.err.println("  e.g. roq add theme:resume");
-            System.err.println("  e.g. roq add web:sass");
-            System.err.println("  e.g. roq add rest-jackson");
+            System.err.println("");
+            System.err.println("  Prefixes:");
+            System.err.println("    plugin:<name>   Roq plugin (e.g. tagging, sitemap, aliases, series)");
+            System.err.println("    theme:<name>    Roq theme (e.g. default, resume, base)");
+            System.err.println("    web:<name>      Web Bundler extension (e.g. tailwindcss)");
+            System.err.println("    <name>          Any Quarkus extension (e.g. rest-jackson, hibernate-orm)");
+            System.err.println("    <group:artifact> Full GAV coordinate");
+            System.err.println("");
+            System.err.println("  Examples:");
+            System.err.println("    roq add plugin:tagging plugin:sitemap");
+            System.err.println("    roq add theme:resume");
+            System.err.println("    roq add web:tailwindcss");
+            System.err.println("    roq add rest-jackson");
             System.exit(CommandLine.ExitCode.USAGE);
         }
         String resolved = params.stream()

--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/AddCommand.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/AddCommand.java
@@ -19,9 +19,10 @@ public class AddCommand extends BuildToolDelegatingCommand {
         List<String> params = context.getParams();
         if (params.isEmpty()) {
             System.err.println("Usage: roq add <extension> [extension...]");
-            System.err.println("  e.g. roq add tagging sitemap");
+            System.err.println("  e.g. roq add plugin:tagging plugin:sitemap");
             System.err.println("  e.g. roq add theme:resume");
             System.err.println("  e.g. roq add web:sass");
+            System.err.println("  e.g. roq add rest-jackson");
             System.exit(CommandLine.ExitCode.USAGE);
         }
         String resolved = params.stream()

--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/CreateCommand.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/CreateCommand.java
@@ -28,7 +28,7 @@ public class CreateCommand implements Callable<Integer> {
     private String version;
 
     @Option(names = { "-x",
-            "--extension" }, split = ",", description = "Extensions to add (e.g. theme-default, plugin-tagging, or full GAV)")
+            "--extension" }, split = ",", description = "Extensions to add (e.g. theme:default, plugin:tagging, web:sass, rest-jackson, or full GAV)")
     private List<String> extra;
 
     @Option(names = { "--roq-version" }, description = "Roq version (default: latest)")

--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/CreateCommand.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/CreateCommand.java
@@ -28,7 +28,7 @@ public class CreateCommand implements Callable<Integer> {
     private String version;
 
     @Option(names = { "-x",
-            "--extension" }, split = ",", description = "Extensions to add (e.g. theme:default, plugin:tagging, web:sass, rest-jackson, or full GAV)")
+            "--extension" }, split = ",", description = "Extensions to add (e.g. theme:default, plugin:tagging, web:tailwindcss, rest-jackson, or full GAV)")
     private List<String> extra;
 
     @Option(names = { "--roq-version" }, description = "Roq version (default: latest)")

--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqProjectCreator.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqProjectCreator.java
@@ -116,8 +116,11 @@ public class RoqProjectCreator {
                 .artifactId(artifactId)
                 .version(version)
                 .extensions(allExtensions)
-                .extraCodestarts(extraCodestarts)
-                .noDockerfiles();
+                .extraCodestarts(extraCodestarts);
+
+        if (allExtensions.stream().noneMatch(e -> e.contains("roq-plugin-hybrid"))) {
+            createProject.noDockerfiles();
+        }
 
         if (noCode) {
             createProject.noCode();

--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqProjectCreator.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqProjectCreator.java
@@ -180,7 +180,7 @@ public class RoqProjectCreator {
         if (value.startsWith("web:")) {
             return "io.quarkiverse.web-bundler:quarkus-web-bundler-" + value.substring(4);
         }
-        return ROQ_PREFIX + value;
+        return value;
     }
 
     private static void deleteDirIfNoFiles(Path dir) throws IOException {

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterBasicTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterBasicTest.java
@@ -76,7 +76,24 @@ public class RoqFrontMatterBasicTest {
                 .body("html.body.article.span.find { it.@class == 'date-long' }.text()", containsString("12:00:00"))
                 .body("html.body.article.span.find { it.@class == 'date-long' }.text()", containsString("UTC"))
                 .body("html.body.article.span.find { it.@class == 'date-rfc822' }.text()",
-                        equalTo("Wed, 09 Oct 2024 00:00:00 +0000"));
+                        equalTo("Wed, 09 Oct 2024 00:00:00 +0000"))
+                .body("html.body.article.span.find { it.@class == 'date-style-short' }.text()", equalTo("10/9/24"))
+                .body("html.body.article.span.find { it.@class == 'date-style-medium' }.text()", equalTo("Oct 9, 2024"))
+                .body("html.body.article.span.find { it.@class == 'date-style-long' }.text()", equalTo("October 9, 2024"))
+                .body("html.body.article.span.find { it.@class == 'date-style-full' }.text()",
+                        equalTo("Wednesday, October 9, 2024"))
+                .body("html.body.article.span.find { it.@class == 'date-style-custom' }.text()",
+                        equalTo("2024, Oct 09"));
+    }
+
+    @Test
+    @DisplayName("Post with FM locale renders localized dates")
+    public void testDateFormatsWithFmLocale() {
+        RestAssured.when().get("/the-posts/french-post").then().statusCode(200).log().ifValidationFails()
+                .body("html.body.article.span.find { it.@class == 'date-style-medium' }.text()", equalTo("8 oct. 2024"))
+                .body("html.body.article.span.find { it.@class == 'date-style-long' }.text()", equalTo("8 octobre 2024"))
+                .body("html.body.article.span.find { it.@class == 'date-short-date' }.text()", equalTo("8 oct. 2024"))
+                .body("html.body.article.span.find { it.@class == 'date-long-date' }.text()", equalTo("8 octobre 2024"));
     }
 
     @Test

--- a/roq-frontmatter/deployment/src/test/resources/basic-site/content/posts/2024-10-08-french-post.html
+++ b/roq-frontmatter/deployment/src/test/resources/basic-site/content/posts/2024-10-08-french-post.html
@@ -1,0 +1,9 @@
+---
+layout: post
+title: French Post
+locale: fr
+---
+
+<h1>Un post en français</h1>
+
+<p>Ceci est un post en français.</p>

--- a/roq-frontmatter/deployment/src/test/resources/basic-site/templates/layouts/post.html
+++ b/roq-frontmatter/deployment/src/test/resources/basic-site/templates/layouts/post.html
@@ -16,6 +16,11 @@ link: /the-posts/:slug
   <span class="date-short">{page.date.short}</span>
   <span class="date-long">{page.date.long}</span>
   <span class="date-rfc822">{page.date.rfc822}</span>
+  <span class="date-style-short">{page.date.style('short')}</span>
+  <span class="date-style-medium">{page.date.style('medium')}</span>
+  <span class="date-style-long">{page.date.style('long')}</span>
+  <span class="date-style-full">{page.date.style('full')}</span>
+  <span class="date-style-custom">{page.date.style('yyyy, MMM dd')}</span>
   <span class="source-path">{page.sourcePath}</span>
   <span class="source-file-absolute">{page.source.file.absolutePath}</span>
   <span class="collection-id">{page.collectionId}</span>

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplateExtension.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplateExtension.java
@@ -388,6 +388,24 @@ public class RoqTemplateExtension {
     }
 
     /**
+     * Returns a formatted date string. Accepts either a {@link FormatStyle} name (short, medium, long, full)
+     * for locale-aware formatting, or a custom pattern (e.g. "yyyy-MM-dd").<br>
+     * Examples: "{page.date.style('long')}", "{page.date.style('yyyy, MMM dd')}".
+     */
+    @TemplateExtension(matchName = "style")
+    public static String dateStyle(ZonedDateTime date, String styleOrFormat,
+            @TemplateAttribute(TemplateInstance.LOCALE) Object locale) {
+        Locale loc = resolveLocale(locale);
+        return switch (styleOrFormat.toLowerCase()) {
+            case "short" -> date.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).withLocale(loc));
+            case "medium" -> date.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(loc));
+            case "long" -> date.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).withLocale(loc));
+            case "full" -> date.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL).withLocale(loc));
+            default -> date.format(DateTimeFormatter.ofPattern(styleOrFormat, loc));
+        };
+    }
+
+    /**
      * Returns a short date string (e.g. "Mar 15, 2024"), locale-aware.<br>
      * Example: "{page.date.shortDate}".
      */

--- a/roq-theme/default/runtime/src/main/resources/templates/partials/roq-default/page-header.html
+++ b/roq-theme/default/runtime/src/main/resources/templates/partials/roq-default/page-header.html
@@ -1,4 +1,4 @@
 
 {#if page.data('show-header', true)}
-{#roq/pageHeader title=page.title date=(page.data('show-header-date', true) ? page.date : null) intro=(page.data('show-header-intro', true) ? page.description : null) /}
+{#roq/pageHeader title=page.title date=(page.data('show-header-date', true) ? page.date : null) dateStyle=page.data('post-date-style') intro=(page.data('show-header-intro', true) ? page.description : null) /}
 {/if}

--- a/roq-theme/default/runtime/src/main/resources/templates/tags/roq/pageHeader.html
+++ b/roq-theme/default/runtime/src/main/resources/templates/tags/roq/pageHeader.html
@@ -1,7 +1,7 @@
 <section class="page-header">
   <h1 class="page-title">{title}</h1>
   {#if date??}
-  <div class="page-header-date"><span>{date.format('yyyy, MMM dd')}</span></div>
+  <div class="page-header-date"><span>{date.style(dateStyle ?: 'medium')}</span></div>
   {/if}
   {#if intro??}
   <p class="page-header-intro">

--- a/roq-theme/default/runtime/src/main/resources/templates/tags/roq/postCard.html
+++ b/roq-theme/default/runtime/src/main/resources/templates/tags/roq/postCard.html
@@ -5,7 +5,7 @@
   <div class="post-content">
     <h2 class="post-title"><a href="{post.url}">{post.title}</a></h2>
     <p>{post.description ?: post.contentAbstract}</p>
-    <span class="post-date">{post.date.format('yyyy, MMM dd')}&nbsp;&nbsp;&nbsp;—&nbsp;</span>
+    <span class="post-date">{post.date.style(post.data('post-date-style') ?: 'medium')}&nbsp;&nbsp;&nbsp;—&nbsp;</span>
     <span class="post-words">
     {post.readTime} minute(s) read
   </span>

--- a/roq-theme/default/runtime/src/main/resources/web/_sidebar.css
+++ b/roq-theme/default/runtime/src/main/resources/web/_sidebar.css
@@ -37,12 +37,6 @@
         @apply font-heading text-sidebar-heading;
     }
 
-    .about .site-name::after {
-        @apply content-[''] absolute left-1/2 -translate-x-1/2 bottom-0;
-        @apply block w-2 h-2 rounded-full;
-        background: var(--dot-gradient);
-    }
-
     .about p {
         @apply text-sm m-0 mb-2.5 leading-relaxed text-sidebar-muted;
     }


### PR DESCRIPTION
## Summary

- Add CSS breakage warning to base-theme tutorials (link-tree and blog-from-scratch)
- Clarify data vs data collection in docs and explain purpose of multiple trees in link-tree tutorial
- Use locale-aware date formatting in default theme, add `style()` template extension accepting FormatStyle names or custom patterns, document locale and date formatting
- Include Maven wrapper when creating from site creator, conditionally skip Dockerfiles (only when hybrid is not selected)
- Remove decorative dot below site name in default theme sidebar
- Allow `roq add` to add any Quarkus extension (bare names pass through instead of being prefixed with Roq GAV)
- Add CLI reference section to advanced docs

Fixes #1068, https://github.com/quarkiverse/quarkus-roq/issues/1064