### PR TITLE
Handle null dateStyle in style() extension, default to medium

### DIFF
--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplateExtension.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplateExtension.java
@@ -389,19 +389,21 @@ public class RoqTemplateExtension {
 
     /**
      * Returns a formatted date string. Accepts either a {@link FormatStyle} name (short, medium, long, full)
-     * for locale-aware formatting, or a custom pattern (e.g. "yyyy-MM-dd").<br>
+     * for locale-aware formatting, or a custom pattern (e.g. "yyyy-MM-dd"). When {@code null},
+     * defaults to "medium".<br>
      * Examples: "{page.date.style('long')}", "{page.date.style('yyyy, MMM dd')}".
      */
     @TemplateExtension(matchName = "style")
     public static String dateStyle(ZonedDateTime date, String styleOrFormat,
             @TemplateAttribute(TemplateInstance.LOCALE) Object locale) {
         Locale loc = resolveLocale(locale);
-        return switch (styleOrFormat.toLowerCase()) {
+        String style = styleOrFormat == null || styleOrFormat.isEmpty() ? "medium" : styleOrFormat;
+        return switch (style.toLowerCase()) {
             case "short" -> date.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).withLocale(loc));
             case "medium" -> date.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(loc));
             case "long" -> date.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).withLocale(loc));
             case "full" -> date.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL).withLocale(loc));
-            default -> date.format(DateTimeFormatter.ofPattern(styleOrFormat, loc));
+            default -> date.format(DateTimeFormatter.ofPattern(style, loc));
         };
     }
 

--- a/roq-theme/default/runtime/src/main/resources/templates/tags/roq/pageHeader.html
+++ b/roq-theme/default/runtime/src/main/resources/templates/tags/roq/pageHeader.html
@@ -1,7 +1,7 @@
 <section class="page-header">
   <h1 class="page-title">{title}</h1>
   {#if date??}
-  <div class="page-header-date"><span>{date.style(dateStyle ?: 'medium')}</span></div>
+  <div class="page-header-date"><span>{date.style(dateStyle)}</span></div>
   {/if}
   {#if intro??}
   <p class="page-header-intro">

--- a/roq-theme/default/runtime/src/main/resources/templates/tags/roq/postCard.html
+++ b/roq-theme/default/runtime/src/main/resources/templates/tags/roq/postCard.html
@@ -5,7 +5,7 @@
   <div class="post-content">
     <h2 class="post-title"><a href="{post.url}">{post.title}</a></h2>
     <p>{post.description ?: post.contentAbstract}</p>
-    <span class="post-date">{post.date.style(post.data('post-date-style') ?: 'medium')}&nbsp;&nbsp;&nbsp;—&nbsp;</span>
+    <span class="post-date">{post.date.style(post.data('post-date-style'))}&nbsp;&nbsp;&nbsp;—&nbsp;</span>
     <span class="post-words">
     {post.readTime} minute(s) read
   </span>


### PR DESCRIPTION
## Summary

- `date.style(null)` now defaults to `medium` instead of throwing a NullPointerException
- Removes `?: 'medium'` fallback from default theme templates (`pageHeader.html`, `postCard.html`) since the extension handles it