### PR TITLE
Fix unbalanced quote in aliases plugin redirect template

### DIFF
--- a/blog/src/test/java/io/quarkiverse/roq/it/RoqBlogSlugifiedFilesTest.java
+++ b/blog/src/test/java/io/quarkiverse/roq/it/RoqBlogSlugifiedFilesTest.java
@@ -66,7 +66,7 @@ public class RoqBlogSlugifiedFilesTest {
     @Test
     public void testAlias() {
         RestAssured.when().get("/first-roq-article-ever/").then().statusCode(200)
-                .body(containsString("url=\"/posts/welcome-to-roq/\""));
+                .body(containsString("url='/posts/welcome-to-roq/'"));
     }
 
     @Test

--- a/blog/src/test/java/io/quarkiverse/roq/it/RoqBlogTest.java
+++ b/blog/src/test/java/io/quarkiverse/roq/it/RoqBlogTest.java
@@ -66,7 +66,7 @@ public class RoqBlogTest {
     @Test
     public void testAlias() {
         RestAssured.when().get("/first-roq-article-ever/").then().statusCode(200)
-                .body(containsString("url=\"/posts/welcome-to-roq/\""));
+                .body(containsString("url='/posts/welcome-to-roq/'"));
     }
 
     @Test

--- a/roq-plugin/aliases/integration-tests/src/test/java/io/quarkiverse/roq/RoqAliasesTest.java
+++ b/roq-plugin/aliases/integration-tests/src/test/java/io/quarkiverse/roq/RoqAliasesTest.java
@@ -45,4 +45,32 @@ public class RoqAliasesTest {
         RestAssured.when().get("/another-alias").then().statusCode(200).log().ifValidationFails()
                 .body(containsString("Redirecting"));
     }
+
+    @Test
+    public void testMetaRefreshTagHasCorrectQuoting() {
+        // Regression test: meta refresh URL must not use double quotes (causes unbalanced quotes)
+        // Bug was: content="0; url="{url}"
+        //   After substitution: content="0; url="https://..." - second " prematurely closes content attribute
+        // Fix is: content="0; url='{url}'"
+        //   After substitution: content="0; url='https://...'" - properly balanced
+        String body = RestAssured.when().get("/old-post-url/").then().statusCode(200).extract().asString();
+
+        // Verify meta refresh tag exists
+        org.junit.jupiter.api.Assertions.assertTrue(
+                body.contains("http-equiv=\"refresh\""),
+                "Should have meta refresh tag");
+
+        // Extract the meta refresh line
+        String metaRefreshLine = body.lines()
+                .filter(line -> line.contains("http-equiv=\"refresh\""))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Meta refresh tag not found"));
+
+        // Regression check: ensure URL is not wrapped in double quotes (the bug pattern)
+        // Bug pattern: url="..." causes unbalanced quotes (second " closes the content attribute early)
+        // Correct pattern: url='...' (single quotes, properly balanced)
+        org.junit.jupiter.api.Assertions.assertFalse(
+                metaRefreshLine.matches(".*url=\"[^>]*\".*"),
+                "URL should NOT be wrapped in double quotes (causes unbalanced quotes). Actual line: " + metaRefreshLine);
+    }
 }

--- a/roq-plugin/aliases/runtime/src/main/java/io/quarkiverse/roq/plugin/aliases/runtime/RoqFrontMatterAliasesRecorder.java
+++ b/roq-plugin/aliases/runtime/src/main/java/io/quarkiverse/roq/plugin/aliases/runtime/RoqFrontMatterAliasesRecorder.java
@@ -20,7 +20,7 @@ public class RoqFrontMatterAliasesRecorder {
                                   <meta charset="utf-8">
                                   <title>Redirecting&hellip;</title>
                                   <link rel="canonical" href="{url}">
-                                  <meta http-equiv="refresh" content="0; url="{url}">
+                                  <meta http-equiv="refresh" content="0; url='{url}'">
                                   <meta name="robots" content="noindex">
                               </head>
                               <body>


### PR DESCRIPTION
The redirect template had quotes around  the`{url}` placeholder which caused double-quoting when the URL was substituted, breaking the meta refresh tag. Actually, it's worse than that, because it didn't have double-quotes, it had *a* double quote (singular). :)

Changed: `content="0; url="{url}`
To: `content="0; url={url}"`

```
  // Original (buggy):
  <meta http-equiv="refresh" content="0; url="{url}">
     
  // After substitution with https://...:
  <meta http-equiv="refresh" content="0; url="https://...">
```

  The second " prematurely closes the content attribute, leaving https://...">
  as naked text outside any attribute. 

  With the fix:
```
  // Fixed:
  <meta http-equiv="refresh" content="0; url='{url}'">
  
  // After substitution:
  <meta http-equiv="refresh" content="0; url='https://...'">
```