### PR TITLE
Expose resolved layout in page.data when it comes from defaults

### DIFF
--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterAssembleUtils.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterAssembleUtils.java
@@ -60,6 +60,10 @@ public final class RoqFrontMatterAssembleUtils {
         Optional<String> sourceTheme = extractSourceTheme(isThemeLayout, metadata.templateId());
         String layoutId = availableLayouts.resolveLayoutId(config.theme(), sourceTheme, layoutRef);
 
+        if (layoutId != null && !data.containsKey(LAYOUT) && !data.containsKey(THEME_LAYOUT)) {
+            data.put(LAYOUT, RoqFrontMatterLayoutUtils.getLayoutKey(config.theme(), layoutId));
+        }
+
         for (RoqFrontMatterDataModificationBuildItem modification : dataModifications) {
             data = modification.modifier()
                     .modify(new RoqFrontMatterDataModificationBuildItem.SourceData(

--- a/roq-frontmatter/deployment/src/test/collection-site/templates/layouts/guide.html
+++ b/roq-frontmatter/deployment/src/test/collection-site/templates/layouts/guide.html
@@ -7,4 +7,5 @@ link: /guides/:slug
   {#insert /}
   <span class="collection-id">{page.collectionId}</span>
   <span class="collection-size">{page.collection.size}</span>
+  <span class="data-layout">{page.data.layout}</span>
 </article>

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterCollectionTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterCollectionTest.java
@@ -42,10 +42,10 @@ public class RoqFrontMatterCollectionTest {
     }
 
     @Test
-    @DisplayName("Guides collection has 2 documents")
+    @DisplayName("Guides collection has 3 documents")
     public void testGuidesCollectionSize() {
         RestAssured.when().get("/").then().statusCode(200).log().ifValidationFails()
-                .body("html.body.span.find { it.@class == 'guides-count' }.text()", equalTo("2"));
+                .body("html.body.span.find { it.@class == 'guides-count' }.text()", equalTo("3"));
     }
 
     @Test
@@ -93,6 +93,22 @@ public class RoqFrontMatterCollectionTest {
     public void testPrevFromMiddle() {
         RestAssured.when().get("/2024/02/second-post").then().statusCode(200).log().ifValidationFails()
                 .body("html.body.article.span.find { it.@class == 'prev-title' }.text()", equalTo("Third Post"));
+    }
+
+    // --- Collection-level defaults in page.data ---
+
+    @Test
+    @DisplayName("page.data.layout is populated from collection default when not in frontmatter")
+    public void testCollectionDefaultLayoutInPageData() {
+        RestAssured.when().get("/guides/no-layout-guide").then().statusCode(200).log().ifValidationFails()
+                .body("html.body.article.span.find { it.@class == 'data-layout' }.text()", equalTo("guide"));
+    }
+
+    @Test
+    @DisplayName("page.data.layout is populated when explicitly set in frontmatter")
+    public void testExplicitLayoutInPageData() {
+        RestAssured.when().get("/guides/getting-started").then().statusCode(200).log().ifValidationFails()
+                .body("html.body.article.span.find { it.@class == 'data-layout' }.text()", equalTo("guide"));
     }
 
     // --- Custom link patterns ---
@@ -198,10 +214,10 @@ public class RoqFrontMatterCollectionTest {
     }
 
     @Test
-    @DisplayName("Guide collection size includes both sources")
+    @DisplayName("Guide collection size includes all sources")
     public void testGuideCollectionSizeIncludesBothSources() {
         RestAssured.when().get("/guides/getting-started").then().statusCode(200).log().ifValidationFails()
-                .body("html.body.article.span.find { it.@class == 'collection-size' }.text()", equalTo("2"));
+                .body("html.body.article.span.find { it.@class == 'collection-size' }.text()", equalTo("3"));
     }
 
     // --- Multi-origin directory page attachments ---

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterLayoutUtilsTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/util/RoqFrontMatterLayoutUtilsTest.java
@@ -2,6 +2,9 @@ package io.quarkiverse.roq.frontmatter.deployment.util;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.lang.reflect.Proxy;
+import java.nio.file.Path;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -12,9 +15,14 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkiverse.roq.frontmatter.deployment.exception.RoqLayoutNotFoundException;
 import io.quarkiverse.roq.frontmatter.deployment.exception.RoqThemeConfigurationException;
+import io.quarkiverse.roq.frontmatter.deployment.items.scan.FrontMatterTemplateMetadata;
 import io.quarkiverse.roq.frontmatter.deployment.items.scan.RoqFrontMatterAvailableLayoutsBuildItem;
 import io.quarkiverse.roq.frontmatter.deployment.items.scan.RoqFrontMatterQuteMarkupBuildItem.WrapperFilter;
 import io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterAssembleUtils.LayoutRef;
+import io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterAssembleUtils.ProcessedTemplate;
+import io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterTemplateUtils.ParsedHeaders;
+import io.quarkiverse.roq.frontmatter.runtime.config.ConfiguredCollection;
+import io.quarkiverse.roq.frontmatter.runtime.config.RoqSiteConfig;
 import io.quarkiverse.roq.frontmatter.runtime.model.SourceFile;
 import io.vertx.core.json.JsonObject;
 
@@ -364,6 +372,108 @@ public class RoqFrontMatterLayoutUtilsTest {
         void nonThemePath() {
             assertEquals("layouts/default",
                     RoqFrontMatterLayoutUtils.removeThemePrefix("layouts/default"));
+        }
+    }
+
+    // ── processTemplate: data population ──────────────────────────────
+
+    @Nested
+    @DisplayName("processTemplate: layout key in data")
+    class ProcessTemplateLayoutData {
+
+        private static RoqSiteConfig minimalConfig(Optional<String> theme, Optional<String> pageLayout) {
+            return (RoqSiteConfig) Proxy.newProxyInstance(
+                    RoqSiteConfig.class.getClassLoader(),
+                    new Class<?>[] { RoqSiteConfig.class },
+                    (proxy, method, args) -> switch (method.getName()) {
+                        case "theme" -> theme;
+                        case "pageLayout" -> pageLayout;
+                        default -> null;
+                    });
+        }
+
+        private static FrontMatterTemplateMetadata metadata(JsonObject data, String content) {
+            return new FrontMatterTemplateMetadata(
+                    Path.of("content/guides/test.html"),
+                    "content/guides/test.html",
+                    new SourceFile(".", "content/guides/test.html"),
+                    null, // no markup transform
+                    new ParsedHeaders(data, content),
+                    "content/guides/test",
+                    "guides/test",
+                    true, // isHtml
+                    true, // isPartial (so layout is resolved)
+                    null);
+        }
+
+        @Test
+        @DisplayName("Collection default layout populates data.layout")
+        void collectionDefaultPopulatesData() {
+            var layouts = availableLayouts("layouts/guide");
+            var config = minimalConfig(NO_THEME, Optional.of("page"));
+            var collection = new ConfiguredCollection("guides", false, false, false, "guide",
+                    "/:collection/:slug/", Optional.empty());
+            JsonObject data = new JsonObject().put("title", "Test Guide");
+
+            ProcessedTemplate result = RoqFrontMatterAssembleUtils.processTemplate(
+                    metadata(data, "<p>content</p>"), true, false,
+                    collection, false, false, config, layouts, Collections.emptyList());
+
+            assertEquals("layouts/guide", result.layout());
+            assertEquals("guide", result.data().getString("layout"),
+                    "data.layout should be populated from collection default");
+        }
+
+        @Test
+        @DisplayName("Explicit frontmatter layout is preserved in data")
+        void explicitLayoutPreserved() {
+            var layouts = availableLayouts("layouts/guide");
+            var config = minimalConfig(NO_THEME, Optional.of("page"));
+            var collection = new ConfiguredCollection("guides", false, false, false, "guide",
+                    "/:collection/:slug/", Optional.empty());
+            JsonObject data = new JsonObject().put("title", "Test Guide").put("layout", "guide");
+
+            ProcessedTemplate result = RoqFrontMatterAssembleUtils.processTemplate(
+                    metadata(data, "<p>content</p>"), true, false,
+                    collection, false, false, config, layouts, Collections.emptyList());
+
+            assertEquals("layouts/guide", result.layout());
+            assertEquals("guide", result.data().getString("layout"),
+                    "data.layout should retain the explicit frontmatter value");
+        }
+
+        @Test
+        @DisplayName("Page default layout populates data.layout when no collection default")
+        void pageDefaultPopulatesData() {
+            var layouts = availableLayouts("layouts/page");
+            var config = minimalConfig(NO_THEME, Optional.of("page"));
+            JsonObject data = new JsonObject().put("title", "Test Page");
+
+            ProcessedTemplate result = RoqFrontMatterAssembleUtils.processTemplate(
+                    metadata(data, "<p>content</p>"), true, false,
+                    null, false, false, config, layouts, Collections.emptyList());
+
+            assertEquals("layouts/page", result.layout());
+            assertEquals("page", result.data().getString("layout"),
+                    "data.layout should be populated from page default");
+        }
+
+        @Test
+        @DisplayName("Theme layout populates data with user-facing key")
+        void themeLayoutPopulatesData() {
+            var layouts = availableLayouts("theme-layouts/my-theme/post");
+            var config = minimalConfig(MY_THEME, Optional.empty());
+            var collection = new ConfiguredCollection("posts", false, false, false, "post",
+                    "/:collection/:slug/", Optional.empty());
+            JsonObject data = new JsonObject().put("title", "Test Post");
+
+            ProcessedTemplate result = RoqFrontMatterAssembleUtils.processTemplate(
+                    metadata(data, "<p>content</p>"), true, false,
+                    collection, false, false, config, layouts, Collections.emptyList());
+
+            assertEquals("theme-layouts/my-theme/post", result.layout());
+            assertEquals("post", result.data().getString("layout"),
+                    "data.layout should be the user-facing key, not the internal ID");
         }
     }
 

--- a/roq-frontmatter/deployment/src/test/resources/collection-site-resources/content/guides/no-layout-guide.html
+++ b/roq-frontmatter/deployment/src/test/resources/collection-site-resources/content/guides/no-layout-guide.html
@@ -1,0 +1,5 @@
+---
+title: No Layout Guide
+---
+<h1>{page.title}</h1>
+<p>This guide has no explicit layout in its frontmatter, so it should inherit the collection default.</p>


### PR DESCRIPTION
Resolves https://github.com/quarkiverse/quarkus-roq/issues/1080

When a collection defines a default layout via config (e.g. site.collections.guides.layout=guide), the layout was used for rendering but page.data.layout returned null because only frontmatter-declared values were in the data JsonObject. Now processTemplate writes the resolved layout key back into data when neither layout nor theme-layout is present in frontmatter. 

I wondered if other defaults would need to be handled in the same way (or if the solution should be generic), but Claude says not: 

 Looking at the other ConfiguredCollection properties:
  - enabled — controls whether the collection is active, not a page property
  - hidden — controls whether pages are served on a path, not page-level data
  - future — controls visibility of future-dated posts, not page-level data
  - fromData — collection config plumbing, not page data

  The only other candidate is link, but it's a URL pattern template rather than a semantic
  property templates would query. Templates use page.url for the resolved URL. I don't think
  page.data.link returning the pattern template (/:collection/:slug/) would be useful —
  it's more of an internal routing concern.

  So layout is the only property that matters here. The issue mentions "other default-ed
  properties" as a possibility, but looking at the actual config, layout is the only one
  that's both a user-facing semantic property and has a collection/page-level default that
  templates would want to inspect.