### PR TITLE
Fix duplicates in Site.allPages caused by tagging collections

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
@@ -123,7 +123,7 @@ public class LiquidToQuteConverter {
         // Convert Jekyll site.posts to Roq collections access
         content = convertSiteCollections(content);
 
-        // Make site.tags lenient (not available in Roq by default)
+        // Make site.tags lenient (needed until  (https://github.com/quarkiverse/quarkus-roq/issues/964 is fixed in a release)
         content = makeSiteTagsLenient(content);
 
         // Liquid {{ }} never HTML-escapes; Qute {= } does. Append .raw for fidelity.

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/Site.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/Site.java
@@ -6,7 +6,6 @@ import static io.quarkiverse.roq.frontmatter.runtime.utils.Pages.getImgFromData;
 import static io.quarkiverse.roq.frontmatter.runtime.utils.Pages.normaliseName;
 import static io.quarkiverse.roq.frontmatter.runtime.utils.Pages.resolvePublicFile;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +44,7 @@ public final class Site {
     private final LazyValue<Map<String, DocumentPage>> documentsById;
     private final NormalPage page;
     private final Map<Page, String> pageContentCache = new ConcurrentHashMap<>();
-    private final List<Page> allPages;
+    private final Collection<Page> allPages;
 
     /**
      * @param url the Roq site url to the index page
@@ -71,7 +70,7 @@ public final class Site {
     /**
      * @return The full list of pages for this site
      */
-    public List<Page> allPages() {
+    public Collection<Page> allPages() {
         return allPages;
     }
 
@@ -326,12 +325,14 @@ public final class Site {
                 .toString();
     }
 
-    private static ArrayList<Page> getAllPages(List<NormalPage> pages, RoqCollections collections) {
-        final ArrayList<Page> allPages = new ArrayList<>(pages);
+    private static Collection<Page> getAllPages(List<NormalPage> pages, RoqCollections collections) {
+        final Map<String, Page> allPages = pages.stream().collect(Collectors.toMap(Page::id, page -> page, (a, b) -> b));
         for (RoqCollection value : collections.collections().values()) {
-            allPages.addAll(value);
+            for (Page page : value) {
+                allPages.put(page.id(), page);
+            }
         }
-        return allPages;
+        return allPages.values();
     }
 
 }

--- a/roq-plugin/tagging/integration-tests/pom.xml
+++ b/roq-plugin/tagging/integration-tests/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.roq</groupId>
+        <artifactId>quarkus-roq-plugin-tagging-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-roq-plugin-tagging-integration-tests</artifactId>
+    <name>Quarkus Roq - Plugin - Tagging - Integration Tests</name>
+
+    <properties>
+        <skipITs>true</skipITs>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.roq</groupId>
+            <artifactId>quarkus-roq</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.roq</groupId>
+            <artifactId>quarkus-roq-plugin-tagging</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/roq-plugin/tagging/integration-tests/src/main/resources/content/index.html
+++ b/roq-plugin/tagging/integration-tests/src/main/resources/content/index.html
@@ -1,0 +1,4 @@
+---
+title: Home
+---
+<h1>Tagging Plugin Test Site</h1>

--- a/roq-plugin/tagging/integration-tests/src/main/resources/content/posts/post-java.md
+++ b/roq-plugin/tagging/integration-tests/src/main/resources/content/posts/post-java.md
@@ -1,0 +1,9 @@
+---
+title: Java Post
+tags:
+  - java
+  - jvm
+date: 2024-01-01
+---
+
+This post is about Java.

--- a/roq-plugin/tagging/integration-tests/src/main/resources/content/posts/post-no-tags.md
+++ b/roq-plugin/tagging/integration-tests/src/main/resources/content/posts/post-no-tags.md
@@ -1,0 +1,6 @@
+---
+title: Post Without Tags
+date: 2024-01-04
+---
+
+This post has no tags.

--- a/roq-plugin/tagging/integration-tests/src/main/resources/content/posts/post-quarkus.md
+++ b/roq-plugin/tagging/integration-tests/src/main/resources/content/posts/post-quarkus.md
@@ -1,0 +1,7 @@
+---
+title: Quarkus Post
+tags: quarkus, java, cloud-native
+date: 2024-01-02
+---
+
+This post is about Quarkus (comma-separated tags).

--- a/roq-plugin/tagging/integration-tests/src/main/resources/content/posts/post-roq.md
+++ b/roq-plugin/tagging/integration-tests/src/main/resources/content/posts/post-roq.md
@@ -1,0 +1,10 @@
+---
+title: Roq Post
+tags:
+  - roq
+  - static-site
+  - java
+date: 2024-01-03
+---
+
+This post is about Roq.

--- a/roq-plugin/tagging/integration-tests/src/main/resources/content/posts/post-spaces.md
+++ b/roq-plugin/tagging/integration-tests/src/main/resources/content/posts/post-spaces.md
@@ -1,0 +1,7 @@
+---
+title: Quarkus Post With Tags With Spaces
+tags: bunnies, some topic, cloud native
+date: 2024-01-02
+---
+
+This post is about Quarkus (comma-separated tags with spaces).

--- a/roq-plugin/tagging/integration-tests/src/main/resources/content/tags-test.html
+++ b/roq-plugin/tagging/integration-tests/src/main/resources/content/tags-test.html
@@ -1,0 +1,18 @@
+---
+title: Tags Test Page
+---
+<h1>All Tags</h1>
+<ul id="all-tags">
+{#for entry in site.tags}
+  <li data-tag="{entry.key}" data-count="{entry.value.size}">{entry.key}: {entry.value.size} posts</li>
+{/for}
+</ul>
+
+<h2>Java Tag Pages</h2>
+<ul id="java-pages">
+{#if site.tags.get('java')}
+  {#for page in site.tags.get('java')}
+  <li>{page.title}</li>
+  {/for}
+{/if}
+</ul>

--- a/roq-plugin/tagging/integration-tests/src/main/resources/templates/layouts/tag.html
+++ b/roq-plugin/tagging/integration-tests/src/main/resources/templates/layouts/tag.html
@@ -1,0 +1,8 @@
+---
+tagging: posts
+---
+
+{#for post in site.collections.get(page.data.tagCollection)}
+<h2>This is a page for a tag</h2>
+<div>{post.title}</div>
+{/for}

--- a/roq-plugin/tagging/integration-tests/src/test/java/io/quarkiverse/roq/plugin/tagging/RoqTaggingTest.java
+++ b/roq-plugin/tagging/integration-tests/src/test/java/io/quarkiverse/roq/plugin/tagging/RoqTaggingTest.java
@@ -4,6 +4,8 @@ import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -12,82 +14,134 @@ import io.quarkus.test.junit.QuarkusTest;
 public class RoqTaggingTest {
 
     @Test
-    public void testSiteTagsReturnsAllTags() {
+    public void testGeneratedTagPage() {
         // site.tags should return a map with all tags from all pages
-        when().get("/tags-test/")
+        when().get("/posts/tag/quarkus")
                 .then()
                 .statusCode(200)
                 .log().ifValidationFails()
-                .body(containsString("data-tag=\"java\""))
-                .body(containsString("data-tag=\"quarkus\""))
-                .body(containsString("data-tag=\"roq\""))
-                .body(containsString("data-tag=\"jvm\""))
-                .body(containsString("data-tag=\"cloud-native\""))
-                .body(containsString("data-tag=\"static-site\""));
+                .body(containsString("Quarkus Post"));
     }
 
     @Test
-    public void testSiteTagsCountsPagesCorrectly() {
-        // Verify page counts for each tag
-        // java: 3 posts (post-java, post-quarkus, post-roq)
-        // quarkus: 1 post
-        // roq: 1 post
-        when().get("/tags-test/")
+    public void testGeneratedTagPageForTagWithHyphen() {
+        // site.tags should return a map with all tags from all pages
+        when().get("/posts/tag/cloud-native")
                 .then()
                 .statusCode(200)
                 .log().ifValidationFails()
-                .body(containsString("data-tag=\"java\" data-count=\"3\""))
-                .body(containsString("data-tag=\"quarkus\" data-count=\"1\""))
-                .body(containsString("data-tag=\"roq\" data-count=\"1\""));
+                .body(containsString("Quarkus Post"));
     }
 
+    /**
+     * If a tag has a space, the expected behaviour is that it gets split, so "some topic" becomes "some" and "topic" tags.
+     */
     @Test
-    public void testSiteTagsGetReturnsSpecificTagPages() {
-        // site.tags.get('java') should return all pages with java tag
-        when().get("/tags-test/")
+    public void testGeneratedTagPageForTagWithSpace() {
+        // site.tags should return a map with all tags from all pages
+        when().get("/posts/tag/some")
                 .then()
                 .statusCode(200)
                 .log().ifValidationFails()
-                .body(containsString("<ul id=\"java-pages\">"))
-                .body(containsString("<li>Java Post</li>"))
-                .body(containsString("<li>Quarkus Post</li>"))
-                .body(containsString("<li>Roq Post</li>"))
-                .body(not(containsString("<li>Post Without Tags</li>")));
+                .body(containsString("Quarkus Post"));
+
+        when().get("/posts/tag/some-topic")
+                .then()
+                .statusCode(404);
     }
 
-    @Test
-    public void testTagsAreSlugified() {
-        // Tags should be slugified (lowercase, hyphens)
-        // "Cloud Native" or "cloud_native" -> "cloud-native"
-        when().get("/tags-test/")
-                .then()
-                .statusCode(200)
-                .log().ifValidationFails()
-                .body(containsString("data-tag=\"cloud-native\""))
-                .body(containsString("data-tag=\"static-site\""));
-    }
+    @Nested
+    class SiteTagsAggregationTest {
+        @Test
+        public void testSiteTagsReturnsAllTags() {
+            // site.tags should return a map with all tags from all pages
+            when().get("/tags-test/")
+                    .then()
+                    .statusCode(200)
+                    .log().ifValidationFails()
+                    .body(containsString("data-tag=\"java\""))
+                    .body(containsString("data-tag=\"quarkus\""))
+                    .body(containsString("data-tag=\"roq\""))
+                    .body(containsString("data-tag=\"jvm\""))
+                    .body(containsString("data-tag=\"cloud-native\""))
+                    .body(containsString("data-tag=\"static-site\""));
+        }
 
-    @Test
-    public void testCommaSeparatedTagsWork() {
-        // Tags from post-quarkus.md: "quarkus, java, cloud-native"
-        // Should be parsed correctly
-        when().get("/tags-test/")
-                .then()
-                .statusCode(200)
-                .log().ifValidationFails()
-                .body(containsString("data-tag=\"quarkus\""))
-                .body(containsString("data-tag=\"cloud-native\""));
-    }
+        @Disabled("See https://github.com/quarkiverse/quarkus-roq/issues/1086. When a tagging template is present, a page gets n extra copies in Site.allPages, where n is the number of tags it has.")
+        @Test
+        public void testSiteTagsCountsPagesCorrectly() {
+            // Verify page counts for each tag
+            when().get("/tags-test/")
+                    .then()
+                    .statusCode(200)
+                    .log().ifValidationFails()
+                    .body(containsString("data-tag=\"java\" data-count=\"3\""))
+                    .body(containsString("data-tag=\"quarkus\" data-count=\"1\""))
+                    .body(containsString("data-tag=\"roq\" data-count=\"1\""));
+        }
 
-    @Test
-    public void testListFormatTagsWork() {
-        // Tags from post-java.md and post-roq.md use YAML list format
-        // Should be parsed correctly
-        when().get("/tags-test/")
-                .then()
-                .statusCode(200)
-                .log().ifValidationFails()
-                .body(containsString("data-tag=\"jvm\""))
-                .body(containsString("data-tag=\"static-site\""));
+        @Test
+        public void testSiteTagsGetReturnsSpecificTagPages() {
+            // site.tags.get('java') should return all pages with java tag
+            when().get("/tags-test/")
+                    .then()
+                    .statusCode(200)
+                    .log().ifValidationFails()
+                    .body(containsString("<ul id=\"java-pages\">"))
+                    .body(containsString("<li>Java Post</li>"))
+                    .body(containsString("<li>Quarkus Post</li>"))
+                    .body(containsString("<li>Roq Post</li>"))
+                    .body(not(containsString("<li>Post Without Tags</li>")));
+        }
+
+        @Test
+        public void testTagsAreSlugified() {
+            // Tags should be slugified (lowercase, hyphens)
+            // "Cloud Native" or "cloud_native" -> "cloud-native"
+            when().get("/tags-test/")
+                    .then()
+                    .statusCode(200)
+                    .log().ifValidationFails()
+                    .body(containsString("data-tag=\"cloud-native\""))
+                    .body(containsString("data-tag=\"static-site\""));
+        }
+
+        @Test
+        public void testCommaSeparatedTagsWork() {
+            // Tags from post-quarkus.md: "quarkus, java, cloud-native"
+            // Should be parsed correctly
+            when().get("/tags-test/")
+                    .then()
+                    .statusCode(200)
+                    .log().ifValidationFails()
+                    .body(containsString("data-tag=\"quarkus\""))
+                    .body(containsString("data-tag=\"cloud-native\""));
+        }
+
+        @Test
+        public void testTagsWithSpacesDoNotCauseErrors() {
+            // At the moment, tags with spaces get split; this confirms that splitting happens, rather than an error
+            when().get("/tags-test")
+                    .then()
+                    .statusCode(200)
+                    .log().ifValidationFails()
+                    .body(containsString("data-tag=\"quarkus\""))
+                    .body(containsString("data-tag=\"cloud\""))
+                    .body(containsString("data-tag=\"native\""))
+                    .body(containsString("data-tag=\"some\""))
+                    .body(containsString("data-tag=\"topic\""));
+        }
+
+        @Test
+        public void testListFormatTagsWork() {
+            // Tags from post-java.md and post-roq.md use YAML list format
+            // Should be parsed correctly
+            when().get("/tags-test/")
+                    .then()
+                    .statusCode(200)
+                    .log().ifValidationFails()
+                    .body(containsString("data-tag=\"jvm\""))
+                    .body(containsString("data-tag=\"static-site\""));
+        }
     }
 }

--- a/roq-plugin/tagging/integration-tests/src/test/java/io/quarkiverse/roq/plugin/tagging/RoqTaggingTest.java
+++ b/roq-plugin/tagging/integration-tests/src/test/java/io/quarkiverse/roq/plugin/tagging/RoqTaggingTest.java
@@ -4,7 +4,6 @@ import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -67,7 +66,6 @@ public class RoqTaggingTest {
                     .body(containsString("data-tag=\"static-site\""));
         }
 
-        @Disabled("See https://github.com/quarkiverse/quarkus-roq/issues/1086. When a tagging template is present, a page gets n extra copies in Site.allPages, where n is the number of tags it has.")
         @Test
         public void testSiteTagsCountsPagesCorrectly() {
             // Verify page counts for each tag

--- a/roq-plugin/tagging/integration-tests/src/test/java/io/quarkiverse/roq/plugin/tagging/RoqTaggingTest.java
+++ b/roq-plugin/tagging/integration-tests/src/test/java/io/quarkiverse/roq/plugin/tagging/RoqTaggingTest.java
@@ -1,0 +1,93 @@
+package io.quarkiverse.roq.plugin.tagging;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class RoqTaggingTest {
+
+    @Test
+    public void testSiteTagsReturnsAllTags() {
+        // site.tags should return a map with all tags from all pages
+        when().get("/tags-test/")
+                .then()
+                .statusCode(200)
+                .log().ifValidationFails()
+                .body(containsString("data-tag=\"java\""))
+                .body(containsString("data-tag=\"quarkus\""))
+                .body(containsString("data-tag=\"roq\""))
+                .body(containsString("data-tag=\"jvm\""))
+                .body(containsString("data-tag=\"cloud-native\""))
+                .body(containsString("data-tag=\"static-site\""));
+    }
+
+    @Test
+    public void testSiteTagsCountsPagesCorrectly() {
+        // Verify page counts for each tag
+        // java: 3 posts (post-java, post-quarkus, post-roq)
+        // quarkus: 1 post
+        // roq: 1 post
+        when().get("/tags-test/")
+                .then()
+                .statusCode(200)
+                .log().ifValidationFails()
+                .body(containsString("data-tag=\"java\" data-count=\"3\""))
+                .body(containsString("data-tag=\"quarkus\" data-count=\"1\""))
+                .body(containsString("data-tag=\"roq\" data-count=\"1\""));
+    }
+
+    @Test
+    public void testSiteTagsGetReturnsSpecificTagPages() {
+        // site.tags.get('java') should return all pages with java tag
+        when().get("/tags-test/")
+                .then()
+                .statusCode(200)
+                .log().ifValidationFails()
+                .body(containsString("<ul id=\"java-pages\">"))
+                .body(containsString("<li>Java Post</li>"))
+                .body(containsString("<li>Quarkus Post</li>"))
+                .body(containsString("<li>Roq Post</li>"))
+                .body(not(containsString("<li>Post Without Tags</li>")));
+    }
+
+    @Test
+    public void testTagsAreSlugified() {
+        // Tags should be slugified (lowercase, hyphens)
+        // "Cloud Native" or "cloud_native" -> "cloud-native"
+        when().get("/tags-test/")
+                .then()
+                .statusCode(200)
+                .log().ifValidationFails()
+                .body(containsString("data-tag=\"cloud-native\""))
+                .body(containsString("data-tag=\"static-site\""));
+    }
+
+    @Test
+    public void testCommaSeparatedTagsWork() {
+        // Tags from post-quarkus.md: "quarkus, java, cloud-native"
+        // Should be parsed correctly
+        when().get("/tags-test/")
+                .then()
+                .statusCode(200)
+                .log().ifValidationFails()
+                .body(containsString("data-tag=\"quarkus\""))
+                .body(containsString("data-tag=\"cloud-native\""));
+    }
+
+    @Test
+    public void testListFormatTagsWork() {
+        // Tags from post-java.md and post-roq.md use YAML list format
+        // Should be parsed correctly
+        when().get("/tags-test/")
+                .then()
+                .statusCode(200)
+                .log().ifValidationFails()
+                .body(containsString("data-tag=\"jvm\""))
+                .body(containsString("data-tag=\"static-site\""));
+    }
+}

--- a/roq-plugin/tagging/pom.xml
+++ b/roq-plugin/tagging/pom.xml
@@ -15,5 +15,6 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
+        <module>integration-tests</module>
     </modules>
 </project>

--- a/roq-plugin/tagging/runtime/src/main/java/io/quarkiverse/roq/plugin/tagging/RoqTaggingTemplateExtension.java
+++ b/roq-plugin/tagging/runtime/src/main/java/io/quarkiverse/roq/plugin/tagging/RoqTaggingTemplateExtension.java
@@ -3,10 +3,20 @@ package io.quarkiverse.roq.plugin.tagging;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
+import io.quarkiverse.roq.frontmatter.runtime.RoqTemplateExtension;
+import io.quarkiverse.roq.frontmatter.runtime.model.Page;
 import io.quarkiverse.roq.frontmatter.runtime.model.RoqCollection;
+import io.quarkiverse.roq.frontmatter.runtime.model.Site;
 import io.quarkus.qute.TemplateExtension;
+import io.vertx.core.json.JsonArray;
 
 @TemplateExtension
 public class RoqTaggingTemplateExtension {
@@ -40,6 +50,89 @@ public class RoqTaggingTemplateExtension {
      * @param count the count of the tag
      */
     public record TagCount(String name, Long count) {
+    }
+
+    /**
+     * Support for site.tags aggregation across all collections.
+     * Returns a Map<String, List<Page>> where keys are tag names (slugified)
+     * and values are lists of pages tagged with that tag.
+     *
+     * This enables this syntax in templates:
+     * {#for entry in site.tags}
+     * Tag: {entry.key} has {entry.value.size} pages
+     * {/for}
+     *
+     * Or with sorting:
+     * {#let tag_words=site.tags.entrySet.sort('key')}
+     * {#for entry in tag_words}
+     * <a href="/blog/tag/{entry.key}">{entry.key}</a> ({entry.value.size})
+     * {/for}
+     * {/let}
+     *
+     *
+     * @param site the Roq site
+     * @return a map of tag names to lists of pages with that tag
+     */
+    public static Map<String, List<Page>> tags(Site site) {
+        if (site == null) {
+            return Map.of();
+        }
+
+        Map<String, List<Page>> tagMap = new LinkedHashMap<>();
+
+        // Aggregate tags from all pages across all collections
+        for (Page page : site.allPages()) {
+            List<String> tags = extractTags(page);
+            for (String tag : tags) {
+                // Slugify the tag (lowercase, replace spaces with hyphens)
+                String slugified = RoqTemplateExtension.slugify(tag);
+                tagMap.computeIfAbsent(slugified, k -> new ArrayList<>()).add(page);
+            }
+        }
+
+        return tagMap;
+    }
+
+    /**
+     * Extract tags from a page's frontmatter data.
+     * Handles both List<String> and comma-separated String formats.
+     * Package-private for testing.
+     */
+    static List<String> extractTags(Page page) {
+        Object tagsObj = page.data().getValue("tags");
+        if (tagsObj == null) {
+            return List.of();
+        }
+
+        // Handle List format (most common)
+        if (tagsObj instanceof List<?> list) {
+            return list.stream()
+                    .filter(Objects::nonNull)
+                    .map(Object::toString)
+                    .collect(Collectors.toList());
+        }
+
+        // Handle JsonArray format
+        if (tagsObj instanceof JsonArray jsonArray) {
+            List<String> result = new ArrayList<>();
+            for (int i = 0; i < jsonArray.size(); i++) {
+                Object item = jsonArray.getValue(i);
+                if (item != null) {
+                    result.add(item.toString());
+                }
+            }
+            return result;
+        }
+
+        // Handle comma-separated String format
+        if (tagsObj instanceof String str) {
+            return Arrays.stream(str.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toList());
+        }
+
+        return List.of();
     }
 
 }

--- a/roq-plugin/tagging/runtime/src/main/java/io/quarkiverse/roq/plugin/tagging/RoqTaggingTemplateExtension.java
+++ b/roq-plugin/tagging/runtime/src/main/java/io/quarkiverse/roq/plugin/tagging/RoqTaggingTemplateExtension.java
@@ -4,19 +4,14 @@ import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
-import io.quarkiverse.roq.frontmatter.runtime.RoqTemplateExtension;
 import io.quarkiverse.roq.frontmatter.runtime.model.Page;
 import io.quarkiverse.roq.frontmatter.runtime.model.RoqCollection;
 import io.quarkiverse.roq.frontmatter.runtime.model.Site;
 import io.quarkus.qute.TemplateExtension;
-import io.vertx.core.json.JsonArray;
 
 @TemplateExtension
 public class RoqTaggingTemplateExtension {
@@ -80,59 +75,13 @@ public class RoqTaggingTemplateExtension {
 
         Map<String, List<Page>> tagMap = new LinkedHashMap<>();
 
-        // Aggregate tags from all pages across all collections
         for (Page page : site.allPages()) {
-            List<String> tags = extractTags(page);
-            for (String tag : tags) {
-                // Slugify the tag (lowercase, replace spaces with hyphens)
-                String slugified = RoqTemplateExtension.slugify(tag);
-                tagMap.computeIfAbsent(slugified, k -> new ArrayList<>()).add(page);
+            for (String tag : RoqTaggingUtils.slugifiedTagStrings(page.data())) {
+                tagMap.computeIfAbsent(tag, k -> new ArrayList<>()).add(page);
             }
         }
 
         return tagMap;
-    }
-
-    /**
-     * Extract tags from a page's frontmatter data.
-     * Handles both List<String> and comma-separated String formats.
-     * Package-private for testing.
-     */
-    static List<String> extractTags(Page page) {
-        Object tagsObj = page.data().getValue("tags");
-        if (tagsObj == null) {
-            return List.of();
-        }
-
-        // Handle List format (most common)
-        if (tagsObj instanceof List<?> list) {
-            return list.stream()
-                    .filter(Objects::nonNull)
-                    .map(Object::toString)
-                    .collect(Collectors.toList());
-        }
-
-        // Handle JsonArray format
-        if (tagsObj instanceof JsonArray jsonArray) {
-            List<String> result = new ArrayList<>();
-            for (int i = 0; i < jsonArray.size(); i++) {
-                Object item = jsonArray.getValue(i);
-                if (item != null) {
-                    result.add(item.toString());
-                }
-            }
-            return result;
-        }
-
-        // Handle comma-separated String format
-        if (tagsObj instanceof String str) {
-            return Arrays.stream(str.split(","))
-                    .map(String::trim)
-                    .filter(s -> !s.isEmpty())
-                    .collect(Collectors.toList());
-        }
-
-        return List.of();
     }
 
 }


### PR DESCRIPTION
Resolves #1086. Builds on #1079, so I'll rebase after that merges.

I assumed `page.id()` was a valid uniqueness identifier. 