### PR TITLE
docs: document that {#rss} is included by base theme and all built-in themes

### DIFF
--- a/blog/content/docs/basics.adoc
+++ b/blog/content/docs/basics.adoc
@@ -571,7 +571,7 @@ If you use a custom layout, add the `\{#ga4 /}` tag to your HTML head.
 [[rss]]
 === RSS
 
-The `\{#rss site /}` tag is automatically included by the default theme. If you use a custom layout, add it to your HTML head:
+The `\{#rss site /}` tag is automatically included by the base theme layout and all built-in themes (default, resume). If you use a custom layout that overrides `\{#head-meta}`, add it to your HTML head:
 
 [source,html]
 ----

--- a/roq-frontmatter/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/roq-frontmatter/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -415,7 +415,7 @@ Add to root layout `<head>`:
 ```
 
 - `{#seo page site /}` — generates `<title>`, `<meta>` author/description, Open Graph and Twitter card tags. Also emits `<meta name="robots">` when the page frontmatter defines a `robots:` value
-- `{#rss site /}` — adds the RSS `<link>` tag to the HTML head (does not generate the feed itself)
+- `{#rss site /}` — adds the RSS `<link>` tag to the HTML head (does not generate the feed itself). Included by the base theme layout and all built-in themes
 - `{#favicon site /}` — auto-discovers favicon files from `public/` (favicon.svg, .ico, .png, apple-touch-icon.png)
 - `{#ga4 /}` — Google Analytics 4 (configure `analytics.ga4` in site index frontmatter)
 

--- a/roq/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/roq/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -49,7 +49,7 @@ Create `content/rss.xml`:
 {#include fm/rss.html /}
 ```
 
-Add `{#rss site /}` to your root layout `<head>` to include the RSS feed link.
+`{#rss site /}` is automatically included in the base theme layout and all built-in themes. If you use a custom layout that overrides `{#head-meta}`, add it to your `<head>`.
 
 Use `contentLimit` to control `<content:encoded>`: omit for description only (default), `contentLimit=0` for full rendered content, `contentLimit=N` for a word-limited content abstract (e.g. `{#include fm/rss.html contentLimit=150 /}`).
 


### PR DESCRIPTION
Follow-up to #1062. Documents that the `{#rss site /}` tag is now automatically included by the base theme layout (`roq-base`) and all built-in themes (default, resume), so users only need to add it manually when using a custom layout that overrides `{#head-meta}`.