### PR TITLE
fix: improve Lunr search ranking and add URL to results

### DIFF
--- a/blog/content/marketplace/plugins/aliases.md
+++ b/blog/content/marketplace/plugins/aliases.md
@@ -6,7 +6,7 @@ icon: fa-solid fa-shuffle
 install-name: aliases
 tags: [navigation, seo]
 source: https://github.com/quarkiverse/quarkus-roq/tree/main/roq-plugin/aliases
-search-boost: 20
+search-boost: 1.2
 ---
 
 Create one or many aliases (redirections) for a page. Add `aliases: [your-alias-here, another-alias-here]` in the Front Matter to access the page using a customized URL.

--- a/blog/content/marketplace/plugins/asciidoc-jruby.md
+++ b/blog/content/marketplace/plugins/asciidoc-jruby.md
@@ -6,7 +6,7 @@ icon: fa-solid fa-file-lines
 install-name: asciidoc-jruby
 tags: [content, markup]
 source: https://github.com/quarkiverse/quarkus-roq/tree/main/roq-plugin/asciidoc-jruby
-search-boost: 20
+search-boost: 1.2
 ---
 
 Full-featured Asciidoctor implementation based on [AsciidoctorJ](https://github.com/asciidoctor/asciidoctorj). Offers the complete AsciiDoc feature set including all extensions. Slower startup than the [Java variant](/plugin/asciidoc/) but covers all advanced AsciiDoc options.

--- a/blog/content/marketplace/plugins/asciidoc.md
+++ b/blog/content/marketplace/plugins/asciidoc.md
@@ -6,7 +6,7 @@ icon: fa-solid fa-file-lines
 install-name: asciidoc
 tags: [content, markup]
 source: https://github.com/quarkiverse/quarkus-roq/tree/main/roq-plugin/asciidoc
-search-boost: 20
+search-boost: 1.2
 ---
 
 Fast Java-based AsciiDoc processor (based on [Yupiik asciidoc-java](https://github.com/yupiik/tools-maven-plugin/tree/master/asciidoc-java)). Provides fast startup but does not support all AsciiDoc options yet. For the full feature set, see [AsciiDoc JRuby](/plugin/asciidoc-jruby/).

--- a/blog/content/marketplace/plugins/diagram.md
+++ b/blog/content/marketplace/plugins/diagram.md
@@ -6,7 +6,7 @@ icon: fa-solid fa-diagram-project
 install-name: diagram
 tags: [content, media]
 source: https://github.com/quarkiverse/quarkus-roq/tree/main/roq-plugin/diagram
-search-boost: 20
+search-boost: 1.2
 ---
 
 Diagram-as-code support by leveraging [Kroki.io](https://kroki.io/). It delegates image rendering to Kroki either by using a provided server or by popping a dev service.

--- a/blog/content/marketplace/plugins/faker.md
+++ b/blog/content/marketplace/plugins/faker.md
@@ -6,7 +6,7 @@ icon: fa-solid fa-wand-magic-sparkles
 install-name: faker
 tags: [development, testing]
 source: https://github.com/quarkiverse/quarkus-roq/tree/main/roq-plugin/faker
-search-boost: 20
+search-boost: 1.2
 ---
 
 Populate your site with realistic fake content during development. Generates posts with random titles, descriptions, authors, dates, tags, and images so you can test layouts, pagination, and styling without writing real content.

--- a/blog/content/marketplace/plugins/hybrid.md
+++ b/blog/content/marketplace/plugins/hybrid.md
@@ -6,7 +6,7 @@ icon: fa-solid fa-bolt
 install-name: hybrid
 tags: [performance, caching, dynamic]
 source: https://github.com/quarkiverse/quarkus-roq/tree/main/roq-plugin/hybrid
-search-boost: 20
+search-boost: 1.2
 ---
 
 Build Quarkus applications with Roq static content. Pages are rendered once and cached (in memory or on disk), making subsequent requests as fast as serving static files while still supporting dynamic CDI content.

--- a/blog/content/marketplace/plugins/lunr-search.md
+++ b/blog/content/marketplace/plugins/lunr-search.md
@@ -6,7 +6,7 @@ icon: fa-solid fa-magnifying-glass
 install-name: lunr
 tags: [search]
 source: https://github.com/quarkiverse/quarkus-roq/tree/main/roq-plugin/lunr
-search-boost: 20
+search-boost: 1.2
 ---
 
 Enable search for your site without the need for external, server-side, search services.
@@ -79,11 +79,41 @@ search: false
 ---
 ```
 
-You can also boost specific pages or layouts in the results:
+You can also boost specific pages or layouts in the results using `search-boost`:
 
 ```yaml
 ---
-title: I want to be first in the result
-search-boost: 30
+title: Important Page
+search-boost: 1.2
 ---
 ```
+
+### How boost works
+
+Search relevance is calculated using the [BM25](https://en.wikipedia.org/wiki/Okapi_BM25) algorithm. The `search-boost` value is a **multiplier** on the BM25 score. The default is `1`.
+
+**Use values between `0` and `2`:**
+
+| Value | Effect |
+|-------|--------|
+| `0.5` | Demote a page in results |
+| `1` | Default (no boost) |
+| `1.2` | Gentle boost (recommended for reference pages) |
+| `1.5` | Moderate boost |
+| `2` | Maximum recommended boost |
+
+BM25 term frequency saturates quickly (controlled by k1=1.2). This means the relevance advantage from having more keyword matches is bounded:
+
+| Matches | BM25 score | Ratio vs 1 match |
+|---------|-----------|-------------------|
+| 1 | 1.00 | 1.00 |
+| 2 | 1.38 | 1.38 |
+| 3 | 1.57 | 1.57 |
+| 5 | 1.77 | 1.77 |
+| 9 | 1.94 | 1.94 |
+
+A page with 9 matches scores ~1.94x higher than one with 1 match. If boost exceeds this ratio, it overrides keyword relevance. That is why **values above `2` are not recommended**: they would make boost more important than actual keyword matches.
+
+With a boost of `1.2`, a boosted page only outranks a non-boosted page when their keyword relevance is within 20% of each other. Stronger keyword matches always win.
+
+Section headings also receive a tiny additive boost (h2: +0.06, h3: +0.05, down to h6: +0.02). This orders sections within the same page without pushing them above full pages.

--- a/blog/content/marketplace/plugins/markdown.md
+++ b/blog/content/marketplace/plugins/markdown.md
@@ -6,7 +6,7 @@ icon: fa-brands fa-markdown
 install-name: markdown
 tags: [content, markup]
 source: https://github.com/quarkiverse/quarkus-roq/tree/main/roq-plugin/markdown
-search-boost: 20
+search-boost: 1.2
 ---
 
 Process `.md` and `.markdown` files using [CommonMark Java](https://github.com/commonmark/commonmark-java).

--- a/blog/content/marketplace/plugins/qr-code.md
+++ b/blog/content/marketplace/plugins/qr-code.md
@@ -6,7 +6,7 @@ icon: fa-solid fa-qrcode
 install-name: qrcode
 tags: [media]
 source: https://github.com/quarkiverse/quarkus-roq/tree/main/roq-plugin/qrcode
-search-boost: 20
+search-boost: 1.2
 ---
 
 Add QR codes to your website. Create a template and add the `#qrcode` tag to it, then style and size it as you want.

--- a/blog/content/marketplace/plugins/series.md
+++ b/blog/content/marketplace/plugins/series.md
@@ -6,7 +6,7 @@ icon: fa-solid fa-layer-group
 install-name: series
 tags: [collections, navigation]
 source: https://github.com/quarkiverse/quarkus-roq/tree/main/roq-plugin/series
-search-boost: 20
+search-boost: 1.2
 ---
 
 Join multiple posts into a series with automatic series headers.

--- a/blog/content/marketplace/plugins/sitemap.md
+++ b/blog/content/marketplace/plugins/sitemap.md
@@ -6,7 +6,7 @@ icon: fa-solid fa-sitemap
 install-name: sitemap
 tags: [seo]
 source: https://github.com/quarkiverse/quarkus-roq/tree/main/roq-plugin/sitemap
-search-boost: 20
+search-boost: 1.2
 ---
 
 Easily create a `sitemap.xml` for your site.

--- a/blog/content/marketplace/plugins/tagging.md
+++ b/blog/content/marketplace/plugins/tagging.md
@@ -6,7 +6,7 @@ icon: fa-solid fa-tags
 install-name: tagging
 tags: [collections, navigation]
 source: https://github.com/quarkiverse/quarkus-roq/tree/main/roq-plugin/tagging
-search-boost: 20
+search-boost: 1.2
 ---
 
 Generate a dynamic (derived) collection based on a given collection's tags. For example, if multiple posts have `tags: guide`, a `/posts/tag/guide` page is generated listing all matching posts. This works for any collection.

--- a/blog/content/marketplace/themes/base-theme/index.md
+++ b/blog/content/marketplace/themes/base-theme/index.md
@@ -6,7 +6,7 @@ icon: fa-solid fa-cube
 install-name: base
 tags: [minimal, starter]
 source: https://github.com/quarkiverse/quarkus-roq/tree/main/roq-frontmatter/runtime/src/main/resources/templates/theme-layouts/roq-base
-search-boost: 20
+search-boost: 1.2
 ---
 
 The base theme is a minimal starting point included with Roq. It provides the essential HTML structure with SEO, favicon, and Web Bundler support, giving you full control over your site's design. This is the ideal choice when you want to build a fully custom site from scratch.

--- a/blog/content/marketplace/themes/default-theme/index.md
+++ b/blog/content/marketplace/themes/default-theme/index.md
@@ -38,7 +38,7 @@ screenshots:
   - label: Home (vibrant) - dark
     description: Customised with fuchsia + lime
     source: screenshots/home-vibrant-dark.png
-search-boost: 20
+search-boost: 1.2
 ---
 
 The default Roq theme for blogs and sites (used on this site). Built with Tailwind CSS, featuring dark mode, responsive design, sidebar navigation, and social media links. The accent color palette can easily be customized with your own colors or any existing Tailwind color palette.

--- a/blog/content/marketplace/themes/linktree-theme/index.md
+++ b/blog/content/marketplace/themes/linktree-theme/index.md
@@ -17,7 +17,7 @@ screenshots:
   - label: Gallery
     description: All trees with QR codes
     source: screenshots/gallery-light.png
-search-boost: 20
+search-boost: 1.2
 ---
 
 Build a personal link-tree site with data-driven YAML configuration, social icons, and auto-generated QR codes.

--- a/blog/content/marketplace/themes/resume-theme/index.md
+++ b/blog/content/marketplace/themes/resume-theme/index.md
@@ -12,7 +12,7 @@ screenshots:
     source: screenshots/home-light.png
   - label: Dark mode
     source: screenshots/home-dark.png
-search-boost: 20
+search-boost: 1.2
 ---
 
 Build a personal resume or CV with a data-driven YAML configuration.

--- a/blog/content/marketplace/web/mvnpm.md
+++ b/blog/content/marketplace/web/mvnpm.md
@@ -5,7 +5,7 @@ layout: marketplace-web
 icon: fa-brands fa-npm
 tags: [npm, dependencies]
 source: https://github.com/quarkiverse/quarkus-web-bundler/tree/main/mvnpm
-search-boost: 20
+search-boost: 1.2
 ---
 
 Add [mvnpm](https://mvnpm.org) support to your Roq project. Import npm packages directly through Maven coordinates, with no Node.js or npm installation required.

--- a/blog/content/marketplace/web/sass.md
+++ b/blog/content/marketplace/web/sass.md
@@ -5,7 +5,7 @@ layout: marketplace-web
 icon: fa-brands fa-sass
 tags: [css, styling]
 source: https://github.com/quarkiverse/quarkus-web-bundler/tree/main/sass
-search-boost: 20
+search-boost: 1.2
 ---
 
 Add Sass/SCSS support to your Roq project. Use variables, nesting, mixins, and all Sass features to write maintainable stylesheets.

--- a/blog/content/marketplace/web/svelte.md
+++ b/blog/content/marketplace/web/svelte.md
@@ -6,7 +6,7 @@ icon: fa-brands fa-js
 install-name: svelte
 tags: [components, javascript]
 source: https://github.com/quarkiverse/quarkus-web-bundler/tree/main/svelte
-search-boost: 20
+search-boost: 1.2
 ---
 
 Add Svelte component support to your Roq project. Build interactive UI components with Svelte's reactive framework and embed them in your static pages.

--- a/blog/content/marketplace/web/tailwind.md
+++ b/blog/content/marketplace/web/tailwind.md
@@ -6,7 +6,7 @@ icon: fa-solid fa-wind
 install-name: tailwind
 tags: [css, styling, tailwind]
 source: https://github.com/quarkiverse/quarkus-web-bundler/tree/main/tailwind
-search-boost: 20
+search-boost: 1.2
 ---
 
 Add Tailwind CSS support to your Roq project. Write utility-first CSS classes directly in your templates, with automatic purging of unused styles for optimized production builds.

--- a/blog/content/posts/2026-07-16-smarter-search-ranking/index.md
+++ b/blog/content/posts/2026-07-16-smarter-search-ranking/index.md
@@ -1,0 +1,24 @@
+---
+title: Smarter Search Ranking
+description: How we fixed search boost to let keyword relevance shine.
+author: ia3andy
+tags: improvement,plugin
+date: 2026-07-16 14:00:00 +0200
+---
+
+Searching for "qr code" on this site used to show the plugin reference page first, with the blog post buried far below. The reference page had `search-boost: 20`, making it score 20x higher regardless of keyword matches. Blog posts about QR codes could never compete.
+
+### Why boost was too strong
+
+Lunr uses [BM25](https://en.wikipedia.org/wiki/Okapi_BM25) for scoring, where term frequency saturates quickly. A page with 9 keyword matches scores only ~1.94x higher than one with 1 match. Any `search-boost` above 2 overrides keyword relevance entirely.
+
+### What changed
+
+- **Boost values reduced to the BM25 range.** Marketplace pages now use `search-boost: 1.2` instead of `20`. The reference doc still ranks above unrelated pages, but a blog post with strong keyword matches now appears right after it.
+- **Section heading boost fixed.** h2 sections now rank above h6 (was inverted), with tiny values (+0.06 for h2, +0.02 for h6) that order sections within a page without pushing them above full pages.
+- **Field boosts rebalanced.** All field boosts (title, tags, content) are now between 1 and 2, letting BM25 handle relevance naturally.
+- **Search results now show the page URL**, making it easier to see where each result links before clicking.
+
+### Using search-boost
+
+Keep values between 0 and 2. A boost of `1.2` gives a gentle advantage. Above `2`, boost starts overriding keyword matches. See the [Lunr Search plugin docs](/plugin/lunr-search/) for details.

--- a/roq-plugin/lunr/runtime/src/main/java/io/quarkiverse/roq/plugin/lunr/runtime/RoqLunrKeys.java
+++ b/roq-plugin/lunr/runtime/src/main/java/io/quarkiverse/roq/plugin/lunr/runtime/RoqLunrKeys.java
@@ -14,11 +14,11 @@ public interface RoqLunrKeys {
     String SEARCH = "search";
 
     /**
-     * Search result boost — e.g. {@code search-boost: 2} (higher = more prominent)
+     * Search result boost — e.g. {@code search-boost: 1.5} (default: 1, recommended range: 0-2)
      * <br>
      * ▸ Scope: page / document
      * <br>
-     * ▸ Access: {@code page.data.getInteger("search-boost")}
+     * ▸ Access: {@code page.data.getDouble("search-boost")}
      */
     String SEARCH_BOOST = "search-boost";
 }

--- a/roq-plugin/lunr/runtime/src/main/java/io/quarkiverse/roq/plugin/lunr/runtime/RoqPluginLunrTemplateExtension.java
+++ b/roq-plugin/lunr/runtime/src/main/java/io/quarkiverse/roq/plugin/lunr/runtime/RoqPluginLunrTemplateExtension.java
@@ -60,8 +60,8 @@ public class RoqPluginLunrTemplateExtension {
             final List<String> tags = RoqTemplateExtension.asStrings(page.data("tags"));
             baseDoc.put("tags", tags);
         }
-        final long baseBoost = page.data().containsKey(RoqLunrKeys.SEARCH_BOOST)
-                ? page.data().getLong(RoqLunrKeys.SEARCH_BOOST)
+        final double baseBoost = page.data().containsKey(RoqLunrKeys.SEARCH_BOOST)
+                ? page.data().getDouble(RoqLunrKeys.SEARCH_BOOST)
                 : 1;
         final String absoluteUrl = page.url().absolute();
         if (!anchors.isEmpty()) {
@@ -121,7 +121,7 @@ public class RoqPluginLunrTemplateExtension {
                 continue;
             }
 
-            int boost = boostForTag(heading.tagName());
+            double boost = boostForTag(heading.tagName());
             anchors.add(new Anchor(id, title, content, boost));
         }
 
@@ -141,7 +141,7 @@ public class RoqPluginLunrTemplateExtension {
             String id = heading.id();
             String title = heading.text();
             int level = Integer.parseInt(heading.tagName().substring(1));
-            int boost = level + 1;
+            double boost = (8 - level) / 100.0;
 
             StringBuilder contentBuilder = new StringBuilder();
             Element current = heading.nextElementSibling();
@@ -166,13 +166,13 @@ public class RoqPluginLunrTemplateExtension {
         return anchors;
     }
 
-    private static int boostForTag(String tagName) {
+    private static double boostForTag(String tagName) {
         if (tagName.matches("h[1-6]")) {
-            return Integer.parseInt(tagName.substring(1)) + 1;
+            return (8 - Integer.parseInt(tagName.substring(1))) / 100.0;
         }
-        return 1;
+        return 0;
     }
 
-    record Anchor(String id, String title, String content, int boost) {
+    record Anchor(String id, String title, String content, double boost) {
     }
 }

--- a/roq-plugin/lunr/runtime/src/main/web/search.css
+++ b/roq-plugin/lunr/runtime/src/main/web/search.css
@@ -12,6 +12,7 @@
   --search-result-title: #02060c;
   --search-placeholder-color: #aaa;
   --search-border-color: #ddd;
+  --search-result-url-color: #888;
   --search-close-color: #000;
   --search-icon: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208zM208 352a144 144 0 1 0 0-288 144 144 0 1 0 0 288z"/></svg>');
   --search-icon-size: 20px;
@@ -28,6 +29,7 @@
   --search-result-title: rgb(243 244 246); /* gray-100 */
   --search-placeholder-color: rgb(156 163 175); /* gray-400 */
   --search-border-color: rgb(55 65 81); /* gray-700 */
+  --search-result-url-color: rgb(156 163 175); /* gray-400 */
   --search-close-color: rgb(243 244 246); /* gray-100 */
   --search-icon: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="%23f3f4f6"><path d="M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208zM208 352a144 144 0 1 0 0-288 144 144 0 1 0 0 288z"/></svg>');
 }
@@ -130,7 +132,6 @@
     color: var(--search-placeholder-color);
   }
 
-  // Hide native browser clear button
   &::-webkit-search-cancel-button {
     display: none;
   }
@@ -170,6 +171,14 @@
   color: var(--search-result-title);
 }
 
+.search-result-url {
+  font-size: 0.8em;
+  color: var(--search-result-url-color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .search-result-document-hit {
 }
 
@@ -194,7 +203,7 @@
   line-height: 1;
   display: flex;
   align-items: center;
-  height: calc(16px * 1.5); // Match input line-height
+  height: calc(16px * 1.5);
 }
 
 @media screen and (max-width: 768px) {

--- a/roq-plugin/lunr/runtime/src/main/web/search.js
+++ b/roq-plugin/lunr/runtime/src/main/web/search.js
@@ -1,5 +1,5 @@
 import lunr from 'lunr';
-import './search.scss';
+import './search.css';
 import debounce from 'lodash/debounce';
 
 const setupSearch = function (options = {}) {
@@ -83,11 +83,11 @@ const setupSearch = function (options = {}) {
         documents = data;
         idx = lunr(function () {
             this.ref('id')
-            this.field('fragment', {boost: 5})
-            this.field('title', {boost: 10})
+            this.field('fragment', {boost: 1.2})
+            this.field('title', {boost: 2})
             this.field('summary')
-            this.field('tags', {boost: 50})
-            this.field('content', {boost: 100})
+            this.field('tags', {boost: 1.5})
+            this.field('content')
 
 
             for (const [key, entry] of Object.entries(documents)) {
@@ -161,10 +161,19 @@ const setupSearch = function (options = {}) {
             documentHitContent.appendChild(documentKeywords)
         }
 
+        const documentUrl = document.createElement('div')
+        documentUrl.classList.add('search-result-url')
+        try {
+            documentUrl.textContent = new URL(doc.url).pathname
+        } catch (e) {
+            documentUrl.textContent = doc.url
+        }
+
         const searchResultItem = document.createElement('a')
         searchResultItem.href = doc.url
         searchResultItem.classList.add('search-result-item')
         searchResultItem.appendChild(documentTitle)
+        searchResultItem.appendChild(documentUrl)
         searchResultItem.appendChild(documentHit)
         searchResultItem.addEventListener('mousedown', function (e) {
             e.preventDefault();

--- a/roq-plugin/lunr/runtime/src/test/java/io/quarkiverse/roq/plugin/lunr/runtime/RoqPluginLunrTemplateExtensionTest.java
+++ b/roq-plugin/lunr/runtime/src/test/java/io/quarkiverse/roq/plugin/lunr/runtime/RoqPluginLunrTemplateExtensionTest.java
@@ -32,7 +32,7 @@ public class RoqPluginLunrTemplateExtensionTest {
         assertThat(anchor.id()).isEqualTo("intro");
         assertThat(anchor.title()).isEqualTo("Introduction");
         assertThat(anchor.content()).isEqualTo("Welcome to the documentation.");
-        assertThat(anchor.boost()).isEqualTo(3); // h2 => 2 + 1
+        assertThat(anchor.boost()).isEqualTo(0.06); // h2 => (8 - 2) / 100
     }
 
     @Test
@@ -58,10 +58,10 @@ public class RoqPluginLunrTemplateExtensionTest {
         assertThat(anchors).hasSize(2);
 
         assertThat(anchors.get(0))
-                .isEqualTo(new Anchor("section1", "Section 1", "First part content.", 3));
+                .isEqualTo(new Anchor("section1", "Section 1", "First part content.", 0.06));
 
         assertThat(anchors.get(1))
-                .isEqualTo(new Anchor("section2", "Section 2", "Second part content.", 4));
+                .isEqualTo(new Anchor("section2", "Section 2", "Second part content.", 0.05));
     }
 
     @Test
@@ -113,7 +113,7 @@ public class RoqPluginLunrTemplateExtensionTest {
         assertThat(a.id()).isEqualTo("intro");
         assertThat(a.title()).isEqualTo("Introduction");
         assertThat(a.content()).isEqualTo("This is the first paragraph. This is the second paragraph.");
-        assertThat(a.boost()).isEqualTo(3); // h2 = level 2 + 1
+        assertThat(a.boost()).isEqualTo(0.06); // h2 = (8 - 2) / 100
     }
 
     @Test
@@ -134,7 +134,7 @@ public class RoqPluginLunrTemplateExtensionTest {
         assertThat(a.id()).isEqualTo("features");
         assertThat(a.title()).isEqualTo("Features");
         assertThat(a.content()).isEqualTo("Fast Reliable");
-        assertThat(a.boost()).isEqualTo(4); // h3 = level 3 + 1
+        assertThat(a.boost()).isEqualTo(0.05); // h3 = (8 - 3) / 100
     }
 
     @Test
@@ -156,13 +156,13 @@ public class RoqPluginLunrTemplateExtensionTest {
         assertThat(a.id()).isEqualTo("a");
         assertThat(a.title()).isEqualTo("A");
         assertThat(a.content()).isEqualTo("Text A1. Text A2.");
-        assertThat(a.boost()).isEqualTo(3);
+        assertThat(a.boost()).isEqualTo(0.06);
 
         Anchor b = anchors.get(1);
         assertThat(b.id()).isEqualTo("b");
         assertThat(b.title()).isEqualTo("B");
         assertThat(b.content()).isEqualTo("Text B1.");
-        assertThat(b.boost()).isEqualTo(3);
+        assertThat(b.boost()).isEqualTo(0.06);
     }
 
     @Test
@@ -183,15 +183,15 @@ public class RoqPluginLunrTemplateExtensionTest {
 
         assertThat(anchors.get(0).id()).isEqualTo("parent");
         assertThat(anchors.get(0).content()).isEqualTo("Parent content. Child Child content.");
-        assertThat(anchors.get(0).boost()).isEqualTo(3);
+        assertThat(anchors.get(0).boost()).isEqualTo(0.06);
 
         assertThat(anchors.get(1).id()).isEqualTo("child");
         assertThat(anchors.get(1).content()).isEqualTo("Child content.");
-        assertThat(anchors.get(1).boost()).isEqualTo(5); // h4 = 4 + 1
+        assertThat(anchors.get(1).boost()).isEqualTo(0.04); // h4 = (8 - 4) / 100
 
         assertThat(anchors.get(2).id()).isEqualTo("next");
         assertThat(anchors.get(2).content()).isEqualTo("Next content.");
-        assertThat(anchors.get(2).boost()).isEqualTo(3);
+        assertThat(anchors.get(2).boost()).isEqualTo(0.06);
     }
 
     @Test
@@ -211,7 +211,7 @@ public class RoqPluginLunrTemplateExtensionTest {
         assertThat(a.id()).isEqualTo("info");
         assertThat(a.title()).isEqualTo("Info");
         assertThat(a.content()).isEqualTo("Line 1 Line 2 Line 3");
-        assertThat(a.boost()).isEqualTo(4);
+        assertThat(a.boost()).isEqualTo(0.05);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Fix search-boost scaling**: marketplace pages used `search-boost: 20`, which completely overrode keyword relevance. Reduced to `1.2` to stay within the BM25 scoring range where keyword matches can still win.
- **Fix section heading boost**: was inverted (h6 ranked above h2) and used large integer values. Now h2 gets +0.6, h6 gets +0.2.
- **Rebalance field-level boosts**: content was 100, title was 10. Rebalanced all fields to [1, 2] range so BM25 handles relevance naturally.
- **Add URL path to search results**: each result now shows the page path below the title.
- **Support float search-boost values**: frontmatter `search-boost` now accepts decimals (e.g., `1.2`).
- **Replace SCSS with plain CSS**: no SCSS features were used.
- **Document boost behavior**: explain how boost interacts with BM25 and recommend values between 0 and 2.