### PR TITLE
fix: root pages rank above sections in search

### DIFF
--- a/blog/content/marketplace/plugins/lunr-search.md
+++ b/blog/content/marketplace/plugins/lunr-search.md
@@ -116,4 +116,4 @@ A page with 9 matches scores ~1.94x higher than one with 1 match. If boost excee
 
 With a boost of `1.2`, a boosted page only outranks a non-boosted page when their keyword relevance is within 20% of each other. Stronger keyword matches always win.
 
-Section headings also receive a tiny additive boost (h2: +0.06, h3: +0.05, down to h6: +0.02). This orders sections within the same page without pushing them above full pages.
+Full pages receive a 10% boost (×1.1) so they always rank above their own sections. Sections are slightly demoted (h2: ×0.96, h3: ×0.95, down to h6: ×0.92), keeping them ordered by heading level within the same page.

--- a/blog/content/posts/2026-07-16-smarter-search-ranking/index.md
+++ b/blog/content/posts/2026-07-16-smarter-search-ranking/index.md
@@ -1,6 +1,7 @@
 ---
 title: Smarter Search Ranking
 description: How we fixed search boost to let keyword relevance shine.
+image: https://images.unsplash.com/photo-1520500807606-4ac9ae633574?q=80&w=1200&auto=format&fit=crop
 author: ia3andy
 tags: improvement,plugin
 date: 2026-07-16 14:00:00 +0200
@@ -15,7 +16,7 @@ Lunr uses [BM25](https://en.wikipedia.org/wiki/Okapi_BM25) for scoring, where te
 ### What changed
 
 - **Boost values reduced to the BM25 range.** Marketplace pages now use `search-boost: 1.2` instead of `20`. The reference doc still ranks above unrelated pages, but a blog post with strong keyword matches now appears right after it.
-- **Section heading boost fixed.** h2 sections now rank above h6 (was inverted), with tiny values (+0.06 for h2, +0.02 for h6) that order sections within a page without pushing them above full pages.
+- **Section heading boost fixed.** h2 sections now rank above h6 (was inverted). Sections are slightly demoted (h2: ×0.96, h6: ×0.92) while full pages get a 10% boost, ensuring pages always rank above their own sections.
 - **Field boosts rebalanced.** All field boosts (title, tags, content) are now between 1 and 2, letting BM25 handle relevance naturally.
 - **Search results now show the page URL**, making it easier to see where each result links before clicking.
 

--- a/roq-plugin/lunr/runtime/src/main/java/io/quarkiverse/roq/plugin/lunr/runtime/RoqPluginLunrTemplateExtension.java
+++ b/roq-plugin/lunr/runtime/src/main/java/io/quarkiverse/roq/plugin/lunr/runtime/RoqPluginLunrTemplateExtension.java
@@ -74,14 +74,14 @@ public class RoqPluginLunrTemplateExtension {
                         .put("title", page.title() + " - " + a.title())
                         .put("url", absoluteUrl + "#" + a.id())
                         .put("fragment", a.id())
-                        .put("boost", baseBoost + a.boost());
+                        .put("boost", baseBoost * a.boost());
                 map.put(page.id() + "#" + a.id(), d);
             }
         }
         baseDoc.put("url", absoluteUrl)
                 .put("title", page.title())
                 .put("content", htmlDoc.text())
-                .put("boost", baseBoost);
+                .put("boost", baseBoost * 1.1);
         map.put(page.id(), baseDoc);
         return map;
     }
@@ -141,7 +141,7 @@ public class RoqPluginLunrTemplateExtension {
             String id = heading.id();
             String title = heading.text();
             int level = Integer.parseInt(heading.tagName().substring(1));
-            double boost = (8 - level) / 100.0;
+            double boost = (98 - level) / 100.0;
 
             StringBuilder contentBuilder = new StringBuilder();
             Element current = heading.nextElementSibling();
@@ -168,9 +168,9 @@ public class RoqPluginLunrTemplateExtension {
 
     private static double boostForTag(String tagName) {
         if (tagName.matches("h[1-6]")) {
-            return (8 - Integer.parseInt(tagName.substring(1))) / 100.0;
+            return (98 - Integer.parseInt(tagName.substring(1))) / 100.0;
         }
-        return 0;
+        return 1;
     }
 
     record Anchor(String id, String title, String content, double boost) {

--- a/roq-plugin/lunr/runtime/src/main/web/search.js
+++ b/roq-plugin/lunr/runtime/src/main/web/search.js
@@ -83,7 +83,6 @@ const setupSearch = function (options = {}) {
         documents = data;
         idx = lunr(function () {
             this.ref('id')
-            this.field('fragment', {boost: 1.2})
             this.field('title', {boost: 2})
             this.field('summary')
             this.field('tags', {boost: 1.5})

--- a/roq-plugin/lunr/runtime/src/test/java/io/quarkiverse/roq/plugin/lunr/runtime/RoqPluginLunrTemplateExtensionTest.java
+++ b/roq-plugin/lunr/runtime/src/test/java/io/quarkiverse/roq/plugin/lunr/runtime/RoqPluginLunrTemplateExtensionTest.java
@@ -32,7 +32,7 @@ public class RoqPluginLunrTemplateExtensionTest {
         assertThat(anchor.id()).isEqualTo("intro");
         assertThat(anchor.title()).isEqualTo("Introduction");
         assertThat(anchor.content()).isEqualTo("Welcome to the documentation.");
-        assertThat(anchor.boost()).isEqualTo(0.06); // h2 => (8 - 2) / 100
+        assertThat(anchor.boost()).isEqualTo(0.96); // h2 => (8 - 2) * 0.01 + 0.9
     }
 
     @Test
@@ -58,10 +58,10 @@ public class RoqPluginLunrTemplateExtensionTest {
         assertThat(anchors).hasSize(2);
 
         assertThat(anchors.get(0))
-                .isEqualTo(new Anchor("section1", "Section 1", "First part content.", 0.06));
+                .isEqualTo(new Anchor("section1", "Section 1", "First part content.", 0.96));
 
         assertThat(anchors.get(1))
-                .isEqualTo(new Anchor("section2", "Section 2", "Second part content.", 0.05));
+                .isEqualTo(new Anchor("section2", "Section 2", "Second part content.", 0.95));
     }
 
     @Test
@@ -113,7 +113,7 @@ public class RoqPluginLunrTemplateExtensionTest {
         assertThat(a.id()).isEqualTo("intro");
         assertThat(a.title()).isEqualTo("Introduction");
         assertThat(a.content()).isEqualTo("This is the first paragraph. This is the second paragraph.");
-        assertThat(a.boost()).isEqualTo(0.06); // h2 = (8 - 2) / 100
+        assertThat(a.boost()).isEqualTo(0.96); // h2 = (8 - 2) * 0.01 + 0.9
     }
 
     @Test
@@ -134,7 +134,7 @@ public class RoqPluginLunrTemplateExtensionTest {
         assertThat(a.id()).isEqualTo("features");
         assertThat(a.title()).isEqualTo("Features");
         assertThat(a.content()).isEqualTo("Fast Reliable");
-        assertThat(a.boost()).isEqualTo(0.05); // h3 = (8 - 3) / 100
+        assertThat(a.boost()).isEqualTo(0.95); // h3 = (8 - 3) * 0.01 + 0.9
     }
 
     @Test
@@ -156,13 +156,13 @@ public class RoqPluginLunrTemplateExtensionTest {
         assertThat(a.id()).isEqualTo("a");
         assertThat(a.title()).isEqualTo("A");
         assertThat(a.content()).isEqualTo("Text A1. Text A2.");
-        assertThat(a.boost()).isEqualTo(0.06);
+        assertThat(a.boost()).isEqualTo(0.96);
 
         Anchor b = anchors.get(1);
         assertThat(b.id()).isEqualTo("b");
         assertThat(b.title()).isEqualTo("B");
         assertThat(b.content()).isEqualTo("Text B1.");
-        assertThat(b.boost()).isEqualTo(0.06);
+        assertThat(b.boost()).isEqualTo(0.96);
     }
 
     @Test
@@ -183,15 +183,15 @@ public class RoqPluginLunrTemplateExtensionTest {
 
         assertThat(anchors.get(0).id()).isEqualTo("parent");
         assertThat(anchors.get(0).content()).isEqualTo("Parent content. Child Child content.");
-        assertThat(anchors.get(0).boost()).isEqualTo(0.06);
+        assertThat(anchors.get(0).boost()).isEqualTo(0.96);
 
         assertThat(anchors.get(1).id()).isEqualTo("child");
         assertThat(anchors.get(1).content()).isEqualTo("Child content.");
-        assertThat(anchors.get(1).boost()).isEqualTo(0.04); // h4 = (8 - 4) / 100
+        assertThat(anchors.get(1).boost()).isEqualTo(0.94); // h4 = (8 - 4) * 0.01 + 0.9
 
         assertThat(anchors.get(2).id()).isEqualTo("next");
         assertThat(anchors.get(2).content()).isEqualTo("Next content.");
-        assertThat(anchors.get(2).boost()).isEqualTo(0.06);
+        assertThat(anchors.get(2).boost()).isEqualTo(0.96);
     }
 
     @Test
@@ -211,7 +211,7 @@ public class RoqPluginLunrTemplateExtensionTest {
         assertThat(a.id()).isEqualTo("info");
         assertThat(a.title()).isEqualTo("Info");
         assertThat(a.content()).isEqualTo("Line 1 Line 2 Line 3");
-        assertThat(a.boost()).isEqualTo(0.05);
+        assertThat(a.boost()).isEqualTo(0.95);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up to #1092. Root pages were ranking below their own sections because:
- Sections got extra matches from the `fragment` field (anchor slug)
- Section content is shorter, giving higher BM25 keyword density

Changes:
- Root pages get a 10% boost (×1.1) to always rank above their sections
- Sections use a multiplicative factor below 1 (h2: ×0.96, h6: ×0.92)
- Remove `fragment` from Lunr indexed fields (redundant with section title, was giving sections an unfair advantage)
- Update docs and blog post