### PR TITLE
fix: use LazyValue with Arc to access tagging lowercase config

### DIFF
--- a/roq-plugin/tagging/deployment/src/main/java/io/quarkiverse/roq/plugin/tagging/deployment/RoqPluginTaggingProcessor.java
+++ b/roq-plugin/tagging/deployment/src/main/java/io/quarkiverse/roq/plugin/tagging/deployment/RoqPluginTaggingProcessor.java
@@ -32,6 +32,7 @@ import io.quarkiverse.roq.plugin.tagging.RoqTaggingTemplateExtension;
 import io.quarkiverse.roq.plugin.tagging.RoqTaggingUtils;
 import io.quarkiverse.roq.plugin.tagging.runtime.RoqTaggingConfig;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -50,13 +51,15 @@ public class RoqPluginTaggingProcessor {
 
     @BuildStep
     void registerAdditionalBeans(RoqFrontMatterOutputBuildItem roqOutput,
-            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            BuildProducer<UnremovableBeanBuildItem> unremovableBeans) {
         if (roqOutput == null) {
             return;
         }
         additionalBeans.produce(AdditionalBeanBuildItem.builder()
                 .addBeanClasses(RoqTaggingTemplateExtension.class)
                 .setUnremovable().build());
+        unremovableBeans.produce(UnremovableBeanBuildItem.beanTypes(RoqTaggingConfig.class));
     }
 
     @BuildStep

--- a/roq-plugin/tagging/runtime/src/main/java/io/quarkiverse/roq/plugin/tagging/RoqTaggingTemplateExtension.java
+++ b/roq-plugin/tagging/runtime/src/main/java/io/quarkiverse/roq/plugin/tagging/RoqTaggingTemplateExtension.java
@@ -8,15 +8,36 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.microprofile.config.ConfigProvider;
-
 import io.quarkiverse.roq.frontmatter.runtime.model.Page;
 import io.quarkiverse.roq.frontmatter.runtime.model.RoqCollection;
 import io.quarkiverse.roq.frontmatter.runtime.model.Site;
+import io.quarkiverse.roq.plugin.tagging.runtime.RoqTaggingConfig;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.impl.LazyValue;
 import io.quarkus.qute.TemplateExtension;
 
 @TemplateExtension
 public class RoqTaggingTemplateExtension {
+
+    private static final LazyValue<Boolean> LOWERCASE = new LazyValue<>(() -> {
+        var container = Arc.container();
+        if (container == null) {
+            throw new IllegalStateException("Arc container is not available");
+        }
+        var instance = container.instance(RoqTaggingConfig.class);
+        if (!instance.isAvailable()) {
+            throw new IllegalStateException("RoqTaggingConfig bean is not available");
+        }
+        return instance.get().lowercase();
+    });
+
+    private static boolean isLowercase() {
+        try {
+            return LOWERCASE.get();
+        } catch (IllegalStateException e) {
+            return false;
+        }
+    }
 
     /**
      * Returns a list of all tags from the given collection, with each tag slugified.
@@ -74,12 +95,6 @@ public class RoqTaggingTemplateExtension {
         }
 
         return tagMap;
-    }
-
-    private static boolean isLowercase() {
-        return ConfigProvider.getConfig()
-                .getOptionalValue("quarkus.roq.tagging.lowercase", Boolean.class)
-                .orElse(false);
     }
 
 }


### PR DESCRIPTION
## Summary
- Replace `ConfigProvider.getConfig()` with a `LazyValue` that resolves `RoqTaggingConfig` via `Arc.container()`, avoiding hardcoded config keys and repeated lookups
- The `LazyValue` supplier throws when the container or bean isn't available, so it retries on next access instead of caching a wrong `false`
- Mark `RoqTaggingConfig` as unremovable since the programmatic Arc lookup has no compile-time injection point

Follow-up to #1094.