### PR TITLE
Enable alt expression syntax in codestarts and update docs

### DIFF
--- a/blog/content/docs/advanced.adoc
+++ b/blog/content/docs/advanced.adoc
@@ -381,9 +381,7 @@ Sometimes, you want to create a link for a page without holding the variable, in
 
 Qute supports an alternative expression syntax where output expressions use `{=expr}` instead of `{expr}`. This makes templates safer when content contains curly braces (e.g. code samples, JSON) since only `{=...}` and `{#...}` are interpreted as Qute expressions, everything else is plain text.
 
-NOTE: Standard Qute syntax is still the default, but this will change in a future version. New projects already have alt syntax enabled via the generated config. We recommend setting the config explicitly so your project is ready.
-
-NOTE: All examples in this documentation use the alternative expression syntax.
+NOTE: Standard Qute syntax is still the default, but this will change in a future version. New projects already have alt syntax enabled via the generated config. We recommend setting the config explicitly so your project is ready. All examples in this documentation use the alternative expression syntax.
 
 To enable it, add to your configuration:
 

--- a/blog/content/docs/advanced.adoc
+++ b/blog/content/docs/advanced.adoc
@@ -346,13 +346,13 @@ The pages links are automatically converted to urls by Roq, they are available i
 
 [source,html]
 ----
-<a href="{site.url}">Back to main page</a>
+<a href="{=site.url}">Back to main page</a>
 ----
 or to get the next page url in a document:
 
 [source,html]
 ----
-<a href="{page.next.url}">{page.next.title}</a>
+<a href="{=page.next.url}">{=page.next.title}</a>
 ----
 
 or when iterating on documents:
@@ -360,7 +360,7 @@ or when iterating on documents:
 [source,html]
 ----
 {#for post in site.collections.posts}
-  <a href="{post.url}">{post.title}</a>
+  <a href="{=post.url}">{=post.title}</a>
 {/for}
 ----
 
@@ -368,10 +368,10 @@ or also to manually retrieve a page url with `site.page(sourcePath)`:
 
 [source,html]
 ----
-<a href="{site.page('foo.html').url}">{site.page('foo.html').title}</a>
+<a href="{=site.page('foo.html').url}">{=site.page('foo.html').title}</a>
 ----
 
-TIP: By default, url will be rendered as the path from the site root. You can also get the full absolute url (i.e. from `http(s)://`) by using `absolute` on any url (e.g. `{site.url.absolute}`).
+TIP: By default, url will be rendered as the path from the site root. You can also get the full absolute url (i.e. from `http(s)://`) by using `absolute` on any url (e.g. `{=site.url.absolute}`).
 
 === Manual linking
 
@@ -381,7 +381,9 @@ Sometimes, you want to create a link for a page without holding the variable, in
 
 Qute supports an alternative expression syntax where output expressions use `{=expr}` instead of `{expr}`. This makes templates safer when content contains curly braces (e.g. code samples, JSON) since only `{=...}` and `{#...}` are interpreted as Qute expressions, everything else is plain text.
 
-NOTE: This will become the default syntax for Roq in a future version.
+NOTE: Standard Qute syntax is still the default, but this will change in a future version. New projects already have alt syntax enabled via the generated config. We recommend setting the config explicitly so your project is ready.
+
+NOTE: All examples in this documentation use the alternative expression syntax.
 
 To enable it, add to your configuration:
 
@@ -447,7 +449,7 @@ Then use it in templates:
 
 [source,html]
 ----
-{cdi:mountain.name}: {cdi:mountain.elevation}
+{=cdi:mountain.name}: {=cdi:mountain.elevation}
 ----
 
 === Array data files
@@ -464,7 +466,7 @@ public record Mountains(List<Mountain> list) {} // <1>
 [source,html]
 ----
 {#for mountain in cdi:mountains.list}
-  {mountain.name}: {mountain.elevation}
+  {=mountain.name}: {=mountain.elevation}
 {/for}
 ----
 
@@ -485,7 +487,7 @@ public record HeroList(List<Hero> list) {
 [source,html]
 ----
 {#for hero in cdi:heroList.list}
-  {hero.name} from {hero.city}
+  {=hero.name} from {=hero.city}
 {/for}
 ----
 
@@ -500,7 +502,7 @@ public record HeroMap(Map<String, Hero> map) {
 
 [source,html]
 ----
-{cdi:heroMap.map.batman.name}
+{=cdi:heroMap.map.batman.name}
 ----
 
 === Type reference
@@ -581,8 +583,8 @@ The layout template accesses data fields via `page.data`:
 [source,html]
 .templates/layouts/page-event.html
 ----
-<h1>{page.data.name}</h1>
-<p>{page.data.description}</p>
+<h1>{=page.data.name}</h1>
+<p>{=page.data.description}</p>
 ----
 
 === Data configuration
@@ -626,7 +628,7 @@ First, include the `quarkus-roq-testing` test dependency in your `pom.xml`.
     <dependency>
         <groupId>io.quarkiverse.roq</groupId>
         <artifactId>quarkus-roq-testing</artifactId>
-        <version>{cdi:project-info.release.current-version}</version>
+        <version>{=cdi:project-info.release.current-version}</version>
         <scope>test</scope>
     </dependency>
 ----

--- a/blog/content/docs/basics.adoc
+++ b/blog/content/docs/basics.adoc
@@ -69,13 +69,13 @@ description: It is time to start Roqing 🎸!
 
 <p>
   With Roq, it is very easy to link to another
-  <a href="{site.url('/roq-page')}">page</a>. // <2>
+  <a href="{=site.url('/roq-page')}">page</a>. // <2>
 </p>
 
 ----
 
 <1> The index.html also describe your `site` information through a FrontMatter header.
-<2> We use the `{site.url(path)}` using Qute to manually resolve other pages urls.
+<2> We use the `{=site.url(path)}` using Qute to manually resolve other pages urls.
 
 TIP: There are different ways to link your pages as explained in the  link:{site-url}docs/advanced#links[Links & Urls] section.
 
@@ -102,7 +102,7 @@ the-rope: You Roq! <2>
 
 If you thought you hit Roq Bottom, take this 🪢 because :
 
-__{page.data.the-rope}!__ <3>
+__{=page.data.the-rope}!__ <3>
 
 ----
 
@@ -134,7 +134,7 @@ bar: |
     This is using **Markdown**
 ---
 
-{page.data.bar.mdToHtml}
+{=page.data.bar.mdToHtml}
 
 ----
 
@@ -150,7 +150,7 @@ TIP: See the link:/markups/markdown/[Markdown markup test] page for example usag
 AsciiDoc is also fully supported in Roq via the link:/plugin/asciidoc/[AsciiDoc plugin].
 Once installed, to write pages or documents in AsciiDoc, simply use the `.adoc` or `.asciidoc` file extension.
 
-TIP: When using Qute expressions as link targets in AsciiDoc, use the explicit `link:` macro. AsciiDoc only auto-detects links for known URL schemes (http, https, ...), so `\{page.url}[Click here]` won't render as a link. Use `link:\{page.url}[Click here]` instead.
+TIP: When using Qute expressions as link targets in AsciiDoc, use the explicit `link:` macro. AsciiDoc only auto-detects links for known URL schemes (http, https, ...), so `\{=page.url}[Click here]` won't render as a link. Use `link:\{=page.url}[Click here]` instead.
 
 TIP: See the link:/markups/asciidoc/[AsciiDoc markup test] page for example usage of all supported AsciiDoc features.
 
@@ -176,7 +176,7 @@ img: 2024/10/roq-solid.jpg
 
 ---
 
-# {page.title} <2>
+# {=page.title} <2>
 
 Here is a list of puns suggested by Chat GPT:
 1.	Roq and Rule – A play on "rock and roll," implying dominance or success.
@@ -207,11 +207,11 @@ Ok, to dive a bit deeper, we could create a json listing all posts with some inf
 [
 {#for post in site.collections.posts} // <1>
   {
-    "title": "{post.title}",
-    "url": "{post.url.absolute}", // <2>
-    "image": "{post.image.absolute}", // <3>
-    "date": "{post.date}", // <4>
-    "read-time": "{post.readTime}" // <5>
+    "title": "{=post.title}",
+    "url": "{=post.url.absolute}", // <2>
+    "image": "{=post.image.absolute}", // <3>
+    "date": "{=post.date}", // <4>
+    "read-time": "{=post.readTime}" // <5>
   }{#if !post_isLast},{/if}
 {/for}
 ]
@@ -282,7 +282,7 @@ Now, we can access all the new collection `docs` data as follows:
 [source]
 ----
 {#for doc in site.collections.docs}
-- [{doc.title}]({doc.url})
+- [{=doc.title}]({=doc.url})
 {/for}
 ----
 
@@ -350,7 +350,7 @@ To do so, you will first need a `default.html` file as followed:
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{page.title}</title> <1>
+    <title>{=page.title}</title> <1>
 </head>
 <body>
     {#insert /} <2>
@@ -434,10 +434,10 @@ For example, create a tag in `templates/partials/post-link.html`:
 ----
 {@io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage post}
 <div class="post-link">
-    <a href="{post.url}">
-      <img src="{post.image}" alt="{post.title}" class="post-image"/>
-      <h3>{post.title}</h3>
-      <p>{post.description}</p>
+    <a href="{=post.url}">
+      <img src="{=post.image}" alt="{=post.title}" class="post-image"/>
+      <h3>{=post.title}</h3>
+      <p>{=post.description}</p>
     </a>
 </div>
 ----
@@ -636,7 +636,7 @@ Roq uses the site locale to format dates in templates. Set the default locale in
 site.default-locale=fr
 ----
 
-This affects all locale-aware date extensions such as `shortDate`, `longDate`, and `dateStyle`. For example, with `site.default-locale=fr`, `{page.date.longDate}` renders "9 octobre 2024" instead of "October 9, 2024".
+This affects all locale-aware date extensions such as `shortDate`, `longDate`, and `dateStyle`. For example, with `site.default-locale=fr`, `{=page.date.longDate}` renders "9 octobre 2024" instead of "October 9, 2024".
 
 You can also override the locale per page using frontmatter:
 
@@ -682,7 +682,7 @@ Date extensions use Java's `FormatStyle` for locale-aware formatting. The availa
 | Wednesday, October 9, 2024
 |===
 
-The `style` extension also accepts a custom date pattern: `\{page.date.style('yyyy, MMM dd')}`.
+The `style` extension also accepts a custom date pattern: `\{=page.date.style('yyyy, MMM dd')}`.
 
 NOTE: Roq does not yet support i18n collections (generating the same content in multiple languages with locale-specific URLs). The locale setting only affects date and number formatting in templates.
 
@@ -844,7 +844,7 @@ Access it with the `cdi` namespace:
 
 [source,html]
 ----
-{cdi:foo.bar}
+{=cdi:foo.bar}
 ----
 
 For structured data:
@@ -862,10 +862,10 @@ john:
 
 [source,html]
 ----
-{cdi:authors.ia3andy.name}
+{=cdi:authors.ia3andy.name}
 
 {#let author=cdi:authors.get(page.data.author)}
-  <a href="{author.url}">{author.name}</a>
+  <a href="{=author.url}">{=author.name}</a>
 {/let}
 ----
 
@@ -882,8 +882,8 @@ data/heroes/
 
 [source,html]
 ----
-{cdi:heroes.batman.name}
-{cdi:heroes.superman.city}
+{=cdi:heroes.batman.name}
+{=cdi:heroes.superman.city}
 ----
 
 For type-safe Java mappings, data collections, and configuration, see the xref:advanced.adoc#data[Data section] in the advanced guide.
@@ -970,7 +970,7 @@ and then you can use that extension in your template:
 
 [source,asciidoc]
 -----
-{site.pageContent(page).doSomething}
+{=site.pageContent(page).doSomething}
 -----
 
 For more details, see the https://quarkus.io/guides/qute#template-extension-methods[Quarkus] and https://quarkus.io/guides/qute-reference#virtual_methods[Qute] documentation.
@@ -1026,9 +1026,9 @@ The resulting link for a page can be different from its directory name, attached
 
 Let's imagine for a minute that the page link is `https://my-site.org/awesome-page/`, then the slide will be served on `https://my-site.org/awesome-page/slide.pdf`.
 
-You can use `{page.file("slide.pdf")}` to resolve the file url *and check that the file exists*. This is also useful in other cases, for example from another page (e.g. `{site.page("my-page/index.md").file("slide.pdf")}`) or if you want the absolute url (e.g. `{page.file("slide.pdf").absolute}`):
+You can use `{=page.file("slide.pdf")}` to resolve the file url *and check that the file exists*. This is also useful in other cases, for example from another page (e.g. `{=site.page("my-page/index.md").file("slide.pdf")}`) or if you want the absolute url (e.g. `{=page.file("slide.pdf").absolute}`):
 
-TIP: If you want to iterate over page files, they can be listed using `{page.files}`.
+TIP: If you want to iterate over page files, they can be listed using `{=page.files}`.
 
 === Images
 
@@ -1043,20 +1043,20 @@ The default public path is `images/` and can be customized in the site configura
 Use `site.image()` to generate the correct URL:
 
 ```html
-<img src="{site.image('image-1.png')}" />
+<img src="{=site.image('image-1.png')}" />
 ```
 
 TIP: `site.image(name)` is equivalent to:
 
 ```html
-<img src="{site.file('images/' + name)}" />
+<img src="{=site.file('images/' + name)}" />
 ```
 
 ==== Page images
 
-When a page is a directory (for example `posts/surf/index.html`), the method `{page.image(name)}` checks if the image is attached to that page and returns its URL.
+When a page is a directory (for example `posts/surf/index.html`), the method `{=page.image(name)}` checks if the image is attached to that page and returns its URL.
 
-For single‑file pages (`posts/basketball.md`), `{page.image(name)}` behaves like `site.image(name)` and resolves from `public/images/`.
+For single‑file pages (`posts/basketball.md`), `{=page.image(name)}` behaves like `site.image(name)` and resolves from `public/images/`.
 
 Example structure:
 
@@ -1077,7 +1077,7 @@ my-site/
 ```
 
 <1> Non-directory pages → `page.image()` == `site.image()`.
-<2> Page-attached file → accessible via `{page.image('surf.jpg')}`.
+<2> Page-attached file → accessible via `{=page.image('surf.jpg')}`.
 <3> Site images → accessible everywhere via `site.image(name)`.
 
 ==== Usage example
@@ -1090,15 +1090,15 @@ image: cover.jpg
 ---
 <h2>👍</h2>
 <img src="surf.jpg" />                       <!-- 1 -->
-<img src="{page.image()}" />                 <!-- 2 -->
-<img src="{page.image('surf.jpg')}" />       <!-- 3 -->
-<img src="{site.image('basketball.jpg')}" /> <!-- 4 -->
-<img src="{site.image('basketball.png').absolute}" /> <!-- 5 -->
+<img src="{=page.image()}" />                 <!-- 2 -->
+<img src="{=page.image('surf.jpg')}" />       <!-- 3 -->
+<img src="{=site.image('basketball.jpg')}" /> <!-- 4 -->
+<img src="{=site.image('basketball.png').absolute}" /> <!-- 5 -->
 
 <h2>👎</h2>
-<img src="{site.image('surf.jpg')}" />       <!-- 6 -->
-<img src="{page.image('soccer.jpg')}" />     <!-- 6 -->
-<img src="{page.image('basketball.jpg')}" /> <!-- 6 -->
+<img src="{=site.image('surf.jpg')}" />       <!-- 6 -->
+<img src="{=page.image('soccer.jpg')}" />     <!-- 6 -->
+<img src="{=page.image('basketball.jpg')}" /> <!-- 6 -->
 ```
 
 === Page & Site cover image
@@ -1111,10 +1111,10 @@ Page cover image is referenced in the page FM `image` data.
 image: my-page.png
 ---
 
-{page.image}
+{=page.image}
 ----
 
-The url can be accessed from this template (and its parent layouts) through `{page.image}`.
+The url can be accessed from this template (and its parent layouts) through `{=page.image}`.
 
 [source,yaml]
 .index.html
@@ -1124,7 +1124,7 @@ image: my-site.png
 ---
 ----
 
-It can be accessed in any template through `{site.image}`.
+It can be accessed in any template through `{=site.image}`.
 
 == Styles and Javascript
 

--- a/blog/content/marketplace/plugins/asciidoc-jruby.md
+++ b/blog/content/marketplace/plugins/asciidoc-jruby.md
@@ -98,6 +98,6 @@ bar: |
     * I can use asciidoc in the data
 ---
 
-{page.data.foo.asciidocToHtml}
+{=page.data.foo.asciidocToHtml}
 ```
 |}

--- a/blog/content/marketplace/plugins/asciidoc.md
+++ b/blog/content/marketplace/plugins/asciidoc.md
@@ -122,6 +122,6 @@ bar: |
     * I can use asciidoc in the data
 ---
 
-{page.data.bar.asciidocToHtml}
+{=page.data.bar.asciidocToHtml}
 ```
 |}

--- a/blog/content/marketplace/plugins/tagging.md
+++ b/blog/content/marketplace/plugins/tagging.md
@@ -26,7 +26,7 @@ tagging: posts
 ---
 
 {#for post in site.collections.get(page.data.tagCollection)}
-  <div>{post.title}</div>
+  <div>{=post.title}</div>
 {/for}
 ```
 |}
@@ -43,7 +43,7 @@ paginate: true
 ---
 
 {#for post in site.collections.get(page.data.tagCollection).paginated(page.paginator)}
-  <div>{post.title}</div>
+  <div>{=post.title}</div>
 {/for}
 ```
 |}
@@ -57,7 +57,7 @@ There is also a `site.tags` property, which enables this syntax in templates:
 ```html
 {#for entry in site.tags}
     {#for entry in site.tags}
-        Tag: {entry.key} has {entry.value.size} pages
+        Tag: {=entry.key} has {=entry.value.size} pages
     {/for} 
 {/for}
 
@@ -70,7 +70,7 @@ Or with sorting:
 ```html
 {#let tag_words=site.tags.entrySet.sort('key')}
     {#for entry in tag_words}
-        <a href="/blog/tag/{entry.key}">{entry.key}</a> ({entry.value.size})
+        <a href="/blog/tag/{=entry.key}">{=entry.key}</a> ({=entry.value.size})
     {/for}
 {/let}
 ```

--- a/blog/content/posts/2024-09-16-effortless-url-handling-in-roq-with-qute-super-power/index.md
+++ b/blog/content/posts/2024-09-16-effortless-url-handling-in-roq-with-qute-super-power/index.md
@@ -14,19 +14,19 @@ Managing URLs is now very easy! With our updated Qute-powered feature, you can n
 - **Relative URL Example (toString prints the relative url)**:
 
 ```html
-<a class="post-thumbnail" href="\{post.url}"> </a>
+<a class="post-thumbnail" href="\{=post.url}"> </a>
 ```
 
 - **Absolute URL Example**:
 
 ```html
-<a class="post-thumbnail" href="\{post.url.absolute}"> </a>
+<a class="post-thumbnail" href="\{=post.url.absolute}"> </a>
 ```
 
 - ** Smart URL:**
 
 ```html
-<meta name="twitter:image:src" content="\{page.image.absolute}" >
+<meta name="twitter:image:src" content="\{=page.image.absolute}" >
 ```
 
 There is a method in Page to retrieve the image url as a `RoqUrl` from the configured site images path. It is smart so that if the page image is external, it won't be affected.

--- a/blog/content/posts/2026-05-22-generate-first-class-citizen-pages-from-your-data-with-roq/index.adoc
+++ b/blog/content/posts/2026-05-22-generate-first-class-citizen-pages-from-your-data-with-roq/index.adoc
@@ -32,7 +32,7 @@ In this case one item of this collection would be found under the `\https://iamr
 
 And that's all. There is NOTHING else to do. Ok, maybe the _layout_ is still work to do. Ok. A minor peculiarity, for the moment item will be made available for the templating through the page `data`, even you have specified `@DataMapping`.
 
-To access it in your **__Qute__** template you will have to use `{page.data.title}` (or if you use the alternative syntax `\{=page.data.title}`).
+To access it in your **__Qute__** template you will have to use `\{=page.data.title}` (or `\{page.data.title}` if you are not using the alternative expression syntax).
 
 The feature is beeing particularly usefull in this AI era where LLM are so keen to generate structured output. 
 

--- a/blog/content/posts/2026-07-07-add-comments-hybrid/index.md
+++ b/blog/content/posts/2026-07-07-add-comments-hybrid/index.md
@@ -237,7 +237,7 @@ Create `templates/partials/comments.html`:
 <!-- Comments section -->
 <section class="mt-12 border-t border-slate-200 dark:border-slate-700 pt-8">
   <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-6">
-    Comments ({cdi:comments.count(page.slug)})
+    Comments ({=cdi:comments.count(page.slug)})
   </h2>
 
   <!-- Comment list -->
@@ -245,10 +245,10 @@ Create `templates/partials/comments.html`:
     {#for comment in cdi:comments.forPost(page.slug)}
     <div class="p-4 rounded-lg bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700">
       <div class="flex items-center justify-between mb-2">
-        <span class="font-medium text-sm text-slate-800 dark:text-slate-200">{comment.author}</span>
-        <time class="text-xs text-slate-500 dark:text-slate-400">{comment.createdAt.format('MMM d, yyyy HH:mm')}</time>
+        <span class="font-medium text-sm text-slate-800 dark:text-slate-200">{=comment.author}</span>
+        <time class="text-xs text-slate-500 dark:text-slate-400">{=comment.createdAt.format('MMM d, yyyy HH:mm')}</time>
       </div>
-      <p class="text-sm text-slate-700 dark:text-slate-300">{comment.content}</p>
+      <p class="text-sm text-slate-700 dark:text-slate-300">{=comment.content}</p>
     </div>
     {#else}
     <p class="text-sm text-slate-500 dark:text-slate-400 italic">No comments yet. Be the first!</p>
@@ -257,8 +257,8 @@ Create `templates/partials/comments.html`:
 
   <!-- Comment form -->
   <form method="POST" action="/api/comments" class="space-y-4">
-    <input type="hidden" name="postSlug" value="{page.slug}">
-    <input type="hidden" name="redirectUrl" value="{page.url}">
+    <input type="hidden" name="postSlug" value="{=page.slug}">
+    <input type="hidden" name="redirectUrl" value="{=page.url}">
     <div>
       <label for="author" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Name</label>
       <input type="text" id="author" name="author" required

--- a/blog/content/posts/2026-07-07-add-comments-web-component/index.md
+++ b/blog/content/posts/2026-07-07-add-comments-web-component/index.md
@@ -426,7 +426,7 @@ theme-layout: post
 {#insert /}
 
 <script crossorigin src="http://localhost:7070/static/bundle/app.js" type="module"></script>
-<comments-section post-slug="{page.slug}" server-url="http://localhost:7070"></comments-section>
+<comments-section post-slug="{=page.slug}" server-url="http://localhost:7070"></comments-section>
 ```
 
 </details>
@@ -438,7 +438,7 @@ In your existing `templates/layouts/post.html`, add the script and component aft
 
 ```html
 <script crossorigin src="http://localhost:7070/static/bundle/app.js" type="module"></script>
-<comments-section post-slug="{page.slug}" server-url="http://localhost:7070"></comments-section>
+<comments-section post-slug="{=page.slug}" server-url="http://localhost:7070"></comments-section>
 ```
 
 </details>

--- a/blog/content/posts/2026-07-07-create-a-blog-from-scratch-with-roq/index.md
+++ b/blog/content/posts/2026-07-07-create-a-blog-from-scratch-with-roq/index.md
@@ -114,7 +114,7 @@ theme-layout: default
   <header class="border-b border-slate-200 dark:border-slate-800">
     <div class="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
       <a href="/" class="text-lg font-bold text-slate-900 dark:text-white hover:text-sky-600 dark:hover:text-sky-400 transition-colors">
-        {site.title}
+        {=site.title}
       </a>
       <nav class="flex gap-4 text-sm">
         <a href="/" class="text-slate-600 dark:text-slate-400 hover:text-sky-600 dark:hover:text-sky-400 transition-colors">Home</a>
@@ -262,14 +262,14 @@ layout: default
 
 <article class="space-y-6">
   <header class="space-y-2">
-    <h1 class="text-3xl font-bold text-slate-900 dark:text-white">{page.title}</h1>
+    <h1 class="text-3xl font-bold text-slate-900 dark:text-white">{=page.title}</h1>
     {#if page.date}
-    <time class="text-sm text-slate-500 dark:text-slate-400">{page.date.longDate}</time>
+    <time class="text-sm text-slate-500 dark:text-slate-400">{=page.date.longDate}</time>
     {/if}
     {#if page.data.tags}
     <div class="flex gap-2">
       {#for tag in page.data.tags.asStrings}
-      <span class="text-xs bg-sky-100 dark:bg-sky-900 text-sky-700 dark:text-sky-300 px-2 py-0.5 rounded">{tag}</span>
+      <span class="text-xs bg-sky-100 dark:bg-sky-900 text-sky-700 dark:text-sky-300 px-2 py-0.5 rounded">{=tag}</span>
       {/for}
     </div>
     {/if}
@@ -281,10 +281,10 @@ layout: default
 
   <footer class="border-t border-slate-200 dark:border-slate-800 pt-4 flex justify-between text-sm text-slate-500 dark:text-slate-400">
     {#if page.previous}
-    <a href="{page.previous.url}" class="hover:text-sky-600 dark:hover:text-sky-400">&larr; {page.previous.title}</a>
+    <a href="{=page.previous.url}" class="hover:text-sky-600 dark:hover:text-sky-400">&larr; {=page.previous.title}</a>
     {#else}<span></span>{/if}
     {#if page.next}
-    <a href="{page.next.url}" class="hover:text-sky-600 dark:hover:text-sky-400">{page.next.title} &rarr;</a>
+    <a href="{=page.next.url}" class="hover:text-sky-600 dark:hover:text-sky-400">{=page.next.title} &rarr;</a>
     {/if}
   </footer>
 </article>
@@ -396,11 +396,11 @@ paginate:
 
   <div class="space-y-4">
     {#for post in site.collections.posts.paginated(page.paginator)}
-    <a href="{post.url}" class="block p-5 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 hover:border-sky-400 dark:hover:border-sky-500 hover:shadow-md transition-all duration-200">
-      <h2 class="text-lg font-semibold text-slate-900 dark:text-white">{post.title}</h2>
-      <time class="text-xs text-slate-500 dark:text-slate-400">{post.date.longDate}</time>
+    <a href="{=post.url}" class="block p-5 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 hover:border-sky-400 dark:hover:border-sky-500 hover:shadow-md transition-all duration-200">
+      <h2 class="text-lg font-semibold text-slate-900 dark:text-white">{=post.title}</h2>
+      <time class="text-xs text-slate-500 dark:text-slate-400">{=post.date.longDate}</time>
       {#if post.description}
-      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">{post.description}</p>
+      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">{=post.description}</p>
       {/if}
     </a>
     {/for}
@@ -452,14 +452,14 @@ paginate: true
 
 <div class="space-y-6">
   <div class="text-center space-y-2">
-    <h1 class="text-2xl font-bold text-slate-900 dark:text-white">Tag: {page.data.tag}</h1>
+    <h1 class="text-2xl font-bold text-slate-900 dark:text-white">Tag: {=page.data.tag}</h1>
   </div>
 
   <div class="space-y-4">
     {#for post in site.collections.get(page.data.tagCollection).paginated(page.paginator)}
-    <a href="{post.url}" class="block p-5 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 hover:border-sky-400 dark:hover:border-sky-500 hover:shadow-md transition-all duration-200">
-      <h2 class="text-lg font-semibold text-slate-900 dark:text-white">{post.title}</h2>
-      <time class="text-xs text-slate-500 dark:text-slate-400">{post.date.longDate}</time>
+    <a href="{=post.url}" class="block p-5 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 hover:border-sky-400 dark:hover:border-sky-500 hover:shadow-md transition-all duration-200">
+      <h2 class="text-lg font-semibold text-slate-900 dark:text-white">{=post.title}</h2>
+      <time class="text-xs text-slate-500 dark:text-slate-400">{=post.date.longDate}</time>
     </a>
     {/for}
   </div>
@@ -475,7 +475,7 @@ Now update the tag spans in your `post.html` layout to be clickable links:
 <details>
 <summary>See hint</summary>
 
-Replace the `<span>` tags with `<a>` links pointing to `{site.url('/posts/tag', tag.slugify)}`.
+Replace the `<span>` tags with `<a>` links pointing to `{=site.url('/posts/tag', tag.slugify)}`.
 
 </details>
 
@@ -488,7 +488,7 @@ In `templates/layouts/post.html`, replace the tags section:
     {#if page.data.tags}
     <div class="flex gap-2">
       {#for tag in page.data.tags.asStrings}
-      <a href="{site.url('/posts/tag', tag.slugify)}" class="text-xs bg-sky-100 dark:bg-sky-900 text-sky-700 dark:text-sky-300 px-2 py-0.5 rounded hover:bg-sky-200 dark:hover:bg-sky-800 transition-colors">{tag}</a>
+      <a href="{=site.url('/posts/tag', tag.slugify)}" class="text-xs bg-sky-100 dark:bg-sky-900 text-sky-700 dark:text-sky-300 px-2 py-0.5 rounded hover:bg-sky-200 dark:hover:bg-sky-800 transition-colors">{=tag}</a>
       {/for}
     </div>
     {/if}

--- a/blog/content/posts/2026-07-07-create-a-link-tree-with-roq/index.md
+++ b/blog/content/posts/2026-07-07-create-a-link-tree-with-roq/index.md
@@ -374,7 +374,7 @@ Create `templates/partials/profile.html` that displays the avatar, name, handle,
 <details>
 <summary>See hint</summary>
 
-Partials are included with `{#include partials/profile /}` and share the parent template's context. Use `site.image(cdi:profile.image)` for the avatar URL. Loop through `cdi:profile.social` for the social icons with `ph-fill ph-{s.icon}` classes.
+Partials are included with `{#include partials/profile /}` and share the parent template's context. Use `site.image(cdi:profile.image)` for the avatar URL. Loop through `cdi:profile.social` for the social icons with `ph-fill ph-{=s.icon}` classes.
 
 </details>
 
@@ -386,21 +386,21 @@ Create `templates/partials/profile.html`:
 ```html
 <div class="lt-profile">
   {#if cdi:profile.image}
-  <img src="{site.image(cdi:profile.image)}" alt="{cdi:profile.name}" class="lt-avatar">
+  <img src="{=site.image(cdi:profile.image)}" alt="{=cdi:profile.name}" class="lt-avatar">
   {/if}
   <h1 class="lt-name">
-    {#if cdi:profile.name}<span class="lt-name-text">{cdi:profile.name}</span>{/if}
-    {#if cdi:profile.handle}<span class="lt-handle">{#if cdi:profile.name} {/if}{cdi:profile.handle}</span>{/if}
+    {#if cdi:profile.name}<span class="lt-name-text">{=cdi:profile.name}</span>{/if}
+    {#if cdi:profile.handle}<span class="lt-handle">{#if cdi:profile.name} {/if}{=cdi:profile.handle}</span>{/if}
   </h1>
-  <p class="lt-title">{cdi:profile.title}</p>
+  <p class="lt-title">{=cdi:profile.title}</p>
 </div>
 
 {#if cdi:profile.social??}
 <div class="lt-social">
   <div class="lt-social-icons">
     {#for s in cdi:profile.social}
-    <a href="{s.url}" target="_blank" rel="noopener noreferrer" aria-label="{s.name}" class="lt-social-link">
-      <i class="ph-fill ph-{s.icon}" style="font-size: 24px;"></i>
+    <a href="{=s.url}" target="_blank" rel="noopener noreferrer" aria-label="{=s.name}" class="lt-social-link">
+      <i class="ph-fill ph-{=s.icon}" style="font-size: 24px;"></i>
     </a>
     {/for}
   </div>
@@ -429,14 +429,14 @@ Tags are called with `{#linkCard link=myLink /}`. The `link` variable is passed 
 Create `templates/tags/linkCard.html`:
 
 ```html
-<a href="{link.url}" target="_blank" rel="noopener noreferrer" class="group lt-link-card">
+<a href="{=link.url}" target="_blank" rel="noopener noreferrer" class="group lt-link-card">
   <span class="lt-link-content">
     {#if link.icon}
-    <i class="ph ph-{link.icon} lt-link-icon" style="font-size: 20px;"></i>
+    <i class="ph ph-{=link.icon} lt-link-icon" style="font-size: 20px;"></i>
     {/if}
     <span>
-      <span class="lt-link-name">{link.name}</span>
-      <span class="lt-link-desc">{link.description}</span>
+      <span class="lt-link-name">{=link.name}</span>
+      <span class="lt-link-desc">{=link.description}</span>
     </span>
   </span>
   <span class="lt-link-arrow">
@@ -635,9 +635,9 @@ sitemap: false
   <div class="lt-container">
 
     <div class="lt-heading">
-      <h1 class="lt-heading-title">{page.title}</h1>
+      <h1 class="lt-heading-title">{=page.title}</h1>
       {#if page.description}
-      <p class="lt-title">{page.description}</p>
+      <p class="lt-title">{=page.description}</p>
       {/if}
     </div>
 
@@ -717,21 +717,21 @@ layout: default
     <a href="/" class="lt-home-link"><i class="ph ph-house" style="font-size: 16px;"></i> Profile</a>
 
     <div class="lt-heading">
-      <h1 class="lt-heading-title">{page.title}</h1>
+      <h1 class="lt-heading-title">{=page.title}</h1>
     </div>
 
     <div class="lt-trees">
       {#for tree in site.collections.trees}
       <div class="lt-tree-card">
-        <h2 class="lt-tree-title">{tree.data.title}</h2>
-        <p class="lt-tree-desc">{tree.data.description}</p>
+        <h2 class="lt-tree-title">{=tree.data.title}</h2>
+        <p class="lt-tree-desc">{=tree.data.description}</p>
 
-        <div class="lt-qr-wrap qr-wrap" data-filename="qr-{tree.data.title.slugify}.svg">
+        <div class="lt-qr-wrap qr-wrap" data-filename="qr-{=tree.data.title.slugify}.svg">
           {#qrcode value=tree.url.absolute alt=tree.data.title foreground="#0e4a5c" background="#FFFFFF" width=200 height=200 /}
         </div>
 
         <div class="lt-tree-actions">
-          <a href="{tree.url}" class="lt-tree-action">Open</a>
+          <a href="{=tree.url}" class="lt-tree-action">Open</a>
           <button onclick="downloadQR(this)" class="lt-tree-action-btn">Download QR</button>
         </div>
       </div>

--- a/blog/templates/partials/llms-skills.html
+++ b/blog/templates/partials/llms-skills.html
@@ -52,7 +52,7 @@ my-site/
 ├── templates/
 │   ├── layouts/       # Page layouts (page.html, post.html)
 │   └── partials/      # Reusable template fragments
-├── data/              # Structured data files (YAML/JSON), accessible via {cdi:filename.property}
+├── data/              # Structured data files (YAML/JSON), accessible via \{=cdi:filename.property}
 ├── public/            # Static assets served as-is (images, PDFs)
 ├── web/               # JS/CSS sources (bundled by Quarkus Web Bundler)
 └── config/

--- a/docs/modules/ROOT/pages/quarkus-roq-data.adoc
+++ b/docs/modules/ROOT/pages/quarkus-roq-data.adoc
@@ -173,13 +173,13 @@ Data beans are named and can be accessed from any Qute template using the `cdi` 
 
 [source,html]
 ----
-{cdi:mountain.name}: {cdi:mountain.elevation}
+{=cdi:mountain.name}: {=cdi:mountain.elevation}
 
 {#for mountain in cdi:mountains.list}
-  <li>{mountain.name}: {mountain.elevation}</li>
+  <li>{=mountain.name}: {=mountain.elevation}</li>
 {/for}
 
-{cdi:heroes.batman.name}
+{=cdi:heroes.batman.name}
 ----
 
 NOTE: For type-safety, use a `@DataMapping` bean and access it using the `cdi` namespace.

--- a/roq-data/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/roq-data/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -8,6 +8,8 @@ guide: https://docs.quarkiverse.io/quarkus-roq/dev/quarkus-roq-data.html
 
 Roq Data processes JSON and YAML data files into CDI beans, making them accessible in Qute templates and injectable in Java code with type safety.
 
+> **Note:** Template examples use the alternative expression syntax (`{=expr}`), enabled by default in new Roq projects. Standard syntax uses `{expr}` instead. See the [quarkus-roq-frontmatter skill](https://raw.githubusercontent.com/quarkiverse/quarkus-roq/main/roq-frontmatter/deployment/src/main/resources/META-INF/quarkus-skill.md) for details.
+
 ### Data Files
 
 Place JSON (`.json`) or YAML (`.yml`, `.yaml`) files in the `data/` directory. Each file becomes a CDI bean named after the file (without extension).
@@ -24,7 +26,7 @@ john:
 
 **Template access**:
 ```html
-{cdi:authors.ia3andy.name}
+{=cdi:authors.ia3andy.name}
 ```
 
 ### Data Directories
@@ -44,8 +46,8 @@ This produces:
 
 **Template access**:
 ```html
-{cdi:heroes.batman.name}
-{cdi:heroes.superman.city}
+{=cdi:heroes.batman.name}
+{=cdi:heroes.superman.city}
 ```
 
 ### Type-Safe Mapping
@@ -151,16 +153,16 @@ JsonArray contributors;
 
 ```html
 {! Direct property access !}
-{cdi:authors.ia3andy.name}
+{=cdi:authors.ia3andy.name}
 
 {! Iteration !}
 {#for contributor in cdi:contributors.contributors}
-  <span>{contributor.name} ({contributor.role})</span>
+  <span>{=contributor.name} ({=contributor.role})</span>
 {/for}
 
 {! Let bindings for convenience !}
 {#let author=cdi:authors.get(page.data.author)}
-  <a href="{author.url}">{author.name}</a>
+  <a href="{=author.url}">{=author.name}</a>
 {/let}
 ```
 

--- a/roq-frontmatter/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/roq-frontmatter/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -83,7 +83,7 @@ layout: default
 {@io.quarkiverse.roq.frontmatter.runtime.model.Page page}
 {@io.quarkiverse.roq.frontmatter.runtime.model.Site site}
 <main>
-  <h1>{page.title}</h1>
+  <h1>{=page.title}</h1>
   {#insert /}
 </main>
 ```
@@ -95,7 +95,7 @@ layout: default
 <!DOCTYPE html>
 <html>
 <head>
-  <title>{page.title}</title>
+  <title>{=page.title}</title>
   {#seo page site /}
   {#rss site /}{! adds the RSS <link> tag !}
   {#insert head /}
@@ -108,7 +108,7 @@ layout: default
 
 **Layout chain**: A page with `layout: post` → post layout has `layout: main` → main has `layout: default` → default is the root (no layout field). Each level uses `{#insert /}` where child content goes.
 
-**IMPORTANT**: Use `{#insert /}` in layouts to render child content. NEVER use `{page.content}` in layouts — that causes recursive rendering issues.
+**IMPORTANT**: Use `{#insert /}` in layouts to render child content. NEVER use `{=page.content}` in layouts — that causes recursive rendering issues.
 
 ### Collections
 
@@ -162,9 +162,9 @@ This lets multiple collections share the same data source with different layouts
 
 The layout template accesses data fields via `page.data`:
 ```html
-<h1>{page.data.id}</h1>
-<h2>{page.data.name}</h2>
-<p>{page.data.description}</p>
+<h1>{=page.data.id}</h1>
+<h2>{=page.data.name}</h2>
+<p>{=page.data.description}</p>
 ```
 
 **File naming**: Documents in collection directories use date-based names: `YYYY-MM-DD-slug.md` (e.g. `2024-08-29-welcome-to-roq.md`). The date is extracted from the filename.
@@ -174,17 +174,17 @@ The layout template accesses data fields via `page.data`:
 **Iterating**:
 ```html
 {#for post in site.collections.posts}
-  <a href="{post.url}">{post.title}</a>
+  <a href="{=post.url}">{=post.title}</a>
 {/for}
 ```
 
 **Document navigation**:
 ```html
 {#if page.previous}
-  <a href="{page.previous.url}">Previous: {page.previous.title}</a>
+  <a href="{=page.previous.url}">Previous: {=page.previous.title}</a>
 {/if}
 {#if page.next}
-  <a href="{page.next.url}">Next: {page.next.title}</a>
+  <a href="{=page.next.url}">Next: {=page.next.title}</a>
 {/if}
 ```
 
@@ -218,8 +218,8 @@ paginate:
 ```html
 {#for post in site.collections.posts.paginated(page.paginator)}
   <article>
-    <h2><a href="{post.url}">{post.title}</a></h2>
-    <p>{post.description}</p>
+    <h2><a href="{=post.url}">{=post.title}</a></h2>
+    <p>{=post.description}</p>
   </article>
 {/for}
 ```
@@ -251,7 +251,7 @@ paginate:
 - `site.url(path)` — resolve path relative to root. Also `site.url(path, path1)`, `site.url(path, path1, path2)`
 - `site.title` — from index page frontmatter `title`
 - `site.description` — from index page frontmatter `description`
-- `site.image` — default site image from frontmatter `image`/`img`/`picture`. Already resolves from `public/images/`. Use directly: `{site.image}`, never `{site.image('/images/...')}` or `{site.image('images/...')}`
+- `site.image` — default site image from frontmatter `image`/`img`/`picture`. Already resolves from `public/images/`. Use directly: `{=site.image}`, never `{=site.image('/images/...')}` or `{=site.image('images/...')}`
 - `site.image(name)` — resolve image by filename only (e.g. `site.image('logo.png')`, not `site.image('/images/logo.png')`)
 - `site.imageExists(name)` — check if image exists
 - `site.data` — site-level frontmatter data (`JsonObject`)
@@ -271,7 +271,7 @@ paginate:
 - `page.url` — page URL (`RoqUrl`)
 - `page.title` — from frontmatter `title`
 - `page.description` — from frontmatter `description`
-- `page.image` — page image (`RoqUrl`). Already resolves from `public/images/` or attached files. Use directly: `{page.image}`, never `{page.image('/images/...')}` or `{page.image('images/...')}`
+- `page.image` — page image (`RoqUrl`). Already resolves from `public/images/` or attached files. Use directly: `{=page.image}`, never `{=page.image('/images/...')}` or `{=page.image('images/...')}`
 - `page.image(name)` — resolve specific image by filename only (e.g. `page.image('photo.jpg')`, not `page.image('/images/photo.jpg')`)
 - `page.imageExists(name)` — check if image exists
 - `page.date` — page date (`ZonedDateTime`, null for normal pages without a date; always set for collection documents)
@@ -300,22 +300,24 @@ paginate:
 - `page.hidden` — whether document is hidden
 
 **`RoqUrl`** (URL object):
-- `{url}` or `{url.path}` — relative path (e.g. `/posts/my-post/`), encoded
-- `{url.absolute}` — full URL (e.g. `https://example.com/posts/my-post/`)
-- `{url.relative}` — same as `path`
-- `{url.encoded}` — URL-encoded absolute URL
-- `{url.resolve(path)}` or `{url.join(path)}` — join with another path
-- `{url.append(str)}` — concatenate without `/`
-- `{url.isExternal}` — boolean
-- `{url.fromRoot(path)}` — resolve from app root
+- `{=url}` or `{=url.path}` — relative path (e.g. `/posts/my-post/`), encoded
+- `{=url.absolute}` — full URL (e.g. `https://example.com/posts/my-post/`)
+- `{=url.relative}` — same as `path`
+- `{=url.encoded}` — URL-encoded absolute URL
+- `{=url.resolve(path)}` or `{=url.join(path)}` — join with another path
+- `{=url.append(str)}` — concatenate without `/`
+- `{=url.isExternal}` — boolean
+- `{=url.fromRoot(path)}` — resolve from app root
 
 ### Qute Syntax Essentials
 
+> **Note:** Examples in this guide use the alternative expression syntax (`{=expr}`), which is enabled by default in new Roq projects. See [Alternative Expression Syntax](#alternative-expression-syntax) for details.
+
 ```html
 {! Expressions !}
-{page.title}
-{page.data.customField}
-{page.date.format('yyyy, MMM dd')}
+{=page.title}
+{=page.data.customField}
+{=page.date.format('yyyy, MMM dd')}
 
 {! Conditionals !}
 {#if page.image}...{/if}
@@ -334,21 +336,21 @@ paginate:
 {#insert menu}{#include partials/sidebar-menu /}{/}
 
 {! URL resolution !}
-<a href="{site.url('posts/my-post')}">Link</a>
-<a href="{site.url('docs', 'getting-started')}">Docs</a>
+<a href="{=site.url('posts/my-post')}">Link</a>
+<a href="{=site.url('docs', 'getting-started')}">Docs</a>
 
 {! CDI beans (data files) !}
-{cdi:authors.ia3andy.name}
-{#for item in cdi:contributors.contributors}{item.name}{/for}
+{=cdi:authors.ia3andy.name}
+{#for item in cdi:contributors.contributors}{=item.name}{/for}
 
 {! Let bindings !}
 {#let author=cdi:authors.get(page.data.author)}
-  {author.name}
+  {=author.name}
 {/let}
 
 {! Slugify !}
 {#let tagSlug=tag.slugify}
-  <a href="{site.url('/posts/tag', tagSlug)}">{tagSlug}</a>
+  <a href="{=site.url('/posts/tag', tagSlug)}">{=tagSlug}</a>
 {/let}
 
 {! Type declarations (in layouts) !}
@@ -356,8 +358,9 @@ paginate:
 {@io.quarkiverse.roq.frontmatter.runtime.model.Site site}
 {@io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage page}
 
-{! Escaping Qute in content (standard syntax only) !}
-\{not-a-qute-expression}
+{! With alt syntax, curly braces are plain text !}
+{not-evaluated} is just plain text
+{=page.title} is evaluated
 ```
 
 ### Alternative Expression Syntax
@@ -374,7 +377,7 @@ With alt syntax enabled:
 - Sections (unchanged): `{#for ...}`, `{#if ...}`, `{#include ...}`, `{@type ...}`
 - Plain text: `{anything}` is NOT interpreted (no escaping needed)
 
-This will become the default syntax for Roq in a future version.
+Standard Qute syntax is still the default, but this will change in a future version. New projects already have alt syntax enabled via the generated config. We recommend setting the config explicitly so your project is ready.
 
 ### Data Files
 
@@ -389,10 +392,10 @@ ia3andy:
 
 **Template access**:
 ```html
-{cdi:authors.ia3andy.name}
+{=cdi:authors.ia3andy.name}
 
 {#let author=cdi:authors.get(page.data.author)}
-  <span>{author.name}</span>
+  <span>{=author.name}</span>
 {/let}
 ```
 
@@ -422,22 +425,22 @@ Add to root layout `<head>`:
 ### Template Extensions
 
 Date formatting (on `ZonedDateTime`):
-- `{page.date.iso}` — ISO 8601 (`2024-08-29T13:32:20+02:00`)
-- `{page.date.isoDate}` — date only (`2024-08-29`)
-- `{page.date.shortDate}` / `{page.date.longDate}` — locale-aware date
-- `{page.date.shortDateTime}` / `{page.date.longDateTime}` — locale-aware date-time
-- `{page.date.rfc822}` — RFC 822 (for RSS)
-- `{page.date.format('yyyy, MMM dd')}` — custom pattern
+- `{=page.date.iso}` — ISO 8601 (`2024-08-29T13:32:20+02:00`)
+- `{=page.date.isoDate}` — date only (`2024-08-29`)
+- `{=page.date.shortDate}` / `{=page.date.longDate}` — locale-aware date
+- `{=page.date.shortDateTime}` / `{=page.date.longDateTime}` — locale-aware date-time
+- `{=page.date.rfc822}` — RFC 822 (for RSS)
+- `{=page.date.format('yyyy, MMM dd')}` — custom pattern
 
 Content helpers:
-- `{text.slugify}` — URL-friendly slug
-- `{htmlContent.stripHtml}` — remove HTML tags
-- `{text.numberOfWords}` — word count
-- `{text.wordLimit(n)}` — truncate to N words
-- `{page.readTime}` — estimated reading time in minutes
-- `{page.contentAbstract}` / `{page.contentAbstract(n)}` — first N words (default 75)
-- `{list.randomise}` — shuffle a list
-- `{fileName.mimeType}` — MIME type from extension
+- `{=text.slugify}` — URL-friendly slug
+- `{=htmlContent.stripHtml}` — remove HTML tags
+- `{=text.numberOfWords}` — word count
+- `{=text.wordLimit(n)}` — truncate to N words
+- `{=page.readTime}` — estimated reading time in minutes
+- `{=page.contentAbstract}` / `{=page.contentAbstract(n)}` — first N words (default 75)
+- `{=list.randomise}` — shuffle a list
+- `{=fileName.mimeType}` — MIME type from extension
 
 ### Configuration
 
@@ -463,9 +466,9 @@ For advanced Qute template needs (e.g. `@TemplateExtension` to add custom method
 ### Common Pitfalls
 
 - **Layout inheritance** — ALWAYS use the frontmatter `layout:` field for layout inheritance (e.g. `layout: main`). NEVER use Qute's `{#include}` or `{#layout}` directives for this purpose — they won't work with Roq's layout chain.
-- **`{page.content}` in layouts** — NEVER use `{page.content}` in layouts. Use `{#insert /}` to render child content. `{page.content}` causes recursive rendering.
+- **`{=page.content}` in layouts** — NEVER use `{=page.content}` in layouts. Use `{#insert /}` to render child content. `{=page.content}` causes recursive rendering.
 - **Wrong directory location** — Standalone Roq FrontMatter uses `src/main/resources/` for `content/`, `templates/`, `public/`, `data/`. The full `quarkus-roq` extension uses project root instead.
 - **Layout resolution** — `layout: page` resolves local first, then theme fallback (themes require full `quarkus-roq`). Use `theme-layout: page` to explicitly target the theme layout.
 - **Date format in filenames** — Collection documents must use `YYYY-MM-DD-slug.md` format for date extraction.
 - **Image resolution** — Images can be: a full URL (`https://...`), a filename resolved from `public/images/`, or an attached file name for directory-based pages. Do NOT use the `images/` prefix in frontmatter or template calls (e.g. `image: photo.jpg`, not `image: images/photo.jpg`).
-- **Escaping Qute** — Use `\{expression}` to escape Qute expressions in content that should be rendered literally. Add pages to `site.escaped-pages` config to skip Qute parsing entirely.
+- **Escaping Qute** — With alt syntax enabled, plain `{expression}` is not evaluated, so escaping is not needed. Without alt syntax, use `\{expression}` to escape Qute expressions that should be rendered literally. You can also add pages to `site.escaped-pages` config to skip Qute parsing entirely.

--- a/roq-frontmatter/runtime/src/main/codestarts/quarkus/roq-project-codestart/base/config/application.properties
+++ b/roq-frontmatter/runtime/src/main/codestarts/quarkus/roq-project-codestart/base/config/application.properties
@@ -1,0 +1,2 @@
+quarkus.qute.alt-expr-syntax=true
+quarkus.default-locale=en

--- a/roq-frontmatter/runtime/src/main/codestarts/quarkus/roq-project-codestart/base/config/application.properties
+++ b/roq-frontmatter/runtime/src/main/codestarts/quarkus/roq-project-codestart/base/config/application.properties
@@ -1,2 +1,1 @@
 quarkus.qute.alt-expr-syntax=true
-quarkus.default-locale=en

--- a/roq-theme/default/runtime/src/main/codestarts/quarkus/roq-default-theme-codestart/base/content/posts/2024-10-13-the-first-roq/index.md
+++ b/roq-theme/default/runtime/src/main/codestarts/quarkus/roq-default-theme-codestart/base/content/posts/2024-10-13-the-first-roq/index.md
@@ -10,23 +10,23 @@ fun: and fun!
 
 You can access page data like this:
 ```markdown
-* \{page.data.cool}
-* \{page.data.fun}
+* \{=page.data.cool}
+* \{=page.data.fun}
 ```
 **will render ⤵**
 
-* {page.data.cool}
-* {page.data.fun}
+* {=page.data.cool}
+* {=page.data.fun}
 
 
 There are a few helpers on the `page` variable ([more on variables](https://iamroq.dev/docs/basics/#_variables)):
 
 ```markdown
-> \{page.date.format('YYYY')}: \{page.description}
+> \{=page.date.format('YYYY')}: \{=page.description}
 ```
 **will render ⤵**
 
-> {page.date.format('YYYY')}: {page.description}
+> {=page.date.format('YYYY')}: {=page.description}
 
 ---
 
@@ -34,4 +34,4 @@ It's time to write awesome articles!
 
 __Thank you!__
 
-**PS:** To make the tag work ([#blogging]({site.url.resolve('posts/tag/blogging')})), you need to [enable tagging](https://iamroq.dev/plugin/tagging/).
+**PS:** To make the tag work ([#blogging]({=site.url.resolve('posts/tag/blogging')})), you need to [enable tagging](https://iamroq.dev/plugin/tagging/).


### PR DESCRIPTION
## Summary

- Add `quarkus.qute.alt-expr-syntax=true` to the roq-project-codestart config, so new projects use alt expression syntax by default
- Convert all documentation examples to use `{=expr}` syntax (docs, skills, blog posts, plugin pages, llms-skills)
- Update the "Alternative expression syntax" section: standard syntax is still the default but will change in a future version, new projects already have it enabled via the generated config