### PR TITLE
Drop not-entirely-spec-compliant single quotes on url

### DIFF
--- a/blog/src/test/java/io/quarkiverse/roq/it/RoqBlogSlugifiedFilesTest.java
+++ b/blog/src/test/java/io/quarkiverse/roq/it/RoqBlogSlugifiedFilesTest.java
@@ -1,9 +1,6 @@
 package io.quarkiverse.roq.it;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.startsWith;
+import java.util.Map;
 
 import io.quarkiverse.roq.testing.RoqAndRoll;
 import io.quarkus.test.junit.QuarkusTest;
@@ -11,8 +8,12 @@ import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 
 @QuarkusTest
 @RoqAndRoll
@@ -66,7 +67,7 @@ public class RoqBlogSlugifiedFilesTest {
     @Test
     public void testAlias() {
         RestAssured.when().get("/first-roq-article-ever/").then().statusCode(200)
-                .body(containsString("url='/posts/welcome-to-roq/'"));
+                .body(containsString("url=/posts/welcome-to-roq/"));
     }
 
     @Test

--- a/blog/src/test/java/io/quarkiverse/roq/it/RoqBlogTest.java
+++ b/blog/src/test/java/io/quarkiverse/roq/it/RoqBlogTest.java
@@ -1,19 +1,19 @@
 
 package io.quarkiverse.roq.it;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import io.quarkiverse.roq.testing.RoqAndRoll;
 import io.quarkiverse.roq.testing.RoqLinks;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 @RoqAndRoll
@@ -66,7 +66,7 @@ public class RoqBlogTest {
     @Test
     public void testAlias() {
         RestAssured.when().get("/first-roq-article-ever/").then().statusCode(200)
-                .body(containsString("url='/posts/welcome-to-roq/'"));
+                .body(containsString("url=/posts/welcome-to-roq/"));
     }
 
     @Test

--- a/roq-plugin/aliases/runtime/src/main/java/io/quarkiverse/roq/plugin/aliases/runtime/RoqFrontMatterAliasesRecorder.java
+++ b/roq-plugin/aliases/runtime/src/main/java/io/quarkiverse/roq/plugin/aliases/runtime/RoqFrontMatterAliasesRecorder.java
@@ -20,7 +20,7 @@ public class RoqFrontMatterAliasesRecorder {
                                   <meta charset="utf-8">
                                   <title>Redirecting&hellip;</title>
                                   <link rel="canonical" href="{url}">
-                                  <meta http-equiv="refresh" content="0; url='{url}'">
+                                  <meta http-equiv="refresh" content="0; url={url}">
                                   <meta name="robots" content="noindex">
                               </head>
                               <body>


### PR DESCRIPTION
#1078 used single-quotes to avoid putting double quotes inside double quotes, but it turns out the [spec](https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-refresh) prefers no quotes. This is the example they give:

```
<meta http-equiv="Refresh" content="20; URL=page4.html">
``` 

Most browsers will handle single quotes, and the spec kind of implies they should be handled, but I think no-quotes is safest. Which is funny, since I thought single quotes was safest,