### PR TITLE
Handle newUrl and excerpt frontmatter in Jekyll conversion

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterConverter.java
@@ -25,6 +25,10 @@ public class JekyllFrontMatterConverter {
 
     private static final Pattern PERMALINK_LINE = Pattern.compile("^permalink:[ \\t]*(.*)\\n", Pattern.MULTILINE);
 
+    private static final Pattern NEWURL_LINE = Pattern.compile("^newUrl:[ \\t]*(.*)\\n", Pattern.MULTILINE);
+
+    private static final Pattern EXCERPT_LINE = Pattern.compile("^excerpt:[ \\t]*(.*)\\n", Pattern.MULTILINE);
+
     private final YAMLMapper yamlMapper = new YAMLMapper();
 
     /**
@@ -73,6 +77,8 @@ public class JekyllFrontMatterConverter {
                         }
                     });
         }
+        convertNewUrlToAliases(contentDir);
+        convertExcerpts(contentDir);
         convertPagination(contentDir, config);
     }
 
@@ -116,6 +122,43 @@ public class JekyllFrontMatterConverter {
                         .replaceFirst("link: " + Matcher.quoteReplacement(matcher.group(1)) + "\n");
             }
 
+            Files.writeString(file, content);
+        }
+    }
+
+    /**
+     * Convert Jekyll redirect {@code newUrl} frontmatter to Roq {@code aliases}.
+     * Jekyll redirects use newUrl to specify the target; Roq uses aliases for redirects.
+     */
+    public void convertNewUrlToAliases(Path contentDir) throws IOException {
+        for (Path file : findContentFiles(contentDir)) {
+            String content = Files.readString(file);
+            Matcher matcher = NEWURL_LINE.matcher(content);
+            if (!matcher.find()) {
+                continue;
+            }
+
+            String newUrlValue = matcher.group(1).trim();
+            content = NEWURL_LINE.matcher(content)
+                    .replaceFirst("aliases:\n  - " + Matcher.quoteReplacement(newUrlValue) + "\n");
+            Files.writeString(file, content);
+        }
+    }
+
+    /**
+     * Rename Jekyll {@code excerpt} frontmatter to Roq {@code description}.
+     * Skips files that already have a {@code description} field.
+     */
+    public void convertExcerpts(Path contentDir) throws IOException {
+        for (Path file : findContentFiles(contentDir)) {
+            String content = Files.readString(file);
+            if (!EXCERPT_LINE.matcher(content).find()) {
+                continue;
+            }
+            if (Pattern.compile("^description:[ \\t]", Pattern.MULTILINE).matcher(content).find()) {
+                continue;
+            }
+            content = EXCERPT_LINE.matcher(content).replaceFirst("description: $1\n");
             Files.writeString(file, content);
         }
     }

--- a/migration/src/test/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterConverterTest.java
@@ -408,6 +408,85 @@ class JekyllFrontMatterConverterTest {
         assertFalse(result.contains("link:"), "redundant permalink should not become link");
     }
 
+    // --- Excerpt → description tests ---
+
+    @Test
+    void testExcerptRenamedToDescription(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        Files.writeString(contentDir.resolve("post.md"), """
+                ---
+                title: "My Post"
+                excerpt: "A short summary"
+                ---
+                Body text.
+                """);
+
+        converter.convertExcerpts(contentDir);
+
+        String result = Files.readString(contentDir.resolve("post.md"));
+        assertTrue(result.contains("description: \"A short summary\""),
+                "excerpt should be renamed to description");
+        assertFalse(result.contains("excerpt:"),
+                "excerpt key should be removed");
+    }
+
+    @Test
+    void testExcerptSkippedWhenDescriptionExists(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        Files.writeString(contentDir.resolve("post.md"), """
+                ---
+                title: "My Post"
+                description: "Existing description"
+                excerpt: "A short summary"
+                ---
+                """);
+
+        converter.convertExcerpts(contentDir);
+
+        String result = Files.readString(contentDir.resolve("post.md"));
+        assertTrue(result.contains("description: \"Existing description\""),
+                "existing description should be preserved");
+        assertTrue(result.contains("excerpt: \"A short summary\""),
+                "excerpt should remain when description already exists");
+    }
+
+    @Test
+    void testExcerptAbsent(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        String original = """
+                ---
+                title: "My Post"
+                ---
+                Body text.
+                """;
+        Files.writeString(contentDir.resolve("post.md"), original);
+
+        converter.convertExcerpts(contentDir);
+
+        assertEquals(original, Files.readString(contentDir.resolve("post.md")));
+    }
+
+    @Test
+    void testExcerptWithoutQuotes(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        Files.writeString(contentDir.resolve("post.md"), """
+                ---
+                title: My Post
+                excerpt: A short summary without quotes
+                ---
+                """);
+
+        converter.convertExcerpts(contentDir);
+
+        String result = Files.readString(contentDir.resolve("post.md"));
+        assertTrue(result.contains("description: A short summary without quotes"));
+        assertFalse(result.contains("excerpt:"));
+    }
+
     // --- Include target prefix tests ---
 
     @Test
@@ -501,7 +580,25 @@ class JekyllFrontMatterConverterTest {
                 "Already-prefixed file should stay as-is");
     }
 
-    // --- Integration test ---
+    // --- Integration tests ---
+
+    @Test
+    void testConvertProjectConvertsExcerpts(@TempDir Path tempDir) throws IOException {
+        Files.createDirectories(tempDir.resolve("content"));
+        Files.writeString(tempDir.resolve("_config.yml"), "title: Test\n");
+        Files.writeString(tempDir.resolve("content/post.md"), """
+                ---
+                title: "My Post"
+                excerpt: "A short summary"
+                ---
+                """);
+
+        converter.convertProject(tempDir);
+
+        String result = Files.readString(tempDir.resolve("content/post.md"));
+        assertTrue(result.contains("description: \"A short summary\""));
+        assertFalse(result.contains("excerpt:"));
+    }
 
     @Test
     void testConvertProjectRunsBothTransforms(@TempDir Path tempDir) throws IOException {

--- a/migration/src/test/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/migration/jekyll/JekyllFrontMatterConverterTest.java
@@ -278,6 +278,64 @@ class JekyllFrontMatterConverterTest {
         assertFalse(result.contains("link:"));
     }
 
+    // --- newUrl → aliases tests ---
+
+    @Test
+    void testNewUrlConvertedToAliases(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        Files.writeString(contentDir.resolve("old-page.md"), """
+                ---
+                newUrl: /new-page/
+                ---
+                """);
+
+        converter.convertNewUrlToAliases(contentDir);
+
+        String result = Files.readString(contentDir.resolve("old-page.md"));
+        assertTrue(result.contains("aliases:"), "newUrl should be converted to aliases");
+        assertTrue(result.contains("  - /new-page/"), "alias should contain the target URL");
+        assertFalse(result.contains("newUrl:"), "newUrl key should be removed");
+    }
+
+    @Test
+    void testNewUrlPreservesOtherFrontmatter(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        Files.writeString(contentDir.resolve("redirect.md"), """
+                ---
+                layout: redirect
+                newUrl: /guides/new-guide
+                title: Old Guide
+                ---
+                """);
+
+        converter.convertNewUrlToAliases(contentDir);
+
+        String result = Files.readString(contentDir.resolve("redirect.md"));
+        assertTrue(result.contains("aliases:\n  - /guides/new-guide"));
+        assertTrue(result.contains("layout: redirect"));
+        assertTrue(result.contains("title: Old Guide"));
+        assertFalse(result.contains("newUrl:"));
+    }
+
+    @Test
+    void testNewUrlAbsentLeavesFileUnchanged(@TempDir Path tempDir) throws IOException {
+        Path contentDir = tempDir.resolve("content");
+        Files.createDirectories(contentDir);
+        String original = """
+                ---
+                title: Normal Page
+                ---
+                Content.
+                """;
+        Files.writeString(contentDir.resolve("page.md"), original);
+
+        converter.convertNewUrlToAliases(contentDir);
+
+        assertEquals(original, Files.readString(contentDir.resolve("page.md")));
+    }
+
     // --- Redirect deduplication tests ---
 
     @Test
@@ -305,9 +363,11 @@ class JekyllFrontMatterConverterTest {
         assertFalse(Files.exists(redirectsDir.resolve("foo-guide.md")));
 
         String result = Files.readString(redirectsDir.resolve("foo-guide.html"));
-        assertTrue(result.contains("/guides/foo-guide.html"));
-        assertTrue(result.contains("/guides/foo-guide/index.html"));
-        assertTrue(result.contains("newUrl: /guides/foo"));
+        assertTrue(result.contains("aliases:"), "Merged file should have aliases block");
+        assertTrue(result.contains("  - /guides/foo-guide.html"), "aliases should contain HTML permalink");
+        assertTrue(result.contains("  - /guides/foo-guide/index.html"), "aliases should contain MD permalink");
+        assertFalse(result.contains("permalink:"), "permalink should be replaced by aliases");
+        assertTrue(result.contains("newUrl: /guides/foo"), "newUrl should be preserved");
     }
 
     @Test
@@ -361,8 +421,10 @@ class JekyllFrontMatterConverterTest {
         assertFalse(Files.exists(redirectsDir.resolve("bar-guide.md")));
 
         String result = Files.readString(redirectsDir.resolve("bar-guide.html"));
-        assertTrue(result.contains("/guides/bar-guide.html"));
-        assertTrue(result.contains("/guides/bar-guide/index.html"));
+        assertTrue(result.contains("aliases:"), "Merged file should have aliases block");
+        assertTrue(result.contains("  - /guides/bar-guide.html"), "aliases should contain HTML permalink");
+        assertTrue(result.contains("  - /guides/bar-guide/index.html"), "aliases should contain MD permalink");
+        assertFalse(result.contains("permalink:"), "permalink should be replaced by aliases");
     }
 
     @Test
@@ -598,6 +660,25 @@ class JekyllFrontMatterConverterTest {
         String result = Files.readString(tempDir.resolve("content/post.md"));
         assertTrue(result.contains("description: \"A short summary\""));
         assertFalse(result.contains("excerpt:"));
+    }
+
+    @Test
+    void testConvertProjectConvertsNewUrlToAliases(@TempDir Path tempDir) throws IOException {
+        Files.createDirectories(tempDir.resolve("content"));
+        Files.writeString(tempDir.resolve("_config.yml"), "title: Test\n");
+        Files.writeString(tempDir.resolve("content/old-guide.md"), """
+                ---
+                layout: redirect
+                newUrl: /guides/new-guide
+                ---
+                """);
+
+        converter.convertProject(tempDir);
+
+        String result = Files.readString(tempDir.resolve("content/old-guide.md"));
+        assertTrue(result.contains("aliases:\n  - /guides/new-guide"),
+                "convertProject should convert newUrl to aliases");
+        assertFalse(result.contains("newUrl:"));
     }
 
     @Test


### PR DESCRIPTION
I believe Jekyll to Roq conversion is now working well, so I'm trying to get code off my laptop into the repo. There's a lot of it, sorry! 

I'm trying to break it up into digestible chunks. 

This one is fairly painless – it just adds support for `newUrl` and `excerpt` properties in front matter, and maps them to `aliases:` and `description` properties.