### PR TITLE
More support for Jekyll macros and also enable broader-scoped variables by mutation

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
+++ b/migration/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
@@ -1,9 +1,19 @@
 package io.quarkus.tools.migration;
 
 import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 import io.quarkus.qute.RawString;
 import io.quarkus.qute.TemplateExtension;
@@ -13,68 +23,87 @@ import io.vertx.core.json.JsonObject;
 @TemplateExtension
 public class JekyllFiltersExtension {
 
-    /**
-     * Null-safe get for JsonObject. Prevents NPE when key is null (e.g. from ?? operator).
-     */
+    // Null-safe get — prevents NPE when key is null (e.g. from ?? operator)
     static Object get(JsonObject obj, String key) {
-        if (obj == null || key == null || key.isEmpty()) {
+        if (obj == null || key == null || key.isEmpty())
             return null;
-        }
         return obj.getValue(key);
     }
 
-    /**
-     * Jekyll's "where" filter: select items from an array where a property matches a value.
-     * Usage in Qute: {myArray.where("key", "value")}
-     */
     static JsonArray where(JsonArray array, String property, String value) {
         JsonArray result = new JsonArray();
         for (int i = 0; i < array.size(); i++) {
             Object item = array.getValue(i);
             if (item instanceof JsonObject obj) {
                 Object propValue = obj.getValue(property);
-                if (propValue != null && propValue.toString().equals(value)) {
+                if (propValue != null && propValue.toString().equals(value))
                     result.add(obj);
-                }
             }
         }
         return result;
     }
 
-    /**
-     * Get the first element of a JsonArray.
-     * Usage in Qute: {myArray.first}
-     */
     static Object first(JsonArray array) {
-        if (array == null || array.isEmpty()) {
-            return null;
-        }
-        return array.getValue(0);
+        return array == null || array.isEmpty() ? null : array.getValue(0);
     }
 
-    /**
-     * Get the last element of a JsonArray.
-     * Usage in Qute: {myArray.last}
-     */
     static Object last(JsonArray array) {
-        if (array == null || array.isEmpty()) {
-            return null;
-        }
-        return array.getValue(array.size() - 1);
+        return array == null || array.isEmpty() ? null : array.getValue(array.size() - 1);
     }
 
-    /**
-     * Get the size of a JsonArray.
-     * Usage in Qute: {myArray.size}
-     */
     static int size(JsonArray array) {
         return array == null ? 0 : array.size();
     }
 
-    /**
-     * Jekyll's "truncate" filter: truncate a string to a given number of characters.
-     * Usage in Qute: {myString.truncate(280)}
-     */
+    static JsonArray groupBy(JsonArray items, String property) {
+        if (items == null)
+            return new JsonArray();
+        Map<String, JsonArray> groups = new LinkedHashMap<>();
+        for (int i = 0; i < items.size(); i++) {
+            Object item = items.getValue(i);
+            String key = "";
+            if (item instanceof JsonObject obj) {
+                Object val = obj.getValue(property);
+                if (val != null)
+                    key = val.toString();
+            }
+            groups.computeIfAbsent(key, k -> new JsonArray()).add(item);
+        }
+        JsonArray result = new JsonArray();
+        for (var entry : groups.entrySet()) {
+            result.add(new JsonObject()
+                    .put("name", entry.getKey())
+                    .put("items", entry.getValue())
+                    .put("size", entry.getValue().size()));
+        }
+        return result;
+    }
+
+    private static final DateTimeFormatter RFC_822 = DateTimeFormatter
+            .ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
+
+    // Bridges LocalDateTime → RFC 822; Roq's built-in rfc822 only handles ZonedDateTime
+    static String rfc822(LocalDateTime dateTime) {
+        return dateTime.atZone(ZoneOffset.UTC).format(RFC_822);
+    }
+
+    // Qute auto-escapes in .html but not in .xml/.txt
+    static String escapeHtml(String str) {
+        if (str == null)
+            return "";
+        return str.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    static String capitalize(String str) {
+        if (str == null || str.isEmpty())
+            return str;
+        return Character.toUpperCase(str.charAt(0)) + str.substring(1);
+    }
+
     static String truncate(String str, int length) {
         if (str == null)
             return "";
@@ -83,41 +112,60 @@ public class JekyllFiltersExtension {
         return str.substring(0, length) + "...";
     }
 
-    /**
-     * Jekyll's "sort" filter: sort a list by a named property.
-     * Usage in Qute: {myList.sort('title')}
-     */
     static List<?> sort(List<?> list, String property) {
-        if (list == null || list.isEmpty()) {
+        if (list == null || list.isEmpty())
             return List.of();
-        }
         List<Object> sorted = new ArrayList<>(list);
-        sorted.sort((a, b) -> {
-            String va = extractProperty(a, property);
-            String vb = extractProperty(b, property);
-            if (va == null)
-                return vb == null ? 0 : 1;
-            if (vb == null)
-                return -1;
-            return va.compareToIgnoreCase(vb);
-        });
+        sorted.sort(propertyComparator(property));
         return sorted;
+    }
+
+    static JsonArray sort(JsonArray array, String property) {
+        if (array == null || array.isEmpty())
+            return new JsonArray();
+        List<Object> sorted = new ArrayList<>(array.getList());
+        sorted.sort(propertyComparator(property));
+        return new JsonArray(sorted);
+    }
+
+    static JsonArray reverse(JsonArray array) {
+        if (array == null || array.isEmpty())
+            return new JsonArray();
+        List<Object> reversed = new ArrayList<>(array.getList());
+        Collections.reverse(reversed);
+        return new JsonArray(reversed);
+    }
+
+    // Selects items where a boolean property is falsy (bridges Liquid's unless pattern)
+    @TemplateExtension(namespace = "list")
+    static List<Object> whereNot(Iterable<?> items, String property) {
+        List<Object> result = new ArrayList<>();
+        if (items == null)
+            return result;
+        for (Object item : items) {
+            try {
+                Object value = getProperty(item, property);
+                if (value == null || Boolean.FALSE.equals(value) || "false".equals(value.toString()))
+                    result.add(item);
+            } catch (Exception e) {
+                result.add(item);
+            }
+        }
+        return result;
     }
 
     @TemplateExtension(namespace = "list")
     static Object whereExp(Iterable<?> items, String loopVar, Object conditionsObj) {
-        if (items == null) {
+        if (items == null)
             return new ArrayList<>();
-        }
 
         List<String> conditions;
         if (conditionsObj instanceof String s) {
             conditions = List.of(s);
         } else if (conditionsObj instanceof Iterable<?> iter) {
             conditions = new ArrayList<>();
-            for (Object o : iter) {
+            for (Object o : iter)
                 conditions.add(o.toString());
-            }
         } else {
             conditions = List.of(conditionsObj.toString());
         }
@@ -134,32 +182,25 @@ public class JekyllFiltersExtension {
                     break;
                 }
             }
-            if (matches) {
+            if (matches)
                 result.add(item);
-            }
         }
         return isJsonArray ? new JsonArray(result) : result;
     }
 
     private static boolean evaluateCondition(Object item, String prefix, String condition) {
         String[] operators = { ">=", "<=", "!=", "==", ">", "<", "contains" };
-
         for (String op : operators) {
             int idx = condition.indexOf(" " + op + " ");
             if (idx >= 0) {
                 String left = condition.substring(0, idx).trim();
                 String right = condition.substring(idx + op.length() + 2).trim();
-
                 String property = left.startsWith(prefix) ? left.substring(prefix.length()) : left;
-
                 if ((right.startsWith("'") && right.endsWith("'"))
-                        || (right.startsWith("\"") && right.endsWith("\""))) {
+                        || (right.startsWith("\"") && right.endsWith("\"")))
                     right = right.substring(1, right.length() - 1);
-                }
-
                 Object propValue = getProperty(item, property);
                 String propStr = propValue != null ? propValue.toString() : null;
-
                 return compareValues(propStr, op, right);
             }
         }
@@ -183,16 +224,15 @@ public class JekyllFiltersExtension {
     }
 
     private static Object getProperty(Object obj, String property) {
-        if (obj instanceof JsonObject json) {
+        if (obj instanceof JsonObject json)
             return json.getValue(property);
-        }
-        if (obj instanceof java.util.Map<?, ?> map) {
+        if (obj instanceof Map<?, ?> map)
             return map.get(property);
-        }
+        // Try getter method (getX, isX, or plain x)
         Class<?> clazz = obj.getClass();
-        for (String p : new String[] { "get", "is", "" }) {
-            String methodName = p.isEmpty() ? property
-                    : p + Character.toUpperCase(property.charAt(0)) + property.substring(1);
+        for (String prefix : new String[] { "get", "is", "" }) {
+            String methodName = prefix.isEmpty() ? property
+                    : prefix + Character.toUpperCase(property.charAt(0)) + property.substring(1);
             try {
                 Method m = clazz.getMethod(methodName);
                 return m.invoke(obj);
@@ -203,69 +243,142 @@ public class JekyllFiltersExtension {
     }
 
     private static String extractProperty(Object obj, String property) {
-        if (obj instanceof JsonObject json) {
-            Object val = json.getValue(property);
-            return val != null ? val.toString() : null;
-        }
-        if (obj instanceof java.util.Map<?, ?> map) {
-            Object val = map.get(property);
-            return val != null ? val.toString() : null;
-        }
-        return obj != null ? obj.toString() : null;
+        Object val = getProperty(obj, property);
+        if (val != null)
+            return val.toString();
+        if (obj != null && !(obj instanceof JsonObject) && !(obj instanceof Map))
+            return obj.toString();
+        return null;
     }
 
-    /**
-     * Jekyll's "push" filter: append an element to a list and return the new list.
-     * Usage in Qute: {myList.push(item)}
-     */
+    private static Comparator<Object> propertyComparator(String property) {
+        return (a, b) -> {
+            String va = extractProperty(a, property);
+            String vb = extractProperty(b, property);
+            if (va == null)
+                return vb == null ? 0 : 1;
+            if (vb == null)
+                return -1;
+            return va.compareToIgnoreCase(vb);
+        };
+    }
+
     static List<Object> push(List<?> list, Object item) {
         List<Object> result = new ArrayList<>(list);
         result.add(item);
         return result;
     }
 
-    /**
-     * Output a string without HTML escaping.
-     * Qute auto-escapes HTML in .html templates; this bypasses that for trusted content.
-     * Usage in Qute: {=myString.raw}
-     */
+    // Replaces Liquid's push-accumulation pattern (broken in Qute because {#let} is block-scoped)
+    @SuppressWarnings("unchecked")
+    static JsonArray mergeTypes(JsonObject index, String type) {
+        if (index == null || type == null || type.isEmpty())
+            return null;
+        JsonArray result = new JsonArray();
+        for (String key : index.fieldNames()) {
+            Map<String, Object> sourceMap = toMap(index.getValue(key));
+            if (sourceMap == null)
+                continue;
+            Map<String, Object> typesMap = toMap(sourceMap.get("types"));
+            if (typesMap == null)
+                continue;
+            Object items = typesMap.get(type);
+            if (items instanceof JsonArray arr) {
+                for (Object item : arr)
+                    result.add(toJsonObject(item));
+            } else if (items instanceof List<?> list) {
+                for (Object item : list)
+                    result.add(toJsonObject(item));
+            }
+        }
+        if (result.isEmpty())
+            return null;
+        List<Object> sorted = new ArrayList<>(result.getList());
+        sorted.sort(Comparator.comparing(
+                o -> o instanceof JsonObject jo ? jo.getString("title", "") : "",
+                String.CASE_INSENSITIVE_ORDER));
+        return new JsonArray(sorted);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> toMap(Object obj) {
+        if (obj instanceof JsonObject jo)
+            return jo.getMap();
+        if (obj instanceof Map)
+            return (Map<String, Object>) obj;
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static JsonObject toJsonObject(Object obj) {
+        if (obj instanceof JsonObject jo)
+            return jo;
+        if (obj instanceof Map)
+            return new JsonObject((Map<String, Object>) obj);
+        return new JsonObject().put("value", obj);
+    }
+
+    static RawString markdownify(String str) {
+        if (str == null || str.isEmpty())
+            return new RawString("");
+        return new RawString(str);
+    }
+
     static RawString raw(String str) {
         if (str == null)
             return new RawString("");
         return new RawString(str);
     }
 
-    /**
-     * Split a string by delimiter, returning an iterable list.
-     * Uses namespace form so it can handle null base objects (instance extensions can't
-     * dispatch on null). Also returns List instead of String[] for Qute iteration.
-     * Usage in Qute: {str:split(myString, ",")}
-     */
-    @TemplateExtension(namespace = "str")
-    static List<String> split(String str, String delimiter) {
-        if (str == null || str.isEmpty()) {
-            return List.of();
-        }
-        return Arrays.asList(str.split(delimiter));
+    // Liquid's {% assign %} is template-scoped; Qute's {#let} is block-scoped.
+    // MutableMap bridges this: the converter emits mut:map() calls for variables
+    // that would escape their {#let} scope.
+    @TemplateExtension(namespace = "mut")
+    static MutableMap map() {
+        return new MutableMap();
     }
 
-    /**
-     * Split, trim each element, and filter out empty strings.
-     * Replaces the Liquid pattern: assign clean = "" | split: "" / for x in raw / push trimmed / endfor
-     * That pattern doesn't work in Qute because {#let} is block-scoped (push results are discarded).
-     * Usage in Qute: {str:splitTrimmed(myString, ",")}
-     */
+    public static class MutableMap {
+        private final Map<String, Object> data = new HashMap<>();
+
+        // Returns empty RawString so {=_m.assign(...)} produces no visible output
+        public RawString assign(String key, Object value) {
+            data.put(key, value);
+            return new RawString("");
+        }
+
+        public Object read(String key) {
+            return data.get(key);
+        }
+    }
+
+    // Namespace form handles null base objects (instance extensions can't dispatch on null)
+    @TemplateExtension(namespace = "str")
+    static List<String> split(String str, String delimiter) {
+        if (str == null || str.isEmpty())
+            return List.of();
+        return Arrays.asList(str.split(Pattern.quote(delimiter)));
+    }
+
+    @TemplateExtension(namespace = "str")
+    static List<RawString> splitRaw(String str, String delimiter) {
+        if (str == null || str.isEmpty())
+            return List.of();
+        return Arrays.stream(str.split(Pattern.quote(delimiter)))
+                .map(RawString::new)
+                .toList();
+    }
+
+    // Replaces Liquid split+trim+push loop (broken in Qute due to block-scoped {#let})
     @TemplateExtension(namespace = "str")
     static List<String> splitTrimmed(String str, String delimiter) {
-        if (str == null || str.isEmpty()) {
+        if (str == null || str.isEmpty())
             return List.of();
-        }
         List<String> result = new ArrayList<>();
-        for (String s : str.split(delimiter)) {
+        for (String s : str.split(Pattern.quote(delimiter))) {
             String trimmed = s.trim();
-            if (!trimmed.isEmpty()) {
+            if (!trimmed.isEmpty())
                 result.add(trimmed);
-            }
         }
         return result;
     }

--- a/migration/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
+++ b/migration/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
@@ -263,6 +263,29 @@ public class JekyllFiltersExtension {
         };
     }
 
+    static <T> List<T> distinct(List<T> list) {
+        if (list == null || list.isEmpty())
+            return List.of();
+        return list.stream().distinct().toList();
+    }
+
+    static JsonArray distinct(JsonArray array) {
+        if (array == null || array.isEmpty())
+            return new JsonArray();
+        List<Object> seen = new ArrayList<>();
+        for (int i = 0; i < array.size(); i++) {
+            Object val = array.getValue(i);
+            if (!seen.contains(val)) {
+                seen.add(val);
+            }
+        }
+        return new JsonArray(seen);
+    }
+
+    /**
+     * Jekyll's "push" filter: append an element to a list and return the new list.
+     * Usage in Qute: {myList.push(item)}
+     */
     static List<Object> push(List<?> list, Object item) {
         List<Object> result = new ArrayList<>(list);
         result.add(item);

--- a/migration/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
+++ b/migration/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
@@ -25,8 +25,9 @@ public class JekyllFiltersExtension {
 
     // Null-safe get — prevents NPE when key is null (e.g. from ?? operator)
     static Object get(JsonObject obj, String key) {
-        if (obj == null || key == null || key.isEmpty())
+        if (obj == null || key == null || key.isEmpty()) {
             return null;
+        }
         return obj.getValue(key);
     }
 
@@ -36,8 +37,9 @@ public class JekyllFiltersExtension {
             Object item = array.getValue(i);
             if (item instanceof JsonObject obj) {
                 Object propValue = obj.getValue(property);
-                if (propValue != null && propValue.toString().equals(value))
+                if (propValue != null && propValue.toString().equals(value)) {
                     result.add(obj);
+                }
             }
         }
         return result;
@@ -56,16 +58,18 @@ public class JekyllFiltersExtension {
     }
 
     static JsonArray groupBy(JsonArray items, String property) {
-        if (items == null)
+        if (items == null) {
             return new JsonArray();
+        }
         Map<String, JsonArray> groups = new LinkedHashMap<>();
         for (int i = 0; i < items.size(); i++) {
             Object item = items.getValue(i);
             String key = "";
             if (item instanceof JsonObject obj) {
                 Object val = obj.getValue(property);
-                if (val != null)
+                if (val != null) {
                     key = val.toString();
+                }
             }
             groups.computeIfAbsent(key, k -> new JsonArray()).add(item);
         }
@@ -89,8 +93,9 @@ public class JekyllFiltersExtension {
 
     // Qute auto-escapes in .html but not in .xml/.txt
     static String escapeHtml(String str) {
-        if (str == null)
+        if (str == null) {
             return "";
+        }
         return str.replace("&", "&amp;")
                 .replace("<", "&lt;")
                 .replace(">", "&gt;")
@@ -99,38 +104,44 @@ public class JekyllFiltersExtension {
     }
 
     static String capitalize(String str) {
-        if (str == null || str.isEmpty())
+        if (str == null || str.isEmpty()) {
             return str;
+        }
         return Character.toUpperCase(str.charAt(0)) + str.substring(1);
     }
 
     static String truncate(String str, int length) {
-        if (str == null)
+        if (str == null) {
             return "";
-        if (str.length() <= length)
+        }
+        if (str.length() <= length) {
             return str;
+        }
         return str.substring(0, length) + "...";
     }
 
     static List<?> sort(List<?> list, String property) {
-        if (list == null || list.isEmpty())
+        if (list == null || list.isEmpty()) {
             return List.of();
+        }
         List<Object> sorted = new ArrayList<>(list);
         sorted.sort(propertyComparator(property));
         return sorted;
     }
 
     static JsonArray sort(JsonArray array, String property) {
-        if (array == null || array.isEmpty())
+        if (array == null || array.isEmpty()) {
             return new JsonArray();
+        }
         List<Object> sorted = new ArrayList<>(array.getList());
         sorted.sort(propertyComparator(property));
         return new JsonArray(sorted);
     }
 
     static JsonArray reverse(JsonArray array) {
-        if (array == null || array.isEmpty())
+        if (array == null || array.isEmpty()) {
             return new JsonArray();
+        }
         List<Object> reversed = new ArrayList<>(array.getList());
         Collections.reverse(reversed);
         return new JsonArray(reversed);
@@ -140,13 +151,15 @@ public class JekyllFiltersExtension {
     @TemplateExtension(namespace = "list")
     static List<Object> whereNot(Iterable<?> items, String property) {
         List<Object> result = new ArrayList<>();
-        if (items == null)
+        if (items == null) {
             return result;
+        }
         for (Object item : items) {
             try {
                 Object value = getProperty(item, property);
-                if (value == null || Boolean.FALSE.equals(value) || "false".equals(value.toString()))
+                if (value == null || Boolean.FALSE.equals(value) || "false".equals(value.toString())) {
                     result.add(item);
+                }
             } catch (Exception e) {
                 result.add(item);
             }
@@ -156,16 +169,18 @@ public class JekyllFiltersExtension {
 
     @TemplateExtension(namespace = "list")
     static Object whereExp(Iterable<?> items, String loopVar, Object conditionsObj) {
-        if (items == null)
+        if (items == null) {
             return new ArrayList<>();
+        }
 
         List<String> conditions;
         if (conditionsObj instanceof String s) {
             conditions = List.of(s);
         } else if (conditionsObj instanceof Iterable<?> iter) {
             conditions = new ArrayList<>();
-            for (Object o : iter)
+            for (Object o : iter) {
                 conditions.add(o.toString());
+            }
         } else {
             conditions = List.of(conditionsObj.toString());
         }
@@ -182,8 +197,9 @@ public class JekyllFiltersExtension {
                     break;
                 }
             }
-            if (matches)
+            if (matches) {
                 result.add(item);
+            }
         }
         return isJsonArray ? new JsonArray(result) : result;
     }
@@ -208,8 +224,9 @@ public class JekyllFiltersExtension {
     }
 
     private static boolean compareValues(String left, String op, String right) {
-        if (left == null)
+        if (left == null) {
             return false;
+        }
         int cmp = left.compareTo(right);
         return switch (op) {
             case "==" -> cmp == 0;
@@ -244,10 +261,12 @@ public class JekyllFiltersExtension {
 
     private static String extractProperty(Object obj, String property) {
         Object val = getProperty(obj, property);
-        if (val != null)
+        if (val != null) {
             return val.toString();
-        if (obj != null && !(obj instanceof JsonObject) && !(obj instanceof Map))
+        }
+        if (obj != null && !(obj instanceof JsonObject) && !(obj instanceof Map)) {
             return obj.toString();
+        }
         return null;
     }
 
@@ -255,23 +274,27 @@ public class JekyllFiltersExtension {
         return (a, b) -> {
             String va = extractProperty(a, property);
             String vb = extractProperty(b, property);
-            if (va == null)
+            if (va == null) {
                 return vb == null ? 0 : 1;
-            if (vb == null)
+            }
+            if (vb == null) {
                 return -1;
+            }
             return va.compareToIgnoreCase(vb);
         };
     }
 
     static <T> List<T> distinct(List<T> list) {
-        if (list == null || list.isEmpty())
+        if (list == null || list.isEmpty()) {
             return List.of();
+        }
         return list.stream().distinct().toList();
     }
 
     static JsonArray distinct(JsonArray array) {
-        if (array == null || array.isEmpty())
+        if (array == null || array.isEmpty()) {
             return new JsonArray();
+        }
         List<Object> seen = new ArrayList<>();
         for (int i = 0; i < array.size(); i++) {
             Object val = array.getValue(i);
@@ -295,27 +318,33 @@ public class JekyllFiltersExtension {
     // Replaces Liquid's push-accumulation pattern (broken in Qute because {#let} is block-scoped)
     @SuppressWarnings("unchecked")
     static JsonArray mergeTypes(JsonObject index, String type) {
-        if (index == null || type == null || type.isEmpty())
+        if (index == null || type == null || type.isEmpty()) {
             return null;
+        }
         JsonArray result = new JsonArray();
         for (String key : index.fieldNames()) {
             Map<String, Object> sourceMap = toMap(index.getValue(key));
-            if (sourceMap == null)
+            if (sourceMap == null) {
                 continue;
+            }
             Map<String, Object> typesMap = toMap(sourceMap.get("types"));
-            if (typesMap == null)
+            if (typesMap == null) {
                 continue;
+            }
             Object items = typesMap.get(type);
             if (items instanceof JsonArray arr) {
-                for (Object item : arr)
+                for (Object item : arr) {
                     result.add(toJsonObject(item));
+                }
             } else if (items instanceof List<?> list) {
-                for (Object item : list)
+                for (Object item : list) {
                     result.add(toJsonObject(item));
+                }
             }
         }
-        if (result.isEmpty())
+        if (result.isEmpty()) {
             return null;
+        }
         List<Object> sorted = new ArrayList<>(result.getList());
         sorted.sort(Comparator.comparing(
                 o -> o instanceof JsonObject jo ? jo.getString("title", "") : "",
@@ -342,14 +371,16 @@ public class JekyllFiltersExtension {
     }
 
     static RawString markdownify(String str) {
-        if (str == null || str.isEmpty())
+        if (str == null || str.isEmpty()) {
             return new RawString("");
+        }
         return new RawString(str);
     }
 
     static RawString raw(String str) {
-        if (str == null)
+        if (str == null) {
             return new RawString("");
+        }
         return new RawString(str);
     }
 
@@ -378,15 +409,17 @@ public class JekyllFiltersExtension {
     // Namespace form handles null base objects (instance extensions can't dispatch on null)
     @TemplateExtension(namespace = "str")
     static List<String> split(String str, String delimiter) {
-        if (str == null || str.isEmpty())
+        if (str == null || str.isEmpty()) {
             return List.of();
+        }
         return Arrays.asList(str.split(Pattern.quote(delimiter)));
     }
 
     @TemplateExtension(namespace = "str")
     static List<RawString> splitRaw(String str, String delimiter) {
-        if (str == null || str.isEmpty())
+        if (str == null || str.isEmpty()) {
             return List.of();
+        }
         return Arrays.stream(str.split(Pattern.quote(delimiter)))
                 .map(RawString::new)
                 .toList();
@@ -395,13 +428,15 @@ public class JekyllFiltersExtension {
     // Replaces Liquid split+trim+push loop (broken in Qute due to block-scoped {#let})
     @TemplateExtension(namespace = "str")
     static List<String> splitTrimmed(String str, String delimiter) {
-        if (str == null || str.isEmpty())
+        if (str == null || str.isEmpty()) {
             return List.of();
+        }
         List<String> result = new ArrayList<>();
         for (String s : str.split(Pattern.quote(delimiter))) {
             String trimmed = s.trim();
-            if (!trimmed.isEmpty())
+            if (!trimmed.isEmpty()) {
                 result.add(trimmed);
+            }
         }
         return result;
     }

--- a/migration/src/test/java/io/quarkus/tools/migration/JekyllFiltersExtensionTest.java
+++ b/migration/src/test/java/io/quarkus/tools/migration/JekyllFiltersExtensionTest.java
@@ -2,16 +2,96 @@ package io.quarkus.tools.migration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.qute.RawString;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 class JekyllFiltersExtensionTest {
+
+    @Test
+    void testRfc822FromLocalDateTime() {
+        LocalDateTime dt = LocalDateTime.of(2024, 3, 15, 10, 30, 0);
+        String result = JekyllFiltersExtension.rfc822(dt);
+        assertEquals("Fri, 15 Mar 2024 10:30:00 +0000", result);
+    }
+
+    @Test
+    void testRfc822AlwaysEnglish() {
+        LocalDateTime dt = LocalDateTime.of(2024, 1, 1, 0, 0, 0);
+        String result = JekyllFiltersExtension.rfc822(dt);
+        assertTrue(result.startsWith("Mon"), "Day name should be in English");
+        assertTrue(result.contains("Jan"), "Month name should be in English");
+    }
+
+    @Test
+    void testEscapeHtml() {
+        assertEquals("&amp;&lt;&gt;&quot;&#39;",
+                JekyllFiltersExtension.escapeHtml("&<>\"'"));
+    }
+
+    @Test
+    void testEscapeHtmlPlainText() {
+        assertEquals("hello world", JekyllFiltersExtension.escapeHtml("hello world"));
+    }
+
+    @Test
+    void testEscapeHtmlNull() {
+        assertEquals("", JekyllFiltersExtension.escapeHtml(null));
+    }
+
+    @Test
+    void testCapitalizeNormalString() {
+        assertEquals("Hello", JekyllFiltersExtension.capitalize("hello"));
+    }
+
+    @Test
+    void testCapitalizeAlreadyCapitalized() {
+        assertEquals("Hello", JekyllFiltersExtension.capitalize("Hello"));
+    }
+
+    @Test
+    void testCapitalizeSingleChar() {
+        assertEquals("A", JekyllFiltersExtension.capitalize("a"));
+    }
+
+    @Test
+    void testCapitalizeEmpty() {
+        assertEquals("", JekyllFiltersExtension.capitalize(""));
+    }
+
+    @Test
+    void testCapitalizeNull() {
+        assertNull(JekyllFiltersExtension.capitalize(null));
+    }
+
+    @Test
+    void testSplitByDot() {
+        assertEquals(List.of("3", "17"), JekyllFiltersExtension.split("3.17", "."));
+    }
+
+    @Test
+    void testSplitByComma() {
+        assertEquals(List.of("a", "b", "c"), JekyllFiltersExtension.split("a,b,c", ","));
+    }
+
+    @Test
+    void testSplitNull() {
+        assertEquals(List.of(), JekyllFiltersExtension.split(null, ","));
+    }
+
+    @Test
+    void testSplitEmpty() {
+        assertEquals(List.of(), JekyllFiltersExtension.split("", ","));
+    }
 
     @Test
     void testWhereExpSingleConditionGreaterThan() {
@@ -78,5 +158,120 @@ class JekyllFiltersExtensionTest {
         var result = JekyllFiltersExtension.whereExp(items, "pub", "pub.urldate > '2021-09-01'");
         assertInstanceOf(JsonArray.class, result);
         assertEquals(1, ((JsonArray) result).size());
+    }
+
+    @Test
+    void testGroupByGroupsItemsByProperty() {
+        var items = new JsonArray()
+                .add(new JsonObject().put("type", "article").put("title", "A"))
+                .add(new JsonObject().put("type", "video").put("title", "B"))
+                .add(new JsonObject().put("type", "article").put("title", "C"))
+                .add(new JsonObject().put("type", "podcast").put("title", "D"));
+        var groups = JekyllFiltersExtension.groupBy(items, "type");
+        assertEquals(3, groups.size());
+        var articleGroup = (JsonObject) groups.stream()
+                .filter(g -> "article".equals(((JsonObject) g).getString("name")))
+                .findFirst().orElseThrow();
+        assertEquals(2, articleGroup.getJsonArray("items").size());
+    }
+
+    @Test
+    void testGroupByNullReturnsEmpty() {
+        var groups = JekyllFiltersExtension.groupBy(null, "type");
+        assertEquals(0, groups.size());
+    }
+
+    @Test
+    void testSplitRawReturnsRawStrings() {
+        var parts = JekyllFiltersExtension.splitRaw("<p>before</p>|<p>after</p>", "|");
+        assertEquals(2, parts.size());
+        assertInstanceOf(RawString.class, parts.get(0));
+        assertInstanceOf(RawString.class, parts.get(1));
+        assertEquals("<p>before</p>", parts.get(0).toString());
+        assertEquals("<p>after</p>", parts.get(1).toString());
+    }
+
+    @Test
+    void testMergeTypesPreservesAllFields() {
+        JsonObject guide1 = new JsonObject()
+                .put("title", "Getting Started")
+                .put("url", "/guides/getting-started")
+                .put("summary", "Your first Quarkus app")
+                .put("categories", "getting-started")
+                .put("type", "tutorial");
+        JsonObject guide2 = new JsonObject()
+                .put("title", "Building Native")
+                .put("url", "/guides/building-native")
+                .put("summary", "Build native executables")
+                .put("categories", "native")
+                .put("type", "tutorial");
+
+        JsonObject source = new JsonObject()
+                .put("types", new JsonObject()
+                        .put("tutorial", new JsonArray().add(guide2).add(guide1)));
+        JsonObject index = new JsonObject().put("quarkus", source);
+
+        JsonArray result = JekyllFiltersExtension.mergeTypes(index, "tutorial");
+        assertEquals(2, result.size());
+
+        // Should be sorted by title
+        JsonObject first = result.getJsonObject(0);
+        assertEquals("Building Native", first.getString("title"));
+        assertEquals("/guides/building-native", first.getString("url"));
+        assertEquals("Build native executables", first.getString("summary"));
+        assertEquals("native", first.getString("categories"));
+
+        JsonObject second = result.getJsonObject(1);
+        assertEquals("Getting Started", second.getString("title"));
+        assertEquals("/guides/getting-started", second.getString("url"));
+        assertEquals("Your first Quarkus app", second.getString("summary"));
+    }
+
+    @Test
+    void testMergeTypesHandlesRawMapData() {
+        // YAML-loaded data stores nested objects as raw Maps, not JsonObject
+        Map<String, Object> guide1 = Map.of(
+                "title", "Alpha Guide",
+                "url", "/guides/alpha",
+                "summary", "First guide");
+        Map<String, Object> guide2 = Map.of(
+                "title", "Beta Guide",
+                "url", "/guides/beta",
+                "summary", "Second guide");
+
+        // Simulate YAML-loaded structure: types and items as raw Maps/Lists
+        Map<String, Object> typesMap = Map.of("tutorial", List.of(guide2, guide1));
+        Map<String, Object> sourceMap = Map.of("types", typesMap);
+        JsonObject index = new JsonObject(new java.util.LinkedHashMap<>(Map.of("quarkus", sourceMap)));
+
+        JsonArray result = JekyllFiltersExtension.mergeTypes(index, "tutorial");
+        assertEquals(2, result.size());
+
+        // Items should be wrapped as proper JsonObject instances
+        JsonObject first = result.getJsonObject(0);
+        assertInstanceOf(JsonObject.class, first);
+        assertEquals("Alpha Guide", first.getString("title"));
+        assertEquals("/guides/alpha", first.getString("url"));
+        assertEquals("First guide", first.getString("summary"));
+
+        JsonObject second = result.getJsonObject(1);
+        assertEquals("Beta Guide", second.getString("title"));
+        assertEquals("/guides/beta", second.getString("url"));
+    }
+
+    record TagCount(String name, Long count) {
+    }
+
+    @Test
+    void testSortListOfRecordsByProperty() {
+        List<?> input = List.of(
+                new TagCount("quarkus", 5L),
+                new TagCount("alternative", 3L),
+                new TagCount("messaging", 1L));
+        List<?> result = JekyllFiltersExtension.sort(input, "name");
+        assertEquals(3, result.size());
+        assertEquals("alternative", ((TagCount) result.get(0)).name());
+        assertEquals("messaging", ((TagCount) result.get(1)).name());
+        assertEquals("quarkus", ((TagCount) result.get(2)).name());
     }
 }


### PR DESCRIPTION
More utilities to match capabilities that I found in Liquid templates. 

Most of these are just ... functions:

- sort
- group
- date handling 
- escaping html
- splitting strings 
- capitalizing strings

As with the other changes, I suggest we put them into the Jekyll template first, and if they look useful after the dust has settled, we move them to the central template. Otherwise conversion gets blocked on Roq release cadences.

The one function here which is semantically interesting is the mutable map. I used this to fix a nasty problem I kept hitting during the conversion. Qute variables are scoped to the block they're in, but Liquid variables have a higher scope (file, I think). Normally the converter could get round this by hoisting variables, but sometimes it just couldn't, usually when the value of the variable would get changed later on. So what I've done is, in rare cases, shoved the value into a map, and then used map reading and writing to make the variable higher-scoped and mutable. It's icky, but the patterns are there in Jekyll, and we want to get people able to convert.
