### PR TITLE
Add JekyllLayoutConverter for CSS bundle tag migration

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/JekyllLayoutCommand.java
+++ b/migration/src/main/java/io/quarkus/tools/JekyllLayoutCommand.java
@@ -1,0 +1,52 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS info.picocli:picocli:4.7.5
+
+package io.quarkus.tools;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "jekyll-layout", mixinStandardHelpOptions = true, version = "1.0", description = "Converts Jekyll layout HTML to Roq layout HTML")
+public class JekyllLayoutCommand implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "Layout file to convert (e.g., _layouts/base.html)")
+    private Path inputFile;
+
+    @Override
+    public Integer call() throws Exception {
+        if (!Files.exists(inputFile)) {
+            System.err.println("Error: File not found: " + inputFile);
+            return 1;
+        }
+
+        if (!Files.isRegularFile(inputFile)) {
+            System.err.println("Error: Not a regular file: " + inputFile);
+            return 1;
+        }
+
+        JekyllLayoutConverter converter = new JekyllLayoutConverter();
+
+        try {
+            String content = Files.readString(inputFile);
+            String converted = converter.replaceAssetsCssWithBundle(content);
+            Files.writeString(inputFile, converted);
+            System.out.println("Converted: " + inputFile);
+            return 0;
+        } catch (IOException e) {
+            System.err.println("Error converting file: " + e.getMessage());
+            e.printStackTrace();
+            return 1;
+        }
+    }
+
+    public static void main(String... args) {
+        int exitCode = new CommandLine(new JekyllLayoutCommand()).execute(args);
+        System.exit(exitCode);
+    }
+}

--- a/migration/src/main/java/io/quarkus/tools/JekyllLayoutConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/JekyllLayoutConverter.java
@@ -1,0 +1,58 @@
+package io.quarkus.tools;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.regex.Pattern;
+
+/**
+ * Converts Jekyll layout HTML to Roq layout HTML.
+ * Primarily handles replacing /assets/css/ stylesheet links with {#bundle /} tag.
+ */
+public class JekyllLayoutConverter {
+
+    private static final Pattern ASSETS_CSS_PATTERN = Pattern.compile(".*href=.*['\"].*?/assets/css/.*");
+
+    /**
+     * Replace the first /assets/css/ stylesheet link with {#bundle /} and remove
+     * any additional /assets/css/ links.
+     *
+     * This positions the web-bundler tag where Jekyll's main CSS was located,
+     * preserving the CSS load order while removing redundant references.
+     *
+     * Preserves:
+     * - Non-assets CSS (e.g., /guides/stylesheet/config.css)
+     * - External CDN CSS (e.g., https://use.fontawesome.com/...)
+     * - All other HTML
+     *
+     * @param content HTML content to convert
+     * @return Converted HTML with bundle tag replacing /assets/css/ links
+     * @throws IOException if reading the content fails
+     */
+    public String replaceAssetsCssWithBundle(String content) throws IOException {
+        StringWriter output = new StringWriter();
+        boolean bundleTagInserted = false;
+
+        try (BufferedReader reader = new BufferedReader(new StringReader(content))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (ASSETS_CSS_PATTERN.matcher(line).matches()) {
+                    if (!bundleTagInserted) {
+                        // Replace first /assets/css/ link with {#bundle /}
+                        // Preserve indentation from the original line
+                        String indentation = line.substring(0, line.indexOf('<'));
+                        output.write(indentation + "{#bundle /}\n");
+                        bundleTagInserted = true;
+                    }
+                    // Skip this line (first replacement already done, or additional link to remove)
+                } else {
+                    output.write(line);
+                    output.write('\n');
+                }
+            }
+        }
+
+        return output.toString();
+    }
+}

--- a/migration/src/test/java/io/quarkus/tools/JekyllLayoutConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/JekyllLayoutConverterTest.java
@@ -1,0 +1,173 @@
+package io.quarkus.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+class JekyllLayoutConverterTest {
+
+    private final JekyllLayoutConverter converter = new JekyllLayoutConverter();
+
+    @Test
+    void testSingleAssetsCssReplaced() throws IOException {
+        String input = """
+                <head>
+                  <title>Test</title>
+                  <link rel="stylesheet" href="/guides/stylesheet/config.css" />
+                  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}?2021-07-29" />
+                  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.5.2/css/all.css" crossorigin="anonymous">
+                </head>
+                """;
+
+        String result = converter.replaceAssetsCssWithBundle(input);
+
+        // Should have bundle tag
+        assertTrue(result.contains("{#bundle /}"), "Should contain bundle tag");
+
+        // Should NOT have assets/css link
+        assertFalse(result.contains("/assets/css/"), "Should not contain /assets/css/ link");
+
+        // Should preserve config.css
+        assertTrue(result.contains("/guides/stylesheet/config.css"), "Should preserve config.css");
+
+        // Should preserve external CSS
+        assertTrue(result.contains("fontawesome"), "Should preserve external CSS");
+    }
+
+    @Test
+    void testMultipleAssetsCssLinks() throws IOException {
+        String input = """
+                <head>
+                  <title>Test</title>
+                  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
+                  <link rel="stylesheet" href="{{ '/assets/css/custom.css' | relative_url }}" />
+                  <link rel="stylesheet" href="{{ '/assets/css/theme.css' | relative_url }}" />
+                </head>
+                """;
+
+        String result = converter.replaceAssetsCssWithBundle(input);
+
+        // Should have exactly one bundle tag
+        int bundleCount = result.split("\\{#bundle /\\}", -1).length - 1;
+        assertEquals(1, bundleCount, "Should have exactly one bundle tag");
+
+        // Should NOT have any assets/css links
+        assertFalse(result.contains("/assets/css/"), "Should not contain any /assets/css/ links");
+    }
+
+    @Test
+    void testPreservesIndentation() throws IOException {
+        String input = """
+                <head>
+                  <title>Test</title>
+                    <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
+                </head>
+                """;
+
+        String result = converter.replaceAssetsCssWithBundle(input);
+
+        // Should preserve the indentation (4 spaces)
+        assertTrue(result.contains("    {#bundle /}"), "Should preserve indentation");
+    }
+
+    @Test
+    void testNoAssetsCssLinks() throws IOException {
+        String input = """
+                <head>
+                  <title>Test</title>
+                  <link rel="stylesheet" href="/custom/style.css" />
+                  <link rel="stylesheet" href="https://cdn.example.com/style.css" />
+                </head>
+                """;
+
+        String result = converter.replaceAssetsCssWithBundle(input);
+
+        // Should NOT add bundle tag if no /assets/css/ links
+        assertFalse(result.contains("{#bundle /}"), "Should not add bundle tag if no /assets/css/ links");
+
+        // Should preserve all links
+        assertTrue(result.contains("/custom/style.css"), "Should preserve custom CSS");
+        assertTrue(result.contains("cdn.example.com"), "Should preserve CDN CSS");
+    }
+
+    @Test
+    void testMixedAssetsAndNonAssets() throws IOException {
+        String input = """
+                <head>
+                  <link rel="stylesheet" href="/guides/stylesheet/config.css" />
+                  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
+                  <link rel="stylesheet" href="/custom/style.css" />
+                  <link rel="stylesheet" href="{{ '/assets/css/extra.css' | relative_url }}" />
+                  <link rel="stylesheet" href="https://fonts.googleapis.com/css" />
+                </head>
+                """;
+
+        String result = converter.replaceAssetsCssWithBundle(input);
+
+        // Should have one bundle tag
+        assertTrue(result.contains("{#bundle /}"), "Should contain bundle tag");
+
+        // Should NOT have assets/css links
+        assertFalse(result.contains("/assets/css/"), "Should not contain /assets/css/ links");
+
+        // Should preserve non-assets links
+        assertTrue(result.contains("/guides/stylesheet/config.css"), "Should preserve config.css");
+        assertTrue(result.contains("/custom/style.css"), "Should preserve custom CSS");
+        assertTrue(result.contains("fonts.googleapis.com"), "Should preserve Google Fonts");
+    }
+
+    @Test
+    void testDifferentQuoteStyles() throws IOException {
+        String input = """
+                <head>
+                  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
+                  <link rel='stylesheet' href='{{ "/assets/css/alt.css" | relative_url }}' />
+                </head>
+                """;
+
+        String result = converter.replaceAssetsCssWithBundle(input);
+
+        // Should handle both quote styles
+        assertFalse(result.contains("/assets/css/"), "Should handle both single and double quotes");
+        assertTrue(result.contains("{#bundle /}"), "Should contain bundle tag");
+    }
+
+    @Test
+    void testRealWorldQuarkusioExample() throws IOException {
+        // Real example from quarkusio.github.io
+        String input = """
+                <head>
+                  <title>{{ page.title }}</title>
+                  <meta charset="utf-8">
+                  <link rel="canonical" href="{{ canonical_url | prepend: site.url }}">
+                  <link rel="shortcut icon" type="image/png" href="/favicon.ico" >
+                  <link rel="stylesheet" href="/guides/stylesheet/config.css" />
+                  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}?2021-07-29" />
+                  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.5.2/css/all.css" crossorigin="anonymous">
+                  <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
+                </head>
+                """;
+
+        String result = converter.replaceAssetsCssWithBundle(input);
+
+        // Expected output
+        String expected = """
+                <head>
+                  <title>{{ page.title }}</title>
+                  <meta charset="utf-8">
+                  <link rel="canonical" href="{{ canonical_url | prepend: site.url }}">
+                  <link rel="shortcut icon" type="image/png" href="/favicon.ico" >
+                  <link rel="stylesheet" href="/guides/stylesheet/config.css" />
+                  {#bundle /}
+                  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.5.2/css/all.css" crossorigin="anonymous">
+                  <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
+                </head>
+                """;
+
+        assertEquals(expected, result, "Should match expected real-world output");
+    }
+}


### PR DESCRIPTION
Fixes #1070 

The bulk of the slower performance was caused by two css files that couldn't be found, causing a 404. Some delay was also caused by having the `{#bundle}` right after `<head>`. This fixes all three of those issues, by 

- Putting the  {#bundle} declaration where the first original css import is
- Removing all the old css imports, since the bundle handles everything, and 404s are slow 

This eliminates 404 errors from broken static/bundle/app.css references that caused ~100-200ms Lighthouse TBT regression in Jekyll migrations.

Obviously, these classes need to be called, but that's another PR. 