### PR TITLE
Conversion: Updates to config and qute converters to handle arbitary config and other bits

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/JekyllConfigCommand.java
+++ b/migration/src/main/java/io/quarkus/tools/JekyllConfigCommand.java
@@ -10,6 +10,7 @@ import java.util.concurrent.Callable;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 @Command(name = "jekyll-config", mixinStandardHelpOptions = true, version = "1.0", description = "Converts Jekyll _config.yml to Roq application.properties and data/siteConfig.yml")
@@ -17,6 +18,10 @@ public class JekyllConfigCommand implements Callable<Integer> {
 
     @Parameters(index = "0", description = "Jekyll project directory")
     private Path projectDir;
+
+    @Option(names = {
+            "--strict-properties" }, description = "Use THROW strategy for missing properties (requires all optional properties to be guarded with {#if} or .or(''))")
+    private boolean strictProperties;
 
     private JekyllConfigConverter converter = new JekyllConfigConverter();
 
@@ -37,13 +42,8 @@ public class JekyllConfigCommand implements Callable<Integer> {
             return 1;
         }
 
-        Path configFile = projectDir.resolve("_config.yml");
-        if (!Files.exists(configFile)) {
-            System.err.println("Error: _config.yml not found in " + projectDir);
-            return 1;
-        }
-
         try {
+            converter.setStrictProperties(strictProperties);
             converter.convertProject(projectDir);
 
             System.out.println("✓ Jekyll config conversion complete:");

--- a/migration/src/main/java/io/quarkus/tools/JekyllConfigConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/JekyllConfigConverter.java
@@ -4,16 +4,19 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.Template;
 
 /**
  * Converts Jekyll _config.yml to Roq application.properties and data/siteConfig.yml.
@@ -21,6 +24,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
  */
 public class JekyllConfigConverter {
 
+    public static final String COLLECTIONS = "collections";
     public static final String DEFAULT_COLLECTION_NAME = "posts";
     public static final String APPLICATION_PROPERTIES = "application.properties";
     public static final String CONFIG_DIR = "config";
@@ -29,10 +33,14 @@ public class JekyllConfigConverter {
     private final YAMLMapper yamlMapper;
     private final ObjectMapper objectMapper;
     private boolean strictProperties;
+    private final Engine quteEngine;
 
     public JekyllConfigConverter() {
         this.yamlMapper = new YAMLMapper();
         this.objectMapper = new ObjectMapper();
+        this.quteEngine = Engine.builder()
+                .addDefaults()
+                .build();
     }
 
     public void setStrictProperties(boolean strictProperties) {
@@ -62,8 +70,6 @@ public class JekyllConfigConverter {
         properties.setProperty("quarkus.qute.alt-expr-syntax", "true");
         // Set a date format with a sensible default for Jekyll.
         properties.setProperty("site.date-format", "yyyy-MM-dd['T'HH:mm:ss][X]");
-        // Jekyll templates access arbitrary frontmatter fields that may not exist on every page
-        // echo "quarkus.qute.strict-rendering=false" >> ${project_dir}/config/application.properties
         properties.setProperty("quarkus.qute.strict-rendering", "false");
         if (!strictProperties) {
             // Liquid silently swallows missing properties (outputs nothing).
@@ -102,6 +108,7 @@ public class JekyllConfigConverter {
         addAsciidoctorAttributes(config, properties);
         addCollectionProperties(config, properties);
         addEscapedPages(config, properties);
+        addIgnoredFiles(config, properties);
 
         return properties;
     }
@@ -120,19 +127,20 @@ public class JekyllConfigConverter {
         return createSiteConfigYaml(yamlMapper.readTree(configYaml), cnameContent);
     }
 
-    public static final String COLLECTIONS = "collections";
     /**
      * Create a siteConfig.yml from a pre-parsed config.
      */
     private static final Set<String> KEYS_HANDLED_ELSEWHERE = Set.of(
             "url", // → application.properties site.url
-            COLLECTIONS, // → application.properties site.collections.*
+            "collections", // → application.properties site.collections.*
             "plugins", // → application.properties (auto-author, etc.)
             "defaults", // → application.properties (collection layouts)
             "description", // → index page frontmatter
             "autopages", // → application.properties (auto-author config)
             "title", // → index page frontmatter / Roq site.title
-            "asciidoctor" // → application.properties quarkus.asciidoc.attributes.*
+            "asciidoctor", // → application.properties quarkus.asciidoc.attributes.*
+            "exclude", // → application.properties site.ignored-files
+            "search" // → ConfigMapping + application.properties {project}.search.*
     );
 
     public String createSiteConfigYaml(JsonNode config, String cnameContent) throws IOException {
@@ -141,44 +149,16 @@ public class JekyllConfigConverter {
         // Add CNAME
         siteConfig.put("cname", cnameContent != null ? cnameContent.trim() : "");
 
-        // Copy all config keys except those handled by application.properties or index page
-        // Transform all hyphenated keys to camelCase for Qute template compatibility
-        // (Qute doesn't support hyphens in property access - interprets as subtraction)
+        // Copy all config keys except those handled by application.properties or ConfigMappings
         config.fieldNames().forEachRemaining(key -> {
             if (KEYS_HANDLED_ELSEWHERE.contains(key)) {
                 return;
             }
-            copyNodeWithCamelCaseKeys(config.get(key), siteConfig, key);
+            copyIfPresent(config, siteConfig, key);
         });
-
-        // Add empty tags array (for Jekyll compatibility)
-        siteConfig.put("tags", new Object[0]);
 
         // Convert to YAML
         return yamlMapper.writeValueAsString(siteConfig);
-
-    }
-
-    private void copyNodeWithCamelCaseKeys(JsonNode node, Map<String, Object> target, String key) {
-        if (node.isObject()) {
-            // Recursively transform all nested object keys to camelCase
-            Map<String, Object> nestedMap = new LinkedHashMap<>();
-            node.fields().forEachRemaining(entry -> {
-                String camelKey = hyphenToCamelCase(entry.getKey());
-                copyNodeWithCamelCaseKeys(entry.getValue(), nestedMap, camelKey);
-            });
-            target.put(key, nestedMap);
-        } else if (node.isArray()) {
-            target.put(key, objectMapper.convertValue(node, Object.class));
-        } else if (node.isTextual()) {
-            target.put(key, node.asText());
-        } else if (node.isNumber()) {
-            target.put(key, node.numberValue());
-        } else if (node.isBoolean()) {
-            target.put(key, node.asBoolean());
-        } else if (node.isNull()) {
-            target.put(key, null);
-        }
     }
 
     /**
@@ -186,22 +166,8 @@ public class JekyllConfigConverter {
      * Reads _config.yml and CNAME, creates config/application.properties and data/siteConfig.yml.
      * Replaces roq-it-jekyll lines 61-62, 184-192, and 238-277.
      *
-     * <p>
-     * <strong>Warning:</strong> This method performs destructive file operations:
-     * </p>
-     * <ul>
-     * <li>Moves collection directories from {@code _<name>} to {@code content/<name>}
-     * (e.g., {@code _guides} → {@code content/guides})</li>
-     * <li>Modifies {@code index.md/index.html/index.adoc} frontmatter to add site description</li>
-     * <li>Creates/overwrites {@code config/application.properties} and {@code data/siteConfig.yml}</li>
-     * </ul>
-     *
-     * <p>
-     * Run on a clean working tree or ensure you have backups before conversion.
-     * </p>
-     *
      * @param projectDir The Jekyll project directory
-     * @throws IOException if file operations fail, including if collection directory moves fail
+     * @throws IOException if file operations fail
      */
     public void convertProject(Path projectDir) throws IOException {
         Path configFile = projectDir.resolve("_config.yml");
@@ -222,6 +188,15 @@ public class JekyllConfigConverter {
 
         JsonNode config = yamlMapper.readTree(configYaml);
 
+        // Derive project name early — needed for ConfigMapping prefix
+        String projectName = deriveProjectName(projectDir, config);
+        // Use project-derived prefix for ConfigMapping properties to avoid
+        // clashing with the Roq framework's site.* ConfigMapping namespace
+        String configMappingPrefix = configMappingPrefix(projectName);
+
+        // Track config mappings from main config too
+        Map<String, JsonNode> configMappingsToGenerate = new LinkedHashMap<>();
+
         // Write properties manually — Properties.store() escapes colons in values,
         // which corrupts date format patterns like yyyy-MM-dd['T'HH:mm:ss][X]
         try (Writer writer = Files.newBufferedWriter(propsFile)) {
@@ -229,6 +204,28 @@ public class JekyllConfigConverter {
             for (String key : props.stringPropertyNames().stream().sorted().toList()) {
                 writer.write(key + "=" + props.getProperty(key) + "\n");
             }
+
+            // Handle search config from main _config.yml
+            if (config.has("search") && config.get("search").isObject()) {
+                JsonNode search = config.get("search");
+                List<String> searchProps = buildSiteConfigOverrides(
+                        objectMapper.createObjectNode().set("search", search), configMappingPrefix);
+                for (String line : searchProps) {
+                    writer.write(line + "\n");
+                }
+                configMappingsToGenerate.put("search", search);
+            }
+
+            convertOverlayConfigs(projectDir, writer, configMappingsToGenerate, configMappingPrefix);
+        }
+
+        // Generate ConfigMapping interfaces for all config sections
+        if (!configMappingsToGenerate.isEmpty()) {
+            generateConfigMappings(projectDir, projectName, configMappingPrefix, configMappingsToGenerate);
+            addJandexPluginToPom(projectDir);
+
+            Path metadataFile = projectDir.resolve("config/.migration-config-mappings");
+            Files.writeString(metadataFile, String.join("\n", configMappingsToGenerate.keySet()) + "\n");
         }
 
         // Create data/siteConfig.yml
@@ -245,6 +242,14 @@ public class JekyllConfigConverter {
         if (config.has("description")) {
             addDescriptionToIndexPage(projectDir, config.get("description").asText());
         }
+
+        // Add name and simple-name to index page frontmatter (Roq templates use site.data.name and site.data.simple-name)
+        if (config.has("title")) {
+            addNameToIndexPage(projectDir, config.get("title").asText());
+        }
+
+        // Add tagging frontmatter to the tag layout (must run before LiquidToQuteCommand)
+        addTaggingFrontmatter(projectDir, config);
     }
 
     void moveCollectionDirectories(Path projectDir, JsonNode config) throws IOException {
@@ -256,7 +261,6 @@ public class JekyllConfigConverter {
             return;
         }
         Path contentDir = projectDir.resolve("content");
-        List<String> failures = new ArrayList<>();
         collections.fieldNames().forEachRemaining(name -> {
             if (DEFAULT_COLLECTION_NAME.equals(name)) {
                 return;
@@ -268,13 +272,10 @@ public class JekyllConfigConverter {
                     Files.createDirectories(target.getParent());
                     Files.move(source, target);
                 } catch (IOException e) {
-                    failures.add("Failed to move _" + name + " to content/" + name + ": " + e.getMessage());
+                    System.err.println("Warning: could not move _" + name + " to content/" + name + ": " + e.getMessage());
                 }
             }
         });
-        if (!failures.isEmpty()) {
-            throw new IOException("Collection directory migration failed:\n  " + String.join("\n  ", failures));
-        }
     }
 
     void addDescriptionToIndexPage(Path projectDir, String description) throws IOException {
@@ -286,11 +287,29 @@ public class JekyllConfigConverter {
         if (content.contains("description:")) {
             return;
         }
-        // Insert description after the opening --- (handle both LF and CRLF line endings)
-        String escapedDescription = description.replace("\\", "\\\\").replace("\"", "\\\"");
-        content = content.replaceFirst("(---\\s*(?:\\r\\n|\\n))", "$1description: \"" +
-                escapedDescription + "\"\n");
+        // Insert description after the opening ---
+        content = content.replaceFirst("(---\\s*\\n)", "$1description: \"" +
+                description.replace("\"", "\\\"") + "\"\n");
         Files.writeString(indexFile, content);
+    }
+
+    void addNameToIndexPage(Path projectDir, String title) throws IOException {
+        Path indexFile = findIndexFile(projectDir);
+        if (indexFile == null) {
+            return;
+        }
+        String content = Files.readString(indexFile);
+        StringBuilder toInsert = new StringBuilder();
+        if (!content.contains("name:")) {
+            toInsert.append("name: \"").append(title.replace("\"", "\\\"")).append("\"\n");
+        }
+        if (!content.contains("simple-name:")) {
+            toInsert.append("simple-name: \"").append(title.replace("\"", "\\\"")).append("\"\n");
+        }
+        if (!toInsert.isEmpty()) {
+            content = content.replaceFirst("(---\\s*\\n)", "$1" + toInsert);
+            Files.writeString(indexFile, content);
+        }
     }
 
     private Path findIndexFile(Path projectDir) {
@@ -303,6 +322,50 @@ public class JekyllConfigConverter {
             }
         }
         return null;
+    }
+
+    void addTaggingFrontmatter(Path projectDir, JsonNode config) throws IOException {
+        if (config == null || !config.has("jekyll-archives")) {
+            return;
+        }
+        JsonNode archives = config.get("jekyll-archives");
+        if (!archives.has("layouts")) {
+            return;
+        }
+        JsonNode layouts = archives.get("layouts");
+        if (!layouts.has("tag")) {
+            return;
+        }
+        String layoutName = layouts.get("tag").asText();
+
+        String link = null;
+        if (archives.has("permalinks")) {
+            JsonNode permalinks = archives.get("permalinks");
+            if (permalinks.has("tag")) {
+                link = permalinks.get("tag").asText().replace(":name", ":tag");
+            }
+        }
+
+        Path layoutFile = projectDir.resolve("_layouts/" + layoutName + ".html");
+        if (!Files.exists(layoutFile)) {
+            return;
+        }
+
+        String content = Files.readString(layoutFile);
+        if (content.contains("tagging:")) {
+            return;
+        }
+
+        String taggingBlock;
+        if (link != null) {
+            taggingBlock = "tagging:\n  collection: posts\n  link: " + link + "\n";
+        } else {
+            taggingBlock = "tagging: posts\n";
+        }
+
+        content = content.replaceFirst("(---\\s*\\n)", "$1" + taggingBlock.replace("\\", "\\\\"));
+        Files.writeString(layoutFile, content);
+        System.out.println("  [TAGGING] Added tagging frontmatter to " + layoutName + ".html");
     }
 
     private boolean hasPlugin(JsonNode config, String pluginName) {
@@ -405,12 +468,12 @@ public class JekyllConfigConverter {
 
     static String translatePermalinkPlaceholders(String permalink) {
         return permalink
-                .replace(":path", ":dir[1:]/:name")
+                .replace(":path", ":dir[1]/:name")
                 .replace(":title", ":name")
                 .replace(":categories", ":collection");
     }
 
-    private static final Set<String> SKIP_ESCAPE_COLLECTIONS = Set.of(DEFAULT_COLLECTION_NAME, "redirects");
+    private static final Set<String> SKIP_ESCAPE_COLLECTIONS = Set.of("redirects");
 
     private void addEscapedPages(JsonNode config, Properties properties) {
         if (config == null || !config.has(COLLECTIONS)) {
@@ -433,6 +496,157 @@ public class JekyllConfigConverter {
         if (!escaped.isEmpty()) {
             properties.setProperty("site.escaped-pages", escaped.toString());
         }
+    }
+
+    private void addIgnoredFiles(JsonNode config, Properties properties) {
+        String ignored = buildIgnoredFiles(config);
+        if (ignored != null) {
+            properties.setProperty("site.ignored-files", ignored);
+        }
+    }
+
+    String buildIgnoredFiles(JsonNode config) {
+        if (config == null || !config.has("exclude")) {
+            return null;
+        }
+        JsonNode exclude = config.get("exclude");
+        if (!exclude.isArray()) {
+            return null;
+        }
+        StringBuilder ignored = new StringBuilder();
+        for (JsonNode entry : exclude) {
+            String pattern = entry.asText();
+            if (pattern.startsWith("_")) {
+                pattern = pattern.substring(1);
+            }
+            if (!pattern.endsWith("/**") && !pattern.endsWith("/")) {
+                pattern = pattern + "/**";
+            }
+            if (!ignored.isEmpty()) {
+                ignored.append(",");
+            }
+            ignored.append(pattern);
+        }
+        return ignored.isEmpty() ? null : ignored.toString();
+    }
+
+    void convertOverlayConfigs(Path projectDir, Writer mainPropsWriter,
+            Map<String, JsonNode> configMappingsToGenerate, String configMappingPrefix) throws IOException {
+        List<Path> overlays;
+        try (Stream<Path> files = Files.list(projectDir)) {
+            overlays = files
+                    .filter(p -> {
+                        String name = p.getFileName().toString();
+                        return name.endsWith(".yml")
+                                && name.startsWith("_")
+                                && name.contains("config")
+                                && !name.equals("_config.yml");
+                    })
+                    .sorted()
+                    .toList();
+        }
+        Path configDir = projectDir.resolve("config");
+
+        for (Path overlay : overlays) {
+            JsonNode overlayConfig = yamlMapper.readTree(Files.readString(overlay));
+            String profile = deriveProfileName(overlay.getFileName().toString());
+
+            // Build properties for all config values
+            List<String> propertyLines = buildSiteConfigOverrides(overlayConfig, configMappingPrefix);
+
+            // Also handle ignored-files from exclude
+            String ignored = buildIgnoredFiles(overlayConfig);
+            if (ignored != null) {
+                propertyLines.add("site.ignored-files=" + ignored);
+            }
+
+            if (propertyLines.isEmpty()) {
+                Files.delete(overlay);
+                continue;
+            }
+
+            // Write properties with profile prefix if dev, otherwise to separate file
+            if ("dev".equals(profile)) {
+                for (String line : propertyLines) {
+                    mainPropsWriter.write("%" + profile + "." + line + "\n");
+                }
+            } else {
+                Path profileProps = configDir.resolve("application-" + profile + ".properties");
+                try (Writer writer = Files.newBufferedWriter(profileProps)) {
+                    for (String line : propertyLines) {
+                        writer.write(line + "\n");
+                    }
+                }
+            }
+
+            // Track config sections that need ConfigMappings (merge with main config sections)
+            overlayConfig.fieldNames().forEachRemaining(key -> {
+                if (!"exclude".equals(key) && overlayConfig.get(key).isObject()) {
+                    // Merge fields from both main and profile configs
+                    JsonNode existing = configMappingsToGenerate.get(key);
+                    if (existing != null && existing.isObject()) {
+                        // Merge the two objects - profile config adds to base config
+                        ((com.fasterxml.jackson.databind.node.ObjectNode) existing)
+                                .setAll((com.fasterxml.jackson.databind.node.ObjectNode) overlayConfig.get(key));
+                    } else {
+                        configMappingsToGenerate.put(key, overlayConfig.get(key));
+                    }
+                }
+            });
+
+            Files.delete(overlay);
+            System.out.println("  [CONFIG] Converted and deleted: " + overlay.getFileName());
+        }
+    }
+
+    List<String> buildSiteConfigOverrides(JsonNode config) {
+        return buildSiteConfigOverrides(config, "site");
+    }
+
+    List<String> buildSiteConfigOverrides(JsonNode config, String configMappingPrefix) {
+        List<String> lines = new java.util.ArrayList<>();
+        if (config == null) {
+            return lines;
+        }
+        config.fieldNames().forEachRemaining(key -> {
+            if ("exclude".equals(key)) {
+                return;
+            }
+            JsonNode value = config.get(key);
+            if (value.isObject()) {
+                // Object sections use the configMappingPrefix to avoid clashing
+                // with the Roq framework's site.* ConfigMapping
+                value.fields().forEachRemaining(field -> {
+                    if (field.getValue().isValueNode()) {
+                        // Keep kebab-case keys — SmallRye ConfigMapping expects them
+                        lines.add(configMappingPrefix + "." + key + "." + field.getKey()
+                                + "=" + field.getValue().asText());
+                    }
+                });
+            } else if (value.isValueNode()) {
+                lines.add("site." + key + "=" + value.asText());
+            }
+        });
+        return lines;
+    }
+
+    static String deriveProfileName(String filename) {
+        String name = filename;
+        if (name.startsWith("_")) {
+            name = name.substring(1);
+        }
+        if (name.endsWith(".yml")) {
+            name = name.substring(0, name.length() - 4);
+        }
+        name = name.replace("_config", "").replace("config_", "").replace("config", "");
+        if (name.startsWith("_")) {
+            name = name.substring(1);
+        }
+        if (name.endsWith("_")) {
+            name = name.substring(0, name.length() - 1);
+        }
+        name = name.replace('_', '-');
+        return name.isEmpty() ? "overlay" : name;
     }
 
     private void addAutoAuthorProperties(JsonNode config, Properties properties) {
@@ -532,5 +746,187 @@ public class JekyllConfigConverter {
             }
         }
         return sb.toString();
+    }
+
+    /**
+     * Generate ConfigMapping interfaces and CDI wrapper beans for config sections.
+     */
+    void generateConfigMappings(Path projectDir, String projectName, String configMappingPrefix,
+            Map<String, JsonNode> configSections)
+            throws IOException {
+
+        // Load Qute templates
+        Template configMappingTemplate = loadTemplate("ConfigMapping.java");
+        Template configBeanTemplate = loadTemplate("ConfigBean.java");
+
+        for (Map.Entry<String, JsonNode> entry : configSections.entrySet()) {
+            String sectionName = entry.getKey();
+            JsonNode sectionConfig = entry.getValue();
+
+            String packageName = projectName + "." + sectionName + ".config";
+            String packagePath = packageName.replace('.', '/');
+            Path javaDir = projectDir.resolve("src/main/java/" + packagePath);
+            Files.createDirectories(javaDir);
+
+            String interfaceName = capitalize(hyphenToCamelCase(sectionName)) + "Config";
+            String producerClassName = capitalize(hyphenToCamelCase(sectionName)) + "ConfigProducer";
+            String beanName = hyphenToCamelCase(sectionName) + "Config";
+
+            // Prepare properties for the template
+            List<Map<String, String>> properties = new java.util.ArrayList<>();
+            sectionConfig.fields().forEachRemaining(field -> {
+                String propertyName = hyphenToCamelCase(field.getKey());
+                String javaType = inferJavaType(field.getValue());
+                properties.add(Map.of(
+                        "javaType", javaType,
+                        "methodName", propertyName));
+            });
+
+            // Generate ConfigMapping interface with @TemplateData
+            String interfaceCode = configMappingTemplate
+                    .data("packageName", packageName)
+                    .data("configMappingPrefix", configMappingPrefix)
+                    .data("sectionName", sectionName)
+                    .data("interfaceName", interfaceName)
+                    .data("properties", properties)
+                    .render();
+
+            Files.writeString(javaDir.resolve(interfaceName + ".java"), interfaceCode);
+
+            // Generate CDI producer for template access
+            String producerCode = configBeanTemplate
+                    .data("packageName", packageName)
+                    .data("beanName", beanName)
+                    .data("className", producerClassName)
+                    .data("interfaceName", interfaceName)
+                    .render();
+
+            Files.writeString(javaDir.resolve(producerClassName + ".java"), producerCode);
+
+            System.out.println("  [CONFIG] Generated ConfigMapping: " + packageName + "." + interfaceName);
+            System.out.println("  [CONFIG] Generated CDI producer: " + packageName + "." + producerClassName);
+            System.out.println("  [CONFIG] Template access: {cdi:" + beanName + ".propertyName}");
+        }
+
+        // Generate beans.xml to enable CDI bean discovery for ConfigMapping classes.
+        // Only needed when we actually generated ConfigMapping classes.
+        // Quarkus normally uses Jandex to discover beans, but it doesn't automatically
+        // index application classes. beans.xml with bean-discovery-mode="all" tells
+        // CDI to discover all classes regardless of indexing.
+        if (!configSections.isEmpty()) {
+            Path metaInfDir = projectDir.resolve("src/main/resources/META-INF");
+            Files.createDirectories(metaInfDir);
+            Path beansXml = metaInfDir.resolve("beans.xml");
+            if (!Files.exists(beansXml)) {
+                String beansXmlContent = """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+                               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                               xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+                               version="4.0"
+                               bean-discovery-mode="all">
+                        </beans>
+                        """;
+                Files.writeString(beansXml, beansXmlContent);
+                System.out.println("  [CONFIG] Generated META-INF/beans.xml for CDI discovery");
+            }
+        }
+    }
+
+    private Template loadTemplate(String templateName) throws IOException {
+        String templateContent = new String(
+                getClass().getResourceAsStream("/templates/" + templateName).readAllBytes());
+        return quteEngine.parse(templateContent);
+    }
+
+    private String inferJavaType(JsonNode value) {
+        if (value.isInt()) {
+            return "int";
+        } else if (value.isBoolean()) {
+            return "boolean";
+        } else if (value.isDouble() || value.isFloat()) {
+            return "double";
+        } else {
+            return "String";
+        }
+    }
+
+    private String capitalize(String str) {
+        if (str == null || str.isEmpty()) {
+            return str;
+        }
+        return Character.toUpperCase(str.charAt(0)) + str.substring(1);
+    }
+
+    void addJandexPluginToPom(Path projectDir) throws IOException {
+        Path pomFile = projectDir.resolve("pom.xml");
+        if (!Files.exists(pomFile)) {
+            System.err.println("Warning: pom.xml not found, cannot add Jandex plugin");
+            return;
+        }
+
+        String pomContent = Files.readString(pomFile);
+
+        // Check if jandex plugin already exists
+        if (pomContent.contains("jandex-maven-plugin")) {
+            return;
+        }
+
+        // Find the </plugins> closing tag and insert the jandex plugin before it
+        String jandexPlugin = """
+                        <plugin>
+                            <groupId>io.smallrye</groupId>
+                            <artifactId>jandex-maven-plugin</artifactId>
+                            <version>3.2.2</version>
+                            <executions>
+                                <execution>
+                                    <id>make-index</id>
+                                    <phase>process-classes</phase>
+                                    <goals>
+                                        <goal>jandex</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                """;
+
+        // Insert before </plugins>
+        pomContent = pomContent.replace("    </plugins>", jandexPlugin + "    </plugins>");
+        Files.writeString(pomFile, pomContent);
+        System.out.println("  [CONFIG] Added Jandex Maven plugin to pom.xml for @ConfigMapping discovery");
+    }
+
+    private String deriveProjectName(Path projectDir, JsonNode config) throws IOException {
+        // Try to use the site title from config
+        if (config != null && config.has("title")) {
+            String title = config.get("title").asText();
+            // Convert title to a valid package name
+            String packageName = title
+                    .toLowerCase()
+                    .replaceAll("[^a-z0-9]+", "")
+                    .replaceAll("^[0-9]+", ""); // Remove leading digits
+            if (!packageName.isEmpty()) {
+                // Avoid io.quarkus namespace to prevent conflicts with Quarkus core packages
+                String fullPackage = "quarkus".equals(packageName) ? "io.quarkusio" : "io." + packageName;
+                System.out.println("  [CONFIG] Using package name from site title '" + title + "': " + fullPackage);
+                return fullPackage;
+            }
+        }
+
+        // Fall back to directory name
+        String dirName = projectDir.toRealPath().getFileName().toString()
+                .toLowerCase()
+                .replaceAll("[^a-z0-9]+", "")
+                .replaceAll("^[0-9]+", ""); // Remove leading digits
+
+        String fullPackage = "quarkusio".equals(dirName) ? "io.quarkusio" : "io." + dirName;
+        System.out.println("  [CONFIG] Using package name from directory '" + projectDir.getFileName() + "': "
+                + fullPackage);
+        return dirName.isEmpty() ? "io.site" : fullPackage;
+    }
+
+    static String configMappingPrefix(String projectName) {
+        // Strip the leading "io." to get a short prefix like "quarkusio"
+        return projectName.startsWith("io.") ? projectName.substring(3) : projectName;
     }
 }

--- a/migration/src/main/java/io/quarkus/tools/LiquidToQuteCommand.java
+++ b/migration/src/main/java/io/quarkus/tools/LiquidToQuteCommand.java
@@ -43,6 +43,10 @@ public class LiquidToQuteCommand implements Callable<Integer> {
     @Option(names = { "--partials" }, description = "Converting partials/includes (uses {page.content} instead of {#insert /})")
     private boolean partials;
 
+    @Option(names = {
+            "--config-mappings" }, split = ",", description = "ConfigMapping section names from _config.yml (e.g. search,analytics)")
+    private List<String> configMappings;
+
     private LiquidToQuteConverter converter = new LiquidToQuteConverter();
 
     public static void main(String... args) {
@@ -54,6 +58,9 @@ public class LiquidToQuteCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         converter = new LiquidToQuteConverter(extensionSyntax);
         converter.setConvertingPartials(partials);
+        if (configMappings != null && !configMappings.isEmpty()) {
+            converter.setConfigMappingSections(configMappings);
+        }
 
         if (!Files.exists(input)) {
             System.err.println("Error: Input path '" + input + "' does not exist");

--- a/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
@@ -18,6 +18,8 @@ public class LiquidToQuteConverter {
     private final List<String> conversionsApplied = new ArrayList<>();
     private final Map<String, String> splitDelimHoists = new HashMap<>();
     private boolean convertingPartials;
+    // Config that should be references from application.properties, not the data folder
+    private List<String> configMappingSections = List.of();
 
     public LiquidToQuteConverter() {
         this(true);
@@ -30,6 +32,10 @@ public class LiquidToQuteConverter {
 
     void setConvertingPartials(boolean convertingPartials) {
         this.convertingPartials = convertingPartials;
+    }
+
+    public void setConfigMappingSections(List<String> sections) {
+        this.configMappingSections = sections;
     }
 
     public String convert(String content) {
@@ -125,6 +131,11 @@ public class LiquidToQuteConverter {
 
         // Make site.tags lenient (needed until  (https://github.com/quarkiverse/quarkus-roq/issues/964 is fixed in a release)
         content = makeSiteTagsLenient(content);
+        content = collapseTagsCountExtractionPattern(content);
+
+        // Tags in frontmatter may be a YAML list or a comma-separated string.
+        // .asStrings handles both; .orEmpty only works for lists.
+        content = content.replace(".data.tags.orEmpty", ".data.tags.asStrings");
 
         // Liquid {{ }} never HTML-escapes; Qute {= } does. Append .raw for fidelity.
         content = appendRawToOutputExpressions(content);
@@ -261,14 +272,14 @@ public class LiquidToQuteConverter {
         content = content.replaceAll(
                 "'(/[^']*)'\\s*\\|\\s*relative_url", "'$1'");
         content = content.replaceAll(
-                "([a-zA-Z_][a-zA-Z0-9_.\\-]*)\\s*\\|\\s*relative_url", "'/'.concat($1)");
+                "([a-zA-Z_][a-zA-Z0-9_.\\-]*)\\s*\\|\\s*relative_url", "$1.prepend('/')");
         content = content.replaceAll("\\s*\\|\\s*absolute_url", "");
         return content;
     }
 
     private String convertConcatenationFilters(String content) {
-        // Append filter: "text" | append: variable | append: "more" -> "text".concat(variable).concat("more")
-        // Uses .concat() instead of + because Qute's {#let} doesn't support the + operator.
+        // Append filter: "text" | append: variable -> "text".append(variable)
+        // Uses Jekyll filters extension method append() for string concatenation
         Pattern appendPattern = Pattern.compile("([^|{]+?)((?:\\s*\\|\\s*append:\\s*[^|}%]+)+)");
         Matcher appendMatcher = appendPattern.matcher(content);
         StringBuilder appendSb = new StringBuilder();
@@ -282,7 +293,8 @@ public class LiquidToQuteConverter {
             StringBuilder concatenation = new StringBuilder(base);
 
             while (appendValueMatcher.find()) {
-                concatenation.append(".concat(").append(appendValueMatcher.group(1).trim()).append(")");
+                // Generate: base.append(value) instead of base.concat(value)
+                concatenation.append(".append(").append(appendValueMatcher.group(1).trim()).append(")");
             }
 
             String remaining = appends.replaceAll("\\|\\s*append:\\s*[^|]+", "").trim();
@@ -299,7 +311,7 @@ public class LiquidToQuteConverter {
 
         String result = appendSb.toString();
         if (!result.equals(content)) {
-            conversionsApplied.add("Converted append filter to .concat()");
+            conversionsApplied.add("Converted append filter to .append() method");
             content = result;
         }
 
@@ -363,8 +375,9 @@ public class LiquidToQuteConverter {
             }
 
             String base = content.substring(baseStart, baseEnd);
-            content = content.substring(0, baseStart) + value + ".concat(" + base + ")" + content.substring(m.end());
-            conversionsApplied.add("Converted prepend filter to .concat()");
+            // Generate: base.prepend(value) instead of value.concat(base)
+            content = content.substring(0, baseStart) + base + ".prepend(" + value + ")" + content.substring(m.end());
+            conversionsApplied.add("Converted prepend filter to .prepend() method");
         }
 
         return content;
@@ -1609,6 +1622,15 @@ public class LiquidToQuteConverter {
                     if (varRef.matcher(withoutForRebinds).find()) {
                         mutableVars.add(var);
                     }
+                    // An {% include %} after the scope may reference the variable
+                    // in the included file (Liquid assign is global; Qute {#let} is
+                    // block-scoped). We can't inspect the included file, so
+                    // conservatively treat the variable as mutable.
+                    // Use withoutForRebinds: if the variable is rebound by a for-loop,
+                    // includes inside that loop use the loop var, not the assigned one.
+                    if (withoutForRebinds.contains("{#include")) {
+                        mutableVars.add(var);
+                    }
                 }
             }
         }
@@ -1635,11 +1657,25 @@ public class LiquidToQuteConverter {
             content = sb.toString();
         }
 
-        // Step 2: Replace standalone references to mutable vars with _m.read('VAR')
+        // Step 2: Replace references to mutable vars with _m.read('VAR')
+        // Only replace inside Qute expression blocks {= }, {# }, {! } to avoid
+        // matching variable names that appear as literal text in HTML (e.g. "/author/")
         for (String var : mutableVars) {
-            content = content.replaceAll(
-                    "(?<![.\\w'\"])" + Pattern.quote(var) + "\\b(?!['\"])",
-                    "_m.read('" + var + "')");
+            String qVar = Pattern.quote(var);
+            // First, convert bracket notation obj[VAR] to obj.get(_m.read('VAR'))
+            // (only inside Qute blocks — bracket notation in HTML like arr[0] is fine)
+            content = replaceInQuteBlocks(content, "\\[" + qVar + "\\]",
+                    ".get(_m.read('" + var + "'))");
+            // Then replace standalone references, but NOT in {#for VAR in} position
+            Pattern refPattern = Pattern.compile(
+                    "(\\{#for\\s+)" + qVar + "(\\s+in\\b)" + // group 1+2: for-loop declaration
+                            "|(?<![.\\w'\"])" + qVar + "\\b(?!['\"])"); // standalone reference
+            content = replaceInQuteBlocksWithMatcher(content, refPattern, ref -> {
+                if (ref.group(1) != null) {
+                    return ref.group(1) + var + ref.group(2);
+                }
+                return "_m.read('" + var + "')";
+            });
         }
 
         // Step 3: Wrap with mutable-map initialisation (after front matter if present)
@@ -1655,6 +1691,66 @@ public class LiquidToQuteConverter {
             conversionsApplied.add("Converted mutable assigns to mut:map()");
         }
         return content;
+    }
+
+    /**
+     * Replace pattern matches only inside Qute expression blocks ({= }, {# }, {! }, {/ }).
+     * Literal HTML text between blocks is left unchanged.
+     */
+    private String replaceInQuteBlocks(String content, String regex, String replacement) {
+        return replaceInQuteBlocksWithMatcher(content,
+                Pattern.compile(regex),
+                m -> Matcher.quoteReplacement(replacement).equals(replacement)
+                        ? replacement
+                        : replacement);
+    }
+
+    private String replaceInQuteBlocksWithMatcher(String content, Pattern pattern,
+            java.util.function.Function<Matcher, String> replacer) {
+        StringBuilder result = new StringBuilder();
+        int pos = 0;
+        while (pos < content.length()) {
+            int blockStart = content.indexOf('{', pos);
+            if (blockStart < 0) {
+                result.append(content, pos, content.length());
+                break;
+            }
+            // Append literal text before this block
+            result.append(content, pos, blockStart);
+            // Find end of Qute block (matching })
+            int blockEnd = findMatchingBrace(content, blockStart);
+            if (blockEnd < 0) {
+                result.append(content, blockStart, content.length());
+                break;
+            }
+            blockEnd++;
+            // Replace within this block
+            String block = content.substring(blockStart, blockEnd);
+            Matcher m = pattern.matcher(block);
+            StringBuilder blockResult = new StringBuilder();
+            while (m.find()) {
+                m.appendReplacement(blockResult, Matcher.quoteReplacement(replacer.apply(m)));
+            }
+            m.appendTail(blockResult);
+            result.append(blockResult);
+            pos = blockEnd;
+        }
+        return result.toString();
+    }
+
+    private int findMatchingBrace(String content, int openPos) {
+        int depth = 0;
+        for (int i = openPos; i < content.length(); i++) {
+            char c = content.charAt(i);
+            if (c == '{')
+                depth++;
+            else if (c == '}') {
+                depth--;
+                if (depth == 0)
+                    return i;
+            }
+        }
+        return -1;
     }
 
     private int nestingDepth(String content, int position) {
@@ -2220,28 +2316,49 @@ public class LiquidToQuteConverter {
 
     private String convertSiteDataProperties(String content) {
         // Jekyll site.* properties that aren't part of Roq's Site model come from _config.yml.
-        // These are migrated to data/siteConfig.yml and accessed via cdi:siteConfig.*
+        // Some are migrated to ConfigMappings (search.*), others to data/siteConfig.yml
         // Note: Using "siteConfig" instead of "site" to avoid conflict with Roq's built-in Site object
         String knownSiteProps = "url|title|description|image|imageExists|data|pages|allPages|collections|" +
                 "index|files|file|fileExists|page|normalPage|document|imagesDirUrl|pageContent|" +
                 "posts|tags|time";
 
-        // Match site.prop and optionally .sub-prop chains (YAML keys may contain hyphens)
+        // Convert site.<section>.* to cdi:<section>Config.* for each ConfigMapping section
+        for (String section : configMappingSections) {
+            Pattern sectionPattern = Pattern.compile("\\bsite\\." + Pattern.quote(section) + "\\.([a-zA-Z][a-zA-Z0-9_-]*)");
+            StringBuilder sectionBuf = new StringBuilder();
+            Matcher sectionMatcher = sectionPattern.matcher(content);
+            boolean hasSectionConversion = false;
+            while (sectionMatcher.find()) {
+                String propName = sectionMatcher.group(1);
+                String camelCased = JekyllConfigConverter.hyphenToCamelCase(propName);
+                sectionMatcher.appendReplacement(sectionBuf, "cdi:" + section + "Config." + camelCased);
+                hasSectionConversion = true;
+            }
+            sectionMatcher.appendTail(sectionBuf);
+            content = sectionBuf.toString();
+            if (hasSectionConversion) {
+                conversionsApplied.add("Converted site." + section + " properties to ConfigMapping CDI references");
+            }
+        }
+
+        // Then, convert remaining site.* properties to cdi:siteConfig.*
+        String sectionExclusion = String.join("|", configMappingSections);
         Pattern pattern = Pattern.compile(
-                "\\bsite\\.((?!(?:" + knownSiteProps
+                "\\bsite\\.((?!(?:" + knownSiteProps + "|" + sectionExclusion
                         + ")\\b)[a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z][a-zA-Z0-9_]*(?:-[a-zA-Z][a-zA-Z0-9_]*)*)*)");
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         Matcher m = pattern.matcher(content);
+        boolean hasOtherConversion = false;
         while (m.find()) {
             String propChain = m.group(1);
-            // CamelCase any hyphenated segments so Qute dot notation works
             String camelCased = camelCasePropertyChain(propChain);
             m.appendReplacement(sb, "cdi:siteConfig." + camelCased);
+            hasOtherConversion = true;
         }
         m.appendTail(sb);
         String result = sb.toString();
 
-        if (!result.equals(content)) {
+        if (hasOtherConversion) {
             conversionsApplied.add("Converted site data properties to CDI references");
         }
 
@@ -2288,8 +2405,7 @@ public class LiquidToQuteConverter {
         // This applies to 'page' and page-like loop variables like 'post'
         String knownPageProps = "url|title|description|image|imageExists|date|data|content|contentAbstract|" +
                 "rawTemplate|sourcePath|sourceFileName|baseFileName|id|draft|files|file|fileExists|source|site|" +
-                "collectionId|collection|next|nextPage|previous|prev|previousPage|prevPage|hidden|paginator|" +
-                "tags|tagsCount";
+                "collectionId|collection|next|nextPage|previous|prev|previousPage|prevPage|hidden|paginator";
 
         // Match page.customField or post.customField (not *.data.*, *.url.*, or known properties)
         // and convert to *.data.customField
@@ -2361,8 +2477,11 @@ public class LiquidToQuteConverter {
 
     private String convertStandaloneSiteUrl(String content) {
         String original = content;
-        // Match site.url NOT followed by a dot (method call / property access)
-        content = content.replaceAll("\\bsite\\.url\\b(?!\\.)", "site.url.root.url");
+        // Match site.url NOT followed by a property access (but allow method calls like .append())
+        // Negative lookahead: (?!\.[a-zA-Z_]++(?!\()) means NOT followed by .identifier (unless it's a method call)
+        // This converts: site.url → site.url.root.url, site.url.append() → site.url.root.url.append()
+        // But NOT: site.url.someProperty → stays as site.url.someProperty
+        content = content.replaceAll("\\bsite\\.url\\b(?!\\.[a-zA-Z_]++(?!\\())", "site.url.root.url");
         if (!content.equals(original)) {
             conversionsApplied.add("Converted standalone site.url to site.url.root.url (Jekyll site.url is a base URL string)");
         }
@@ -2468,15 +2587,12 @@ public class LiquidToQuteConverter {
     }
 
     private String makeSiteTagsLenient(String content) {
-        // Jekyll's site.tags is auto-generated and doesn't exist in Roq by default.
-        // Replace with cdi:siteConfig.tags which is set to an empty list by the migration script.
+        // Jekyll's site.tags is auto-generated. Convert to Roq tagging plugin API:
+        // - site.tags.TAG-NAME → site.collections.get('posts/tag/TAG-NAME') (posts by tag)
+        // - site.tags → site.collections.get('posts').tagsCount (tag listing)
+        // Also fixes page.data.posts in tag layouts (with tagging: frontmatter)
 
-        Pattern pattern = Pattern.compile("\\bsite\\.tags\\b");
-        Matcher matcher = pattern.matcher(content);
-
-        if (!matcher.find()) {
-            return content; // No site.tags usage
-        }
+        boolean hasSiteTags = Pattern.compile("\\bsite\\.tags\\b").matcher(content).find();
 
         // Split frontmatter from template body
         String frontmatter = "";
@@ -2489,22 +2605,136 @@ public class LiquidToQuteConverter {
             body = content.substring(fmMatcher.end());
         }
 
-        // Add a warning comment at the start of the body
-        String warning = "\n{! TODO: site.tags not available in Roq by default.\n" +
-                "   The tag listing feature is currently disabled (replaced with cdi:siteConfig.tags=[]).\n" +
-                "   Options to restore functionality:\n" +
-                "   (1) Use collection.tagsCount() for a specific collection,\n" +
-                "   (2) Add a site.tags extension method, or\n" +
-                "   (3) Remove the tag listing feature entirely.\n" +
-                "   See migration implementation notes for details. !}\n";
+        boolean hasTaggingFrontmatter = frontmatter.contains("tagging:");
 
-        // Replace all site.tags with cdi:siteConfig.tags (which is an empty list)
-        body = pattern.matcher(body).replaceAll("cdi:siteConfig.tags");
+        if (!hasSiteTags && !hasTaggingFrontmatter) {
+            return content;
+        }
 
-        String result = frontmatter + warning + body;
+        if (hasSiteTags) {
+            // Step 1: site.tags.TAG-NAME → site.collections.get('posts/tag/TAG-NAME')
+            // Only match hyphenated names (tag names like user-story), not method names
+            // like .sort which were added by filter conversion
+            body = Pattern.compile("\\bsite\\.tags\\.([a-zA-Z][a-zA-Z0-9_]*-[a-zA-Z0-9_-]*)")
+                    .matcher(body).replaceAll("site.collections.get('posts/tag/$1')");
 
-        conversionsApplied.add("Replaced site.tags with cdi:siteConfig.tags (needs manual implementation)");
+            // Step 2: site.tags → site.collections.get('posts').tagsCount
+            body = Pattern.compile("\\bsite\\.tags\\b")
+                    .matcher(body).replaceAll("site.collections.get('posts').tagsCount");
 
-        return result;
+            // Step 2b: tagsCount.sort (argless) → tagsCount.sort('name')
+            // Liquid | sort on tag tuples sorted by first element; Roq TagCount needs explicit property
+            body = body.replace("tagsCount.sort", "tagsCount.sort('name')");
+
+            // Step 3: Fix .first/.last on tag iteration variables.
+            // Jekyll site.tags|sort returns [name, posts] tuples; Roq tagsCount returns TagCount(name, count).
+            // The tagsCount result may be assigned to a let variable then iterated:
+            //   {#let tag_words=...tagsCount...}{#for stats in tag_words...}
+            Matcher letMatcher = Pattern.compile("\\{#let (\\w+)=[^}]*tagsCount").matcher(body);
+            while (letMatcher.find()) {
+                String letVar = letMatcher.group(1);
+                Matcher forMatcher = Pattern.compile("\\{#for (\\w+) in " + Pattern.quote(letVar)).matcher(body);
+                if (forMatcher.find()) {
+                    String loopVar = forMatcher.group(1);
+                    body = body.replace(loopVar + ".first", loopVar + ".name");
+                    body = body.replace(loopVar + ".last", loopVar + ".count");
+                    body = body.replace(loopVar + ".get(0)", loopVar + ".name");
+                    body = body.replace(loopVar + ".get(1)", loopVar + ".count");
+                }
+            }
+            // Also handle direct iteration: {#for stats in ...tagsCount...}
+            Matcher directForMatcher = Pattern.compile("\\{#for (\\w+) in [^}]*tagsCount").matcher(body);
+            while (directForMatcher.find()) {
+                String loopVar = directForMatcher.group(1);
+                body = body.replace(loopVar + ".first", loopVar + ".name");
+                body = body.replace(loopVar + ".last", loopVar + ".count");
+                body = body.replace(loopVar + ".get(0)", loopVar + ".name");
+                body = body.replace(loopVar + ".get(1)", loopVar + ".count");
+            }
+
+            conversionsApplied.add("Converted site.tags to Roq tagging plugin API");
+        }
+
+        // Step 4: In tag layouts (with tagging: frontmatter), fix page.data.posts
+        if (hasTaggingFrontmatter) {
+            body = body.replace("page.data.posts", "site.collections.get(page.data.tagCollection)");
+        }
+
+        return frontmatter + body;
+    }
+
+    private String collapseTagsCountExtractionPattern(String content) {
+        // Detect the push/uniq pattern from quarkusio/quarkusio.github.io#2853:
+        //   {#let TAG_KEYS=str:split("", "")}
+        //   {#for STATS in ...tagsCount...}{#let TAG_KEYS=TAG_KEYS.push(STATS.name...)}{/let}{/for}
+        //   {#let TAG_WORDS=TAG_KEYS | uniq.sort}
+        // Collapse to:
+        //   {#let TAG_WORDS=...tagsCount.distinct.sort('name')}
+        //   {#for STATS in TAG_WORDS...}
+
+        String original = content;
+
+        while (true) {
+            Pattern pattern = Pattern.compile(
+                    "\\{#let (\\w+)=str:split\\(\"\", \"\"\\)\\}" +
+                            "\\s*\\{#for (\\w+) in ([^}]*tagsCount[^}]*)\\}" +
+                            "\\s*\\{#let \\1=\\1\\.push\\(\\2\\.name([^}]*)\\)\\}" +
+                            "\\s*\\{/let\\}\\{/for\\}" +
+                            "\\s*\\{#let (\\w+)=\\1(?:\\.distinct| \\| uniq)?(?:\\.sort)?\\}");
+
+            Matcher m = pattern.matcher(content);
+            if (!m.find()) {
+                break;
+            }
+
+            String loopVar = m.group(2); // stats
+            String tagsCountExpr = m.group(3); // site.collections.get('posts').tagsCount.orEmpty
+            String finalVar = m.group(5); // tag_words
+
+            String collectionExpr = tagsCountExpr.replaceFirst("\\.orEmpty$", "");
+
+            String replacement = "{#let " + finalVar + "=" + collectionExpr + ".distinct.sort('name')}";
+
+            content = content.substring(0, m.start()) + replacement + content.substring(m.end());
+
+            // Update the iteration loop: {#for TAG in TAG_WORDS...} → {#for STATS in TAG_WORDS...}
+            // and replace TAG references with STATS.name
+            Pattern iterPattern = Pattern.compile("\\{#for (\\w+) in " + Pattern.quote(finalVar) + "\\.orEmpty\\}");
+            Matcher iterMatcher = iterPattern.matcher(content);
+            if (iterMatcher.find(m.start())) {
+                String iterVar = iterMatcher.group(1); // tag
+                int iterStart = iterMatcher.start();
+
+                int iterBodyStart = iterMatcher.end();
+                int iterEnd = findMatchingEndFor(content, iterBodyStart);
+                String iterBody = content.substring(iterBodyStart, iterEnd);
+
+                String newIterBody = iterBody.replace("{=" + iterVar + ".", "{=" + loopVar + ".name.");
+                newIterBody = newIterBody.replace("{=" + iterVar + ".raw}", "{=" + loopVar + ".name.raw}");
+                newIterBody = newIterBody.replace("{=" + iterVar + "}", "{=" + loopVar + ".name}");
+
+                String newForLoop = "{#for " + loopVar + " in " + finalVar + ".orEmpty}" +
+                        newIterBody + "{/for}";
+
+                String afterFor = content.substring(iterEnd + "{/for}".length());
+
+                // Remove 2 {/let} closers that matched the collapsed {#let} opens.
+                // They may not be adjacent — HTML like </div> can sit between them.
+                for (int i = 0; i < 2; i++) {
+                    int idx = afterFor.indexOf("{/let}");
+                    if (idx >= 0) {
+                        afterFor = afterFor.substring(0, idx) + afterFor.substring(idx + "{/let}".length());
+                    }
+                }
+
+                content = content.substring(0, iterStart) + newForLoop + "{/let}" + afterFor;
+            }
+        }
+
+        if (!content.equals(original)) {
+            conversionsApplied.add("Collapsed tagsCount extraction to tagsCount.sort('name')");
+        }
+
+        return content;
     }
 }

--- a/migration/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
+++ b/migration/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
@@ -440,4 +440,20 @@ public class JekyllFiltersExtension {
         }
         return result;
     }
+
+    // Jekyll append filter: string concatenation
+    // {{ language.url | append: path }} → {=language.url.append(path)}
+    static String append(Object base, Object suffix) {
+        String baseStr = base != null ? base.toString() : "";
+        String suffixStr = suffix != null ? suffix.toString() : "";
+        return baseStr + suffixStr;
+    }
+
+    // Jekyll prepend filter: string concatenation (reversed)
+    // {{ path | prepend: language.url }} → {=path.prepend(language.url)}
+    static String prepend(Object suffix, Object prefix) {
+        String prefixStr = prefix != null ? prefix.toString() : "";
+        String suffixStr = suffix != null ? suffix.toString() : "";
+        return prefixStr + suffixStr;
+    }
 }

--- a/migration/src/main/resources/templates/ConfigBean.java
+++ b/migration/src/main/resources/templates/ConfigBean.java
@@ -1,0 +1,28 @@
+package {packageName};
+
+import io.quarkus.arc.Unremovable;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+@ApplicationScoped
+@Unremovable
+public class {className} {
+
+    @Inject
+    Instance<{interfaceName}> configInstance;
+
+    @Produces
+    @Named("{beanName}")
+    @Unremovable
+    public {interfaceName} produce{interfaceName}() {
+        for (Instance.Handle<{interfaceName}> handle : configInstance.handles()) {
+            if (handle.getBean().getQualifiers().stream().noneMatch(q -> q instanceof Named)) {
+                return handle.get();
+            }
+        }
+        throw new IllegalStateException("{interfaceName} not found");
+    }
+}

--- a/migration/src/main/resources/templates/ConfigMapping.java
+++ b/migration/src/main/resources/templates/ConfigMapping.java
@@ -1,0 +1,13 @@
+package {packageName};
+
+import io.quarkus.qute.TemplateData;
+import io.smallrye.config.ConfigMapping;
+
+@TemplateData
+@ConfigMapping(prefix = "{configMappingPrefix}.{sectionName}")
+public interface {interfaceName} {
+{#for property in properties}
+
+    {property.javaType} {property.methodName}();
+{/for}
+}

--- a/migration/src/test/java/io/quarkus/tools/ConfigMappingIntegrationTest.java
+++ b/migration/src/test/java/io/quarkus/tools/ConfigMappingIntegrationTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.tools;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Integration test to verify that generated ConfigMapping classes can be compiled
+ * and work correctly with Quarkus config system.
+ */
+public class ConfigMappingIntegrationTest {
+
+    @Test
+    void generatedConfigMappingCompiles(@TempDir Path tempDir) throws IOException {
+        // Setup: Create a minimal Jekyll config with search settings
+        String configYaml = """
+                title: Test Site
+                search:
+                  script-mode: cached
+                  host: https://search.example.com
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        // Run the converter
+        JekyllConfigConverter converter = new JekyllConfigConverter();
+        converter.convertProject(tempDir);
+
+        // Verify ConfigMapping files were generated
+        Path searchConfig = tempDir.resolve("src/main/java/io/testsite/search/config/SearchConfig.java");
+        assertTrue(Files.exists(searchConfig), "SearchConfig.java should be generated");
+
+        String configContent = Files.readString(searchConfig);
+        assertTrue(configContent.contains("@ConfigMapping(prefix = \"testsite.search\")"),
+                "Should have @ConfigMapping with project-derived prefix, not site.search");
+        assertTrue(configContent.contains("@TemplateData"), "Should have @TemplateData annotation");
+        assertTrue(configContent.contains("String scriptMode()"), "Should have scriptMode method");
+        assertTrue(configContent.contains("String host()"), "Should have host method");
+
+        // Verify producer was generated
+        Path producer = tempDir.resolve("src/main/java/io/testsite/search/config/SearchConfigProducer.java");
+        assertTrue(Files.exists(producer), "SearchConfigProducer.java should be generated");
+
+        String producerContent = Files.readString(producer);
+        assertTrue(producerContent.contains("@Produces"), "Should have @Produces annotation");
+        assertTrue(producerContent.contains("@Named(\"searchConfig\")"), "Should be named 'searchConfig'");
+
+        // Note: We can't actually test CDI injection here without a full Quarkus test harness
+        // but we can verify the files are syntactically correct and have the right annotations
+    }
+}

--- a/migration/src/test/java/io/quarkus/tools/JekyllConfigConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/JekyllConfigConverterTest.java
@@ -34,9 +34,9 @@ class JekyllConfigConverterTest {
         assertTrue(props.containsKey("site.date-format"));
         assertTrue(props.containsKey("quarkus.qute.strict-rendering"));
         assertTrue(props.containsKey("quarkus.qute.type-check-excludes"));
-        assertEquals("true", props.getProperty("quarkus.qute.alt-expr-syntax"));
-        assertEquals("yyyy-MM-dd['T'HH:mm:ss][X]", props.getProperty("site.date-format"));
-        assertEquals("false", props.getProperty("quarkus.qute.strict-rendering"));
+        assertTrue("true".equals(props.getProperty("quarkus.qute.alt-expr-syntax")));
+        assertTrue("yyyy-MM-dd['T'HH:mm:ss][X]".equals(props.getProperty("site.date-format")));
+        assertTrue("false".equals(props.getProperty("quarkus.qute.strict-rendering")));
         assertTrue(props.getProperty("quarkus.qute.type-check-excludes").contains("java.lang.Object.*"));
         assertTrue(props.getProperty("quarkus.qute.type-check-excludes")
                 .contains("io.quarkiverse.roq.frontmatter.runtime.model.Page.paginator"));
@@ -81,7 +81,8 @@ class JekyllConfigConverterTest {
         assertTrue(siteConfigYaml.contains("baseurl: \"/blog\""));
         assertTrue(siteConfigYaml.contains("language: \"en\""));
         assertTrue(siteConfigYaml.contains("twitter_username: \"johndoe\""));
-        assertTrue(siteConfigYaml.contains("tags: []"));
+        assertFalse(siteConfigYaml.contains("tags:"),
+                "siteConfig should not contain tags (handled by tagging plugin): " + siteConfigYaml);
     }
 
     @Test
@@ -101,14 +102,9 @@ class JekyllConfigConverterTest {
         String siteConfigYaml = converter.createSiteConfigYaml(configYaml, null);
 
         assertNotNull(siteConfigYaml);
-        assertTrue(siteConfigYaml.contains("search:"));
-        assertTrue(siteConfigYaml.contains("scriptMode: \"defer\""));
-        assertTrue(siteConfigYaml.contains("host: \"https://search.example.com\""));
-        assertTrue(siteConfigYaml.contains("scriptPath: \"/search.js\""));
-        assertTrue(siteConfigYaml.contains("cachedScriptFile: \"search-cached.js\""));
-        assertTrue(siteConfigYaml.contains("initialTimeout: 1500"));
-        assertTrue(siteConfigYaml.contains("moreTimeout: 2500"));
-        assertTrue(siteConfigYaml.contains("minChars: 2"));
+        // search should NOT be in siteConfig - it goes to ConfigMapping instead
+        assertFalse(siteConfigYaml.contains("search:"),
+                "search config should be handled by ConfigMapping, not siteConfig.yml");
     }
 
     @Test
@@ -223,6 +219,54 @@ class JekyllConfigConverterTest {
         String indexContent = Files.readString(tempDir.resolve("content/index.md"));
         assertTrue(indexContent.contains("description: \"Supersonic Subatomic Java\""),
                 "Index page in content/ should have description from _config.yml: " + indexContent);
+    }
+
+    @Test
+    void testConvertProjectAddsNameToIndexPage(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+        Files.writeString(tempDir.resolve("index.md"), """
+                ---
+                layout: index
+                ---
+                Hello
+                """);
+
+        converter.convertProject(tempDir);
+
+        String indexContent = Files.readString(tempDir.resolve("index.md"));
+        assertTrue(indexContent.contains("name: \"Test Site\""),
+                "Index page should have name from _config.yml title: " + indexContent);
+        assertTrue(indexContent.contains("simple-name: \"Test Site\""),
+                "Index page should have simple-name from _config.yml title: " + indexContent);
+    }
+
+    @Test
+    void testConvertProjectDoesNotOverwriteExistingName(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+        Files.writeString(tempDir.resolve("index.md"), """
+                ---
+                layout: index
+                name: My Custom Name
+                simple-name: MCN
+                ---
+                Hello
+                """);
+
+        converter.convertProject(tempDir);
+
+        String indexContent = Files.readString(tempDir.resolve("index.md"));
+        assertTrue(indexContent.contains("name: My Custom Name"),
+                "Existing name should not be overwritten: " + indexContent);
+        assertTrue(indexContent.contains("simple-name: MCN"),
+                "Existing simple-name should not be overwritten: " + indexContent);
+        assertFalse(indexContent.contains("name: \"Test Site\""),
+                "Should not add duplicate name: " + indexContent);
     }
 
     @Test
@@ -344,7 +388,7 @@ class JekyllConfigConverterTest {
         converter.convertProject(tempDir);
 
         String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
-        assertFalse(propsContent.contains("site.collections.author"));
+        assertTrue(!propsContent.contains("site.collections.author"));
     }
 
     @Test
@@ -387,9 +431,9 @@ class JekyllConfigConverterTest {
         converter.convertProject(tempDir);
 
         String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
-        assertFalse(propsContent.contains("site.collections.drafts"),
+        assertTrue(!propsContent.contains("site.collections.drafts"),
                 "Should not have drafts collection: " + propsContent);
-        assertFalse(propsContent.contains("site.collections.internal"),
+        assertTrue(!propsContent.contains("site.collections.internal"),
                 "Should not have internal collection: " + propsContent);
     }
 
@@ -408,7 +452,7 @@ class JekyllConfigConverterTest {
         converter.convertProject(tempDir);
 
         String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
-        assertFalse(propsContent.contains("site.collections.posts"),
+        assertTrue(!propsContent.contains("site.collections.posts"),
                 "Should not emit posts collection (Roq built-in): " + propsContent);
         assertTrue(propsContent.contains("site.collections.guides=true"),
                 "Should have guides collection: " + propsContent);
@@ -457,9 +501,9 @@ class JekyllConfigConverterTest {
                 "guides should be moved to content/guides");
         assertTrue(Files.exists(tempDir.resolve("content/versions/main/index.md")),
                 "versions should be moved to content/versions");
-        assertFalse(Files.exists(tempDir.resolve("_guides")),
+        assertTrue(!Files.exists(tempDir.resolve("_guides")),
                 "_guides should no longer exist");
-        assertFalse(Files.exists(tempDir.resolve("_versions")),
+        assertTrue(!Files.exists(tempDir.resolve("_versions")),
                 "_versions should no longer exist");
     }
 
@@ -547,8 +591,8 @@ class JekyllConfigConverterTest {
         String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
         assertTrue(propsContent.contains("site.collections.guides.link=/guides/:name"),
                 "Should translate guides permalink to link: " + propsContent);
-        assertTrue(propsContent.contains("site.collections.versions.link=/version/:dir[1:]/:name"),
-                "Should translate versions permalink to link with :dir[1:]/:name: " + propsContent);
+        assertTrue(propsContent.contains("site.collections.versions.link=/version/:dir[1]/:name"),
+                "Should translate versions permalink to link with :dir[1]/:name: " + propsContent);
     }
 
     @Test
@@ -680,16 +724,6 @@ class JekyllConfigConverterTest {
     }
 
     @Test
-    void testCnameWithWhitespace() throws IOException {
-        String configYaml = """
-                title: Test Site
-                """;
-        String siteConfigYaml = converter.createSiteConfigYaml(configYaml, "  example.com\n");
-        assertTrue(siteConfigYaml.contains("cname: \"example.com\""),
-                "CNAME should be trimmed: " + siteConfigYaml);
-    }
-
-    @Test
     void testUnsetsShowtitleToPreventDuplicateTitles() {
         Properties props = converter.createApplicationProperties();
         assertEquals("true", props.getProperty("quarkus.asciidoc.attributes.\"!showtitle\""),
@@ -739,6 +773,75 @@ class JekyllConfigConverterTest {
     }
 
     @Test
+    void testAddTaggingFrontmatterFromJekyllArchives(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                jekyll-archives:
+                  enabled:
+                    - tags
+                  layouts:
+                    tag: tag-archive
+                  permalinks:
+                    tag: '/blog/tag/:name/'
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+        Files.createDirectories(tempDir.resolve("_layouts"));
+        Files.writeString(tempDir.resolve("_layouts/tag-archive.html"), """
+                ---
+                layout: base
+                ---
+                <h1>{{ page.title }}</h1>
+                """);
+
+        converter.convertProject(tempDir);
+
+        String layoutContent = Files.readString(tempDir.resolve("_layouts/tag-archive.html"));
+        assertTrue(layoutContent.contains("tagging:"),
+                "Tag layout should have tagging frontmatter: " + layoutContent);
+        assertTrue(layoutContent.contains("collection: posts"),
+                "Tagging should target posts collection: " + layoutContent);
+        assertTrue(layoutContent.contains("link: /blog/tag/:tag/"),
+                "Tagging link should use :tag placeholder: " + layoutContent);
+    }
+
+    @Test
+    void testAddTaggingFrontmatterWithoutPermalink(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                jekyll-archives:
+                  enabled:
+                    - tags
+                  layouts:
+                    tag: my-tags
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+        Files.createDirectories(tempDir.resolve("_layouts"));
+        Files.writeString(tempDir.resolve("_layouts/my-tags.html"), """
+                ---
+                layout: base
+                ---
+                <h1>Tags</h1>
+                """);
+
+        converter.convertProject(tempDir);
+
+        String layoutContent = Files.readString(tempDir.resolve("_layouts/my-tags.html"));
+        assertTrue(layoutContent.contains("tagging: posts"),
+                "Without permalink, tagging should use simple form: " + layoutContent);
+    }
+
+    @Test
+    void testNoTaggingFrontmatterWithoutJekyllArchives(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+        // Should not fail — no jekyll-archives config, nothing to do
+    }
+
+    @Test
     void testComplexNestedConfig() throws IOException {
         String configYaml = """
                 title: Complex Site
@@ -763,7 +866,172 @@ class JekyllConfigConverterTest {
         assertTrue(siteConfigYaml.contains("language: \"en\""));
         assertTrue(siteConfigYaml.contains("twitter_username: \"johndoe\""));
         assertTrue(siteConfigYaml.contains("github_username: \"johndoe\""));
-        assertTrue(siteConfigYaml.contains("search:"));
-        assertTrue(siteConfigYaml.contains("scriptMode: \"defer\""));
+        // search should NOT be in siteConfig - it goes to ConfigMapping instead
+        assertFalse(siteConfigYaml.contains("search:"),
+                "search config should be handled by ConfigMapping, not siteConfig.yml");
+    }
+
+    @Test
+    void testExcludeGeneratesIgnoredFiles(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                exclude:
+                  - _versions/2.*
+                  - _versions/3.*
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertTrue(propsContent.contains("site.ignored-files=versions/2.*/**,versions/3.*/**"),
+                "Should have ignored-files property: " + propsContent);
+    }
+
+    @Test
+    void testExcludeStripsUnderscorePrefix(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                exclude:
+                  - _guides
+                  - _versions/4.*
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertTrue(propsContent.contains("site.ignored-files=guides/**,versions/4.*/**"),
+                "Should strip underscore prefix: " + propsContent);
+    }
+
+    @Test
+    void testExcludePreservesExistingGlobs(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                exclude:
+                  - vendor/bundle/
+                  - _versions/2.*
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertTrue(propsContent.contains("vendor/bundle/"),
+                "Should preserve trailing slash pattern: " + propsContent);
+        assertTrue(propsContent.contains("versions/2.*/**"),
+                "Should append /** to glob without suffix: " + propsContent);
+    }
+
+    @Test
+    void testNoExcludeNoIgnoredFiles(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertFalse(propsContent.contains("site.ignored-files"),
+                "Should not have ignored-files without exclude: " + propsContent);
+    }
+
+    @Test
+    void testExcludeNotInSiteConfig(@TempDir Path tempDir) throws IOException {
+        String configYaml = """
+                title: Test Site
+                exclude:
+                  - _versions/2.*
+                """;
+        Files.writeString(tempDir.resolve("_config.yml"), configYaml);
+
+        converter.convertProject(tempDir);
+
+        String siteConfigYaml = Files.readString(tempDir.resolve("data/siteConfig.yml"));
+        assertFalse(siteConfigYaml.contains("exclude"),
+                "exclude should not leak into siteConfig.yml: " + siteConfigYaml);
+    }
+
+    @Test
+    void testDeriveProfileName() {
+        assertEquals("only-latest-guides",
+                JekyllConfigConverter.deriveProfileName("_only_latest_guides_config.yml"));
+        assertEquals("noguides",
+                JekyllConfigConverter.deriveProfileName("_noguides_config.yml"));
+        assertEquals("dev",
+                JekyllConfigConverter.deriveProfileName("_config_dev.yml"));
+        assertEquals("overlay",
+                JekyllConfigConverter.deriveProfileName("_config.yml"));
+    }
+
+    @Test
+    void testOverlayConfigCreatesProfileAwareFiles(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("_config.yml"), "title: Test Site\n");
+        Files.writeString(tempDir.resolve("_only_latest_guides_config.yml"), """
+                exclude:
+                  - _versions/2.*
+                  - _versions/3.*
+                """);
+        Files.writeString(tempDir.resolve("_noguides_config.yml"), """
+                exclude:
+                  - _guides
+                  - _versions
+                """);
+
+        converter.convertProject(tempDir);
+
+        String noguides = Files.readString(
+                tempDir.resolve("config/application-noguides.properties"));
+        assertTrue(noguides.contains("site.ignored-files=guides/**,versions/**"),
+                "Should have noguides profile file: " + noguides);
+
+        String latestGuides = Files.readString(
+                tempDir.resolve("config/application-only-latest-guides.properties"));
+        assertTrue(latestGuides.contains(
+                "site.ignored-files=versions/2.*/**,versions/3.*/**"),
+                "Should have only-latest-guides profile file: " + latestGuides);
+
+        assertFalse(Files.exists(tempDir.resolve("_noguides_config.yml")),
+                "Original overlay should be deleted");
+        assertFalse(Files.exists(tempDir.resolve("_only_latest_guides_config.yml")),
+                "Original overlay should be deleted");
+    }
+
+    @Test
+    void testOverlayWithOnlySearchConfigIsDeletedNoProps(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("_config.yml"), "title: Test Site\n");
+        Files.writeString(tempDir.resolve("_config_dev.yml"), """
+                search:
+                  script-mode: direct
+                  host: https://search-dev.example.com
+                """);
+
+        converter.convertProject(tempDir);
+
+        String propsContent = Files.readString(tempDir.resolve("config/application.properties"));
+        assertTrue(propsContent.contains("%dev.testsite.search.script-mode=direct"),
+                "Search config should be in application.properties with %dev prefix");
+        assertTrue(propsContent.contains("%dev.testsite.search.host=https://search-dev.example.com"),
+                "Search config should include host with %dev prefix");
+        assertFalse(Files.exists(tempDir.resolve("_config_dev.yml")),
+                "Original overlay should be deleted");
+        // Verify ConfigMapping files were generated
+        assertTrue(Files.exists(tempDir.resolve("src/main/java/io/testsite/search/config/SearchConfig.java")),
+                "SearchConfig interface should be generated");
+        assertTrue(Files.exists(tempDir.resolve("src/main/java/io/testsite/search/config/SearchConfigProducer.java")),
+                "SearchConfigProducer should be generated");
+    }
+
+    @Test
+    void testEmptyOverlayIsSkipped(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("_config.yml"), "title: Test Site\n");
+        Files.writeString(tempDir.resolve("_config_empty.yml"), "# empty\n");
+
+        converter.convertProject(tempDir);
+
+        assertFalse(Files.exists(tempDir.resolve("config/application-empty.properties")),
+                "Empty overlay should not create profile file");
     }
 }

--- a/migration/src/test/java/io/quarkus/tools/LiquidToQuteConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/LiquidToQuteConverterTest.java
@@ -1,6 +1,11 @@
 package io.quarkus.tools;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -13,6 +18,7 @@ class LiquidToQuteConverterTest {
     @BeforeEach
     void setUp() {
         converter = new LiquidToQuteConverter();
+        converter.setConfigMappingSections(List.of("arbitrary"));
     }
 
     private void assertConverts(String input, String expected, String message) {
@@ -429,15 +435,15 @@ class LiquidToQuteConverterTest {
     @Test
     void testAppendFilter() {
         String input = "{{\"hello\" | append: \" world\"}}";
-        String expected = "{=\"hello\".concat(\" world\").raw}";
-        assertConverts(input, expected, "Append filter should convert to .concat()");
+        String expected = "{=\"hello\".append(\" world\").raw}";
+        assertConverts(input, expected, "Append filter should use .append() method");
     }
 
     @Test
     void testMultipleAppends() {
         String input = "{{\"a\" | append: \"b\" | append: \"c\"}}";
-        String expected = "{=\"a\".concat(\"b\").concat(\"c\").raw}";
-        assertConverts(input, expected, "Multiple appends should chain");
+        String expected = "{=\"a\".append(\"b\").append(\"c\").raw}";
+        assertConverts(input, expected, "Multiple appends should chain .append() calls");
     }
 
     @Test
@@ -558,9 +564,11 @@ class LiquidToQuteConverterTest {
 
     @Test
     void testAuthorFileLines36to38() {
-        String input = "      {% comment %} Build multi-author list for this post {% endcomment %}\n" +
-                "      {% assign authors_raw = post.author | default: \"\" | split: \",\" %}\n" +
-                "      {% assign authors_clean = \"\" | split: \"\" %}";
+        String input = """
+                      {% comment %} Build multi-author list for this post {% endcomment %}
+                      {% assign authors_raw = post.author | default: "" | split: "," %}
+                      {% assign authors_clean = "" | split: "" %}\
+                """;
 
         String expected = """
                       {!  Build multi-author list for this post  !}
@@ -623,11 +631,11 @@ class LiquidToQuteConverterTest {
     @Test
     void testPrependFilter() {
         // Liquid: {{ path | prepend: site.baseurl }}
-        // site.baseurl is removed (Roq has no baseurl concept), empty concat cleaned up
+        // site.baseurl is converted to '' (Roq has no baseurl concept)
         String input = "{{paginator.next_page_path | prepend: site.baseurl}}";
-        String expected = "{=page.paginator.next.raw}";
+        String expected = "{=page.paginator.next.prepend('').raw}";
         assertConverts(input, expected,
-                "Prepend with site.baseurl should simplify to just the expression");
+                "Prepend with site.baseurl should convert baseurl to '' and use .prepend() method");
     }
 
     @Test
@@ -1002,9 +1010,9 @@ class LiquidToQuteConverterTest {
     @Test
     void testReplaceRegexWithPrependChain() {
         String input = "{% assign x = page.url | replace_regex: '^/version/([^/]+)/.*', '\\1' | prepend: ' - ' %}";
-        String expected = "{#let x=' - '.concat(page.url.path.replaceAll('^/version/([^/]+)/.*', '$1'))}{/let}";
+        String expected = "{#let x=page.url.path.replaceAll('^/version/([^/]+)/.*', '$1').prepend(' - ')}{/let}";
         assertConverts(input, expected,
-                "replace_regex chained with prepend should produce valid method call");
+                "replace_regex chained with prepend should use .prepend() method");
     }
 
     @Test
@@ -1111,34 +1119,34 @@ class LiquidToQuteConverterTest {
 
     @Test
     void testSiteUrlNotConvertedWhenFollowedByMethodCall() {
-        String input = "{=site.url.resolve(page.url)}";
-        String expected = "{=site.url.resolve(page.url).raw}";
+        String input = "{=site.url.someMethod(page.url)}";
+        String expected = "{=site.url.root.url.someMethod(page.url).raw}";
         assertConverts(input, expected,
-                "site.url followed by .resolve() should not be double-converted");
+                "site.url followed by a method call should convert to .root.url (methods are allowed, only properties are excluded)");
     }
 
     @Test
     void testSiteHyphenatedPropertyConvertsToCamelCase() {
-        String input = "{=site.search.cached-script-file}";
-        String expected = "{=cdi:siteConfig.search.cachedScriptFile.raw}";
+        String input = "{=site.arbitrary.cached-script-file}";
+        String expected = "{=cdi:arbitraryConfig.cachedScriptFile.raw}";
         assertConverts(input, expected,
-                "Hyphenated site config keys should be camelCased for Qute dot notation");
+                "Hyphenated arbitrary config keys should convert to ConfigMapping with camelCase");
     }
 
     @Test
     void testSiteNestedHyphenatedChain() {
-        String input = "{% assign x = site.search.script-mode %}";
+        String input = "{% assign x = site.arbitrary.script-mode %}";
         String result = converter.convert(input);
-        assertTrue(result.contains("cdi:siteConfig.search.scriptMode"),
-                "Nested hyphenated keys should be camelCased: " + result);
+        assertTrue(result.contains("cdi:arbitraryConfig.scriptMode"),
+                "Nested hyphenated keys should convert to ConfigMapping with camelCase: " + result);
     }
 
     @Test
     void testSiteHyphenatedPropertyWithRelativeUrl() {
-        String input = "{% assign search_script_src = site.search.cached-script-file | relative_url %}";
+        String input = "{% assign arbitrary_script_src = site.arbitrary.cached-script-file | relative_url %}";
         String result = converter.convert(input);
-        assertTrue(result.contains("cdi:siteConfig.search.cachedScriptFile"),
-                "Hyphenated YAML key with relative_url filter should be camelCased: " + result);
+        assertTrue(result.contains("cdi:arbitraryConfig.cachedScriptFile"),
+                "Hyphenated arbitrary config key with relative_url filter should convert to ConfigMapping: " + result);
         assertFalse(result.contains("cachedScriptCdi"),
                 "CamelCase should not bleed into cdi: prefix: " + result);
     }
@@ -1169,42 +1177,42 @@ class LiquidToQuteConverterTest {
 
     @Test
     void testCustomFieldInConditional() {
-        String input = "{% if page.search_wc %}...{% endif %}";
-        String expected = "{#if page.data.search_wc}...{/if}";
+        String input = "{% if page.arbitrary_wc %}...{% endif %}";
+        String expected = "{#if page.data.arbitrary_wc}...{/if}";
         assertConverts(input, expected,
                 "Custom fields in conditionals should not get ?? (breaks JsonObject key lookup)");
     }
 
     @Test
-    void testSiteSearchConvertsToCdi() {
-        String input = "{{site.search.host}}";
-        String expected = "{=cdi:siteConfig.search.host.raw}";
+    void testSitearbitraryConvertsToCdi() {
+        String input = "{{site.arbitrary.host}}";
+        String expected = "{=cdi:arbitraryConfig.host.raw}";
         assertConverts(input, expected,
-                "site.search properties should convert to CDI reference");
+                "site.arbitrary properties should convert to ConfigMapping CDI reference");
     }
 
     @Test
-    void testSiteSearchScriptMode() {
-        String input = "{% if site.search.script-mode == 'direct' %}...{% endif %}";
-        String expected = "{#if cdi:siteConfig.search.scriptMode == 'direct'}...{/if}";
+    void testSitearbitraryScriptMode() {
+        String input = "{% if site.arbitrary.script-mode == 'direct' %}...{% endif %}";
+        String expected = "{#if cdi:arbitraryConfig.scriptMode == 'direct'}...{/if}";
         assertConverts(input, expected,
-                "site.search.script-mode should convert to camelCase CDI reference");
+                "site.arbitrary.script-mode should convert to camelCase ConfigMapping CDI reference");
     }
 
     @Test
     void testUrlConcatenationWithSiteUrl() {
         String input = "{{site.url | append: page.url}}";
-        String expected = "{=site.url.resolve(page.url).raw}";
+        String expected = "{=site.url.root.url.append(page.url).raw}";
         assertConverts(input, expected,
-                "URL concatenation should use .resolve() instead of +");
+                "URL concatenation should use .append() method");
     }
 
     @Test
     void testUrlConcatenationWithVariable() {
         String input = "{{canonical_url | prepend: site.url}}";
-        String expected = "{=site.url.resolve(canonical_url).raw}";
+        String expected = "{=canonical_url.prepend(site.url.root.url).raw}";
         assertConverts(input, expected,
-                "Prepending to URL should use .resolve()");
+                "Prepending URL should use .prepend() method");
     }
 
     @Test
@@ -1291,8 +1299,8 @@ class LiquidToQuteConverterTest {
     @Test
     void testRelativeUrlFilterWithVariable() {
         String input = "{{ page.url | relative_url }}";
-        String expected = "{='/'.concat(page.url).raw}";
-        assertConverts(input, expected, "relative_url filter on variable prepends /");
+        String expected = "{=page.url.prepend('/').raw}";
+        assertConverts(input, expected, "relative_url filter on variable should use .prepend() method");
     }
 
     @Test
@@ -1305,8 +1313,8 @@ class LiquidToQuteConverterTest {
     @Test
     void testPrependWithStringLiteral() {
         String input = "{{ '/assets/images/quarkus_card.png' | prepend: site.url }}";
-        String expected = "{=site.url.resolve('/assets/images/quarkus_card.png').raw}";
-        assertConverts(input, expected, "prepend with string literal containing slashes should work");
+        String expected = "{='/assets/images/quarkus_card.png'.prepend(site.url.root.url).raw}";
+        assertConverts(input, expected, "prepend with string literal should use .prepend() method");
     }
 
     @Test
@@ -1343,8 +1351,8 @@ class LiquidToQuteConverterTest {
     @Test
     void testForLoopPropertyIterableGetsOrEmpty() {
         String input = "{% for tag in post.tags %}{{ tag }}{% endfor %}";
-        String expected = "{#for tag in post.tags.orEmpty}{=tag.raw}{/for}";
-        assertConverts(input, expected, "Property-access iterable in for loop should get .orEmpty");
+        String expected = "{#for tag in post.data.tags.asStrings}{=tag.raw}{/for}";
+        assertConverts(input, expected, "Tags iterable should use .asStrings to handle both string and array values");
     }
 
     @Test
@@ -1491,14 +1499,15 @@ class LiquidToQuteConverterTest {
 
     @Test
     void testPushInNestedLoopCollapsedToMergeTypes() {
-        String input = "{% assign v_type = include.type %}\n" +
-                "{% assign values = \"\" | split: \",\" %}\n" +
-                "{% for source in index -%}\n" +
-                "    {% for item in source[1].types[v_type] -%}\n" +
-                "        {% assign values = values | push: item %}\n" +
-                "    {% endfor -%}\n" +
-                "{% endfor -%}\n" +
-                "{% assign values = values | sort: 'title' %}";
+        String input = """
+                {% assign v_type = include.type %}
+                {% assign values = "" | split: "," %}
+                {% for source in index -%}
+                    {% for item in source[1].types[v_type] -%}
+                        {% assign values = values | push: item %}
+                    {% endfor -%}
+                {% endfor -%}
+                {% assign values = values | sort: 'title' %}""";
         String result = converter.convert(input);
         assertTrue(result.contains("mergeTypes("),
                 "Nested push-in-loop with sort should collapse to mergeTypes(): " + result);
@@ -1558,6 +1567,21 @@ class LiquidToQuteConverterTest {
     }
 
     @Test
+    void testMutableAssignBeforeInclude() {
+        // Variable assigned inside a conditional, then an include appears after
+        // the scope. The include may reference the variable (Liquid assign is global)
+        // so the variable needs mutable treatment.
+        String input = "{% if mode %}{% assign arbitrary_script = host %}{% assign arbitrary_src = arbitrary_script %}{% endif %}"
+                +
+                "{% include head-csp.html %}";
+        String result = converter.convert(input);
+        assertTrue(result.contains("_m.assign('arbitrary_script',"),
+                "Assign before include should use mutable map: " + result);
+        assertTrue(result.contains("_m.assign('arbitrary_src',"),
+                "Second assign before include should use mutable map: " + result);
+    }
+
+    @Test
     void testSingleAssignStaysAsLet() {
         // Single assign, used only within scope — no mutable treatment needed
         String input = "{% assign x = \"hello\" %}\n{=x}\nmore";
@@ -1603,11 +1627,42 @@ class LiquidToQuteConverterTest {
     }
 
     @Test
+    void testMutableVarInBracketNotationUsesGet() {
+        // Qute bracket notation doesn't support method calls inside [],
+        // so obj[mutableVar] must become obj.get(_m.read('mutableVar'))
+        String input = "{% assign key = nil %}" +
+                "{#if cond}{% assign key = name %}{/if}" +
+                "{=data[key]}";
+        String result = converter.convert(input);
+        assertTrue(result.contains("data.get(_m.read('key'))"),
+                "Bracket notation with mutable var should use .get(): " + result);
+        assertFalse(result.contains("data[_m.read"),
+                "Should NOT use bracket notation with _m.read(): " + result);
+    }
+
+    @Test
+    void testMutableVarReplacementDoesNotAffectHtmlText() {
+        // Variable names in HTML text (like "/author/" in a URL path) should not be
+        // replaced with _m.read() — only references inside Qute expressions should.
+        String input = "{% assign author = nil %}" +
+                "{#if cond}{% assign author = data %}{/if}" +
+                "<a href=\"/author/{=key}\">{=author.name}</a>";
+        String result = converter.convert(input);
+        assertTrue(result.contains("/author/"),
+                "Literal '/author/' in HTML should NOT be replaced: " + result);
+        assertTrue(result.contains("_m.read('author').name"),
+                "Variable ref inside Qute expression should be replaced: " + result);
+    }
+
+    @Test
     void testMutableMapInitAfterFrontMatter() {
-        String input = "---\nlayout: base\n---\n" +
-                "{% assign active = false %}" +
-                "{#if cond}{% assign active = true %}{/if}" +
-                "{#if active}yes{/if}";
+        String input = """
+                ---
+                layout: base
+                ---
+                {% assign active = false %}\
+                {#if cond}{% assign active = true %}{/if}\
+                {#if active}yes{/if}""";
         String result = converter.convert(input);
         assertTrue(result.startsWith("---\nlayout: base\n---\n{#let _m=mut:map()}"),
                 "Mutable map init should come after front matter, not before: " + result);
@@ -1630,5 +1685,167 @@ class LiquidToQuteConverterTest {
                 "Variable rebound as for-loop var should not use mutable map: " + result);
         assertFalse(result.contains("_m.read"),
                 "Variable rebound as for-loop var should not use mutable map: " + result);
+    }
+
+    @Test
+    void testForLoopRebindingWithIncludeInsideLoop() {
+        // An {%include%} inside a for-loop that rebinds a variable should NOT trigger
+        // mutable treatment — the include sees the loop var, not the earlier assign.
+        String input = "{% for raw in list %}" +
+                "{% assign key = raw | strip %}" +
+                "{% endfor %}" +
+                "{% for key in clean %}" +
+                "{% include share.html %}" +
+                "{% endfor %}";
+        String result = converter.convert(input);
+        assertFalse(result.contains("_m.assign"),
+                "Include inside rebound for-loop should not trigger mutable: " + result);
+        assertFalse(result.contains("_m.read"),
+                "Include inside rebound for-loop should not trigger mutable: " + result);
+    }
+
+    @Test
+    void testSiteTagsByNameConvertsToCollectionGet() {
+        String input = "{% for post in site.tags.user-story %}{{ post.title }}{% endfor %}";
+        String result = converter.convert(input);
+        assertTrue(result.contains("site.collections.get('posts/tag/user-story')"),
+                "site.tags.TAGNAME should convert to site.collections.get('posts/tag/TAGNAME'): " + result);
+    }
+
+    @Test
+    void testSiteTagsListingConvertsToTagsCount() {
+        String input = "{% assign tag_words = site.tags | sort %}" +
+                "{% for stats in tag_words %}" +
+                "{% assign tag = stats | first %}" +
+                "{% assign posts = stats | last %}" +
+                "<a href=\"/tag/{{ tag }}\">{{ tag }}</a>" +
+                "{% endfor %}";
+        String result = converter.convert(input);
+        assertTrue(result.contains("tagsCount"),
+                "site.tags should convert to tagsCount: " + result);
+        assertTrue(result.contains("tagsCount.sort('name')"),
+                "tagsCount.sort should get explicit 'name' property argument: " + result);
+        assertTrue(result.contains("stats.name"),
+                "stats.first should convert to stats.name: " + result);
+        assertTrue(result.contains("stats.count"),
+                "stats.last should convert to stats.count: " + result);
+        assertFalse(result.contains("cdi:siteConfig.tags"),
+                "Should not use cdi:siteConfig.tags placeholder: " + result);
+    }
+
+    @Test
+    void testSiteTagsArrayIndexingConvertsToNameAndCount() {
+        String input = "{% for stats in site.tags %}" +
+                "{% assign tag_keys = tag_keys | push: stats[0] | downcase %}" +
+                "{% endfor %}";
+        String result = converter.convert(input);
+        assertTrue(result.contains("stats.name"),
+                "stats.get(0) should convert to stats.name for tagsCount iteration: " + result);
+        assertFalse(result.contains("stats.get(0)"),
+                "stats.get(0) should not remain after tagsCount conversion: " + result);
+    }
+
+    @Test
+    void testTagLayoutPagePostsConvertsToTagCollection() {
+        String input = "---\nlayout: base\ntagging: posts\n---\n{% for post in page.posts %}{{ post.title }}{% endfor %}";
+        String result = converter.convert(input);
+        assertTrue(result.contains("site.collections.get(page.data.tagCollection)"),
+                "page.data.posts in tag layout should convert to site.collections.get(page.data.tagCollection): " + result);
+    }
+
+    @Test
+    void testPagePostsWithoutTaggingFrontmatterUnchanged() {
+        String input = "{% for post in page.posts %}{{ post.title }}{% endfor %}";
+        String result = converter.convert(input);
+        assertTrue(result.contains("page.data.posts"),
+                "page.data.posts without tagging frontmatter should stay as page.data.posts: " + result);
+        assertFalse(result.contains("tagCollection"),
+                "Should not use tagCollection without tagging frontmatter: " + result);
+    }
+
+    @Test
+    void testSiteTagsWithBracketNotationConvertsToTagsCountSort() {
+        // Pattern from quarkusio/quarkusio.github.io#2853 (deduplicate by downcasing)
+        String input = "{% assign tag_keys = \"\" | split: \"\" %}" +
+                "{% for stats in site.tags %}" +
+                "{% assign tag_keys = tag_keys | push: stats[0] | downcase %}" +
+                "{% endfor %}" +
+                "{% assign tag_words = tag_keys | uniq | sort %}" +
+                "{% for tag in tag_words %}" +
+                "<a href=\"/tag/{{ tag }}\">{{ tag }}</a>" +
+                "{% endfor %}";
+        String result = converter.convert(input);
+        assertTrue(result.contains("tagsCount.distinct.sort('name')"),
+                "site.tags extraction pattern should convert to tagsCount.distinct.sort('name'): " + result);
+        assertTrue(result.contains("stats.name"),
+                "Loop should iterate over stats and use stats.name: " + result);
+        assertFalse(result.contains("stats.get(0)"),
+                "stats.get(0) should not appear (pattern collapsed): " + result);
+        assertTrue(result.contains(".distinct"),
+                ".distinct should be preserved from original pattern: " + result);
+        assertFalse(result.contains(".push("),
+                "push pattern should not appear in result: " + result);
+        assertTrue(result.contains("{#for stats in tag_words.orEmpty}"),
+                "Loop should iterate over stats variable: " + result);
+    }
+
+    @Test
+    void testAppendFilterSingleVariable() {
+        // Real example from quarkusio base.html hreflang
+        String input = "{{ language.url | append: path }}";
+        String expected = "{=language.url.append(path).raw}";
+        assertConverts(input, expected, "Append filter should use .append() method");
+    }
+
+    @Test
+    void testAppendFilterMultipleVariables() {
+        String input = "{{ base | append: middle | append: end }}";
+        String expected = "{=base.append(middle).append(end).raw}";
+        assertConverts(input, expected, "Multiple append filters should chain .append() calls");
+    }
+
+    @Test
+    void testAppendFilterWithLiteral() {
+        String input = "{{ path | append: \".html\" }}";
+        String expected = "{=path.append(\".html\").raw}";
+        assertConverts(input, expected, "Append with string literal should work");
+    }
+
+    @Test
+    void testPrependFilterWithVariable() {
+        // Real example from quarkusio base.html canonical URL
+        String input = "{{ canonical_url | prepend: site.url }}";
+        String expected = "{=canonical_url.prepend(site.url.root.url).raw}";
+        assertConverts(input, expected, "Prepend filter should use .prepend() method");
+    }
+
+    @Test
+    void testPrependFilterWithLiteral() {
+        String input = "{{ path | prepend: \"/blog\" }}";
+        String expected = "{=path.prepend(\"/blog\").raw}";
+        assertConverts(input, expected, "Prepend with string literal should work");
+    }
+
+    @Test
+    void testAppendAndPrependChained() {
+        // Note: When both prepend and append are used, append processes first (globally),
+        // so the prepend value argument gets append-converted if it has | append in it.
+        // This is a known edge case - real Jekyll templates rarely chain these filters.
+        String input = "{{ page | prepend: site.url | append: \".html\" }}";
+        String expected = "{=page.data.prepend(site.url.root.url.append(\".html\")).raw}";
+        assertConverts(input, expected,
+                "Append processes before prepend (both convert, but order matters); site.url converts to .root.url");
+    }
+
+    @Test
+    void testConcatNotGenerated() {
+        String input = "{{ a | append: b }}{{ c | prepend: d }}";
+        String result = converter.convert(input);
+        assertFalse(result.contains(".concat("),
+                "Should not generate .concat() method calls (Qute doesn't have .concat()): " + result);
+        assertTrue(result.contains(".append("),
+                "Should use .append() extension method: " + result);
+        assertTrue(result.contains(".prepend("),
+                "Should use .prepend() extension method: " + result);
     }
 }


### PR DESCRIPTION
This is a whopper, sorry. :( 

The headline feature here is conversion-time support for what's proposed in the discussion of in https://github.com/quarkiverse/quarkus-roq/issues/1083. The converter looks in the config files, and if any have _profile variants, it knows that config cannot be handled by something in data. So instead it converts that config to live in application.properties, and updates all the accesses to that data to use the different format. It also creates a config mapping and config bean to enable access from templates.

It also fixes https://github.com/quarkiverse/quarkus-roq/issues/1069, an SEO score regression. The cause was that the converter was creating lots of `concat()` in its qute when it saw liquid `|append`, but that method doesn't exist. I've gone back to `append`, but now it exists.

Finally, there are various bit of improvement: 
  - Better handling of mutable variables (variables used after their scope ends, see https://github.com/quarkiverse/quarkus-roq/pull/1101
  -  Smarter detection of variables that need MutableMap vs {#let}
  - New replaceInQuteBlocks() method to safely replace patterns only inside Qute expressions
  - Improved site.url conversion to allow method calls like .append() while blocking property access - this allows site.url.append(path) while still converting bare site.url to site.url.root.url, and fixes an SEO issue
  - Better handling of site.tags with .asStrings for flexibility. The asStrings method handles both yaml or a comma-separated string, but .orEmpty handled lists only
