### PR TITLE
Add converter to convert adoc links to xref

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/migration/asciidoc/AsciiDocLinkToXrefConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/migration/asciidoc/AsciiDocLinkToXrefConverter.java
@@ -1,0 +1,108 @@
+package io.quarkus.tools.migration.asciidoc;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * Converts AsciiDoc link: macros to xref: for cross-document references.
+ *
+ * In Jekyll, guides at _guides/foo.adoc used link:bar to reference sibling files.
+ * In Roq, guides render with directory-style URLs (/guides/foo/) so link:bar resolves
+ * relative to the page URL: /guides/foo/bar → 404.
+ *
+ * AsciiDoc's xref: cross-reference macro uses relfileprefix=../ and relfilesuffix=/
+ * to construct proper relative paths. Roq sets these attributes so xref:bar.adoc
+ * resolves to ../bar/ which works correctly at any nesting depth.
+ */
+public class AsciiDocLinkToXrefConverter {
+
+    // Match link:bare-filename with optional anchor and link text
+    // Group 1: filename (lowercase letters, numbers, hyphens - NO slashes or dots)
+    // Group 2: #anchor (optional)
+    // Group 3: [link text] (optional)
+    // Negative lookahead BEFORE capture: don't match if filename is http or https (URL scheme)
+    // Positive lookahead AFTER filename: must be followed by # or [ or end of string (no / or .)
+    private static final Pattern LINK_PATTERN = Pattern.compile(
+            "link:(?!https?:)([a-z][a-z0-9-]+)(?=[#\\[\\s]|$)(#[a-z0-9_-]+)?(\\[[^\\]]*\\])?");
+
+    /**
+     * Convert link: to xref: in all .adoc and .asciidoc files under contentDir.
+     * Skips URLs (link:http://..., link:https://...) and only converts bare filenames.
+     */
+    public void convertProject(Path contentDir) throws IOException {
+        if (!Files.isDirectory(contentDir)) {
+            return;
+        }
+
+        try (Stream<Path> paths = Files.walk(contentDir)
+                .onClose(() -> {
+                }) // swallow close exceptions
+                .filter(p -> {
+                    try {
+                        return Files.isRegularFile(p);
+                    } catch (Exception e) {
+                        return false; // skip files we can't access
+                    }
+                })) {
+            paths.filter(p -> {
+                String name = p.getFileName().toString();
+                return name.endsWith(".adoc") || name.endsWith(".asciidoc");
+            })
+                    .forEach(this::convertFile);
+        } catch (Exception e) {
+            // Files.walk can throw on permission errors; ignore them
+            if (e.getCause() instanceof java.nio.file.AccessDeniedException) {
+                System.err.println("  Warning: skipped some files due to permissions");
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    private void convertFile(Path file) {
+        try {
+            String content = Files.readString(file);
+            String converted = convertLinks(content);
+
+            if (!content.equals(converted)) {
+                Files.writeString(file, converted);
+                System.out.println("  Converted: " + file);
+            }
+        } catch (IOException e) {
+            System.err.println("  Error converting " + file + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Convert link: macros to xref: in the given content.
+     *
+     * Converts: link:guide-name → xref:guide-name.adoc
+     * Converts: link:guide-name#anchor → xref:guide-name.adoc#anchor
+     * Converts: link:guide-name[text] → xref:guide-name.adoc[text]
+     * Converts: link:guide-name#anchor[text] → xref:guide-name.adoc#anchor[text]
+     *
+     * Skips: link:https://... (URLs preserved)
+     * Skips: link:http://... (URLs preserved)
+     */
+    String convertLinks(String content) {
+        Matcher matcher = LINK_PATTERN.matcher(content);
+        StringBuffer sb = new StringBuffer();
+
+        while (matcher.find()) {
+            String filename = matcher.group(1);
+            String anchor = matcher.group(2) != null ? matcher.group(2) : "";
+            String linkText = matcher.group(3) != null ? matcher.group(3) : "";
+
+            // Convert to xref:filename.adoc#anchor[text]
+            String replacement = "xref:" + filename + ".adoc" + anchor + linkText;
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(sb);
+
+        return sb.toString();
+    }
+}

--- a/migration/src/main/java/io/quarkus/tools/migration/command/AsciiDocLinkToXrefCommand.java
+++ b/migration/src/main/java/io/quarkus/tools/migration/command/AsciiDocLinkToXrefCommand.java
@@ -1,0 +1,51 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS info.picocli:picocli:4.7.5
+
+package io.quarkus.tools.migration.command;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+import io.quarkus.tools.migration.asciidoc.AsciiDocLinkToXrefConverter;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "asciidoc-link-to-xref", mixinStandardHelpOptions = true, version = "1.0", description = "Converts AsciiDoc link: macros to xref: for cross-document references")
+public class AsciiDocLinkToXrefCommand implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "Content directory (e.g., content/)")
+    private Path contentDir;
+
+    private AsciiDocLinkToXrefConverter converter = new AsciiDocLinkToXrefConverter();
+
+    public static void main(String... args) {
+        int exitCode = new CommandLine(new AsciiDocLinkToXrefCommand()).execute(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        if (!Files.exists(contentDir)) {
+            System.err.println("Error: Content directory '" + contentDir + "' does not exist");
+            return 1;
+        }
+
+        if (!Files.isDirectory(contentDir)) {
+            System.err.println("Error: '" + contentDir + "' is not a directory");
+            return 1;
+        }
+
+        try {
+            System.out.println("Converting link: to xref: for cross-document references...");
+            converter.convertProject(contentDir);
+            System.out.println("✓ Link conversion complete");
+            return 0;
+        } catch (Exception e) {
+            System.err.println("✗ Error converting links: " + e.getMessage());
+            e.printStackTrace();
+            return 1;
+        }
+    }
+}

--- a/migration/src/test/java/io/quarkus/tools/migration/asciidoc/AsciiDocLinkToXrefConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/migration/asciidoc/AsciiDocLinkToXrefConverterTest.java
@@ -1,0 +1,111 @@
+package io.quarkus.tools.migration.asciidoc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class AsciiDocLinkToXrefConverterTest {
+
+    private final AsciiDocLinkToXrefConverter converter = new AsciiDocLinkToXrefConverter();
+
+    @Test
+    public void testConvertBareLink() {
+        String input = "See the link:getting-started-testing for details.";
+        String expected = "See the xref:getting-started-testing.adoc for details.";
+        assertEquals(expected, converter.convertLinks(input));
+    }
+
+    @Test
+    public void testConvertLinkWithAnchor() {
+        String input = "See link:getting-started-testing#quarkus-integration-test for details.";
+        String expected = "See xref:getting-started-testing.adoc#quarkus-integration-test for details.";
+        assertEquals(expected, converter.convertLinks(input));
+    }
+
+    @Test
+    public void testConvertLinkWithText() {
+        String input = "See link:getting-started-testing[Testing Guide] for details.";
+        String expected = "See xref:getting-started-testing.adoc[Testing Guide] for details.";
+        assertEquals(expected, converter.convertLinks(input));
+    }
+
+    @Test
+    public void testConvertLinkWithAnchorAndText() {
+        String input = "Details in the link:getting-started-testing#quarkus-integration-test[Testing Guide].";
+        String expected = "Details in the xref:getting-started-testing.adoc#quarkus-integration-test[Testing Guide].";
+        assertEquals(expected, converter.convertLinks(input));
+    }
+
+    @Test
+    public void testPreserveHttpsUrls() {
+        String input = "See link:https://example.com[example site].";
+        String expected = "See link:https://example.com[example site].";
+        assertEquals(expected, converter.convertLinks(input));
+    }
+
+    @Test
+    public void testPreserveHttpUrls() {
+        String input = "See link:http://test.com/path[test].";
+        String expected = "See link:http://test.com/path[test].";
+        assertEquals(expected, converter.convertLinks(input));
+    }
+
+    @Test
+    public void testMixedLinks() {
+        String input = "This guide explains testing. More details in the link:getting-started-testing#quarkus-integration-test[Testing Guide].\n\n"
+                +
+                "See also:\n" +
+                "- link:building-native-image for native builds\n" +
+                "- link:building-native-image#build-modes[different build modes]\n" +
+                "- External link: link:https://example.com[example]\n" +
+                "- Another URL: link:http://test.com/path[test]";
+
+        String expected = "This guide explains testing. More details in the xref:getting-started-testing.adoc#quarkus-integration-test[Testing Guide].\n\n"
+                +
+                "See also:\n" +
+                "- xref:building-native-image.adoc for native builds\n" +
+                "- xref:building-native-image.adoc#build-modes[different build modes]\n" +
+                "- External link: link:https://example.com[example]\n" +
+                "- Another URL: link:http://test.com/path[test]";
+
+        assertEquals(expected, converter.convertLinks(input));
+    }
+
+    @Test
+    public void testRealWorldExample() {
+        // This was the actual failing case from the migration
+        String input = "Producing a native executable can lead to a few issues, and so it's also a good idea to run some tests against the application running in the native file. "
+                +
+                "The reasoning is explained in the link:getting-started-testing#quarkus-integration-test[Testing Guide].";
+
+        String expected = "Producing a native executable can lead to a few issues, and so it's also a good idea to run some tests against the application running in the native file. "
+                +
+                "The reasoning is explained in the xref:getting-started-testing.adoc#quarkus-integration-test[Testing Guide].";
+
+        assertEquals(expected, converter.convertLinks(input));
+    }
+
+    @Test
+    public void testDoesNotConvertPathsWithSlashes() {
+        // Static files or paths with / should not be converted
+        String input = "Download link:assets/mallocstacks.py[mallocstacks.py] script.";
+        String expected = "Download link:assets/mallocstacks.py[mallocstacks.py] script.";
+        assertEquals(expected, converter.convertLinks(input));
+    }
+
+    @Test
+    public void testDoesNotConvertFilesWithExtensions() {
+        // Files that already have extensions should not be converted
+        String input = "See link:example.pdf[PDF guide] for details.";
+        String expected = "See link:example.pdf[PDF guide] for details.";
+        assertEquals(expected, converter.convertLinks(input));
+    }
+
+    @Test
+    public void testDoesNotConvertRelativePaths() {
+        // Relative paths with ./ should not be converted
+        String input = "Check link:./other-guide[other guide] here.";
+        String expected = "Check link:./other-guide[other guide] here.";
+        assertEquals(expected, converter.convertLinks(input));
+    }
+}


### PR DESCRIPTION
In adoc, it's preferred to use `xref:` instead of `link:` for internal cross-references. In Jekyll, `link:` still works, but in Roq, it does not. This converter is a lot of code for a small problem, but it finds the problem `link:` elements and converts them.