### PR TITLE
Handle references to files with parentheses in the name in conversion to avoid 404

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/ParenthesisFileRenamer.java
+++ b/migration/src/main/java/io/quarkus/tools/ParenthesisFileRenamer.java
@@ -1,0 +1,76 @@
+package io.quarkus.tools;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Renames files with parentheses under a directory and updates HTML references.
+ * <p>
+ * Roq's static file handler silently renames files with parentheses
+ * (e.g. {@code content(1)} becomes {@code content-1}) during the build, but does not
+ * update HTML references, so images 404 at runtime.
+ * <p>
+ * This class fixes the source files before the build: it renames files to replace
+ * parentheses with dashes and updates all {@code .html} files in the same tree.
+ */
+public class ParenthesisFileRenamer {
+
+    private static final Pattern PAREN_REFERENCE = Pattern.compile("([a-zA-Z0-9_-]+)\\((\\d+)\\)");
+
+    public record Result(int filesRenamed, int htmlFilesUpdated) {
+    }
+
+    public Result rename(Path directory) throws IOException {
+        if (!Files.isDirectory(directory)) {
+            return new Result(0, 0);
+        }
+
+        // Pass 1: find and rename files with parentheses
+        List<Path> htmlFiles = new ArrayList<>();
+        Map<Path, String> renames = new HashMap<>();
+
+        Files.walkFileTree(directory, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                String name = file.getFileName().toString();
+                if (name.endsWith(".html")) {
+                    htmlFiles.add(file);
+                }
+                if (name.contains("(")) {
+                    String newName = name.replace('(', '-').replace(")", "");
+                    renames.put(file, newName);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        for (Map.Entry<Path, String> entry : renames.entrySet()) {
+            Path source = entry.getKey();
+            Path target = source.resolveSibling(entry.getValue());
+            Files.move(source, target);
+        }
+
+        // Pass 2: update references in HTML files
+        int updatedCount = 0;
+        for (Path html : htmlFiles) {
+            String content = Files.readString(html, StandardCharsets.UTF_8);
+            String updated = PAREN_REFERENCE.matcher(content).replaceAll("$1-$2");
+            if (!updated.equals(content)) {
+                Files.writeString(html, updated, StandardCharsets.UTF_8);
+                updatedCount++;
+            }
+        }
+
+        return new Result(renames.size(), updatedCount);
+    }
+}

--- a/migration/src/main/java/io/quarkus/tools/ParenthesisFileRenamer.java
+++ b/migration/src/main/java/io/quarkus/tools/ParenthesisFileRenamer.java
@@ -2,6 +2,7 @@ package io.quarkus.tools;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -11,6 +12,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -25,7 +27,7 @@ import java.util.regex.Pattern;
  */
 public class ParenthesisFileRenamer {
 
-    private static final Pattern PAREN_REFERENCE = Pattern.compile("([a-zA-Z0-9_-]+)\\((\\d+)\\)");
+    private static final Pattern ATTR_PATTERN = Pattern.compile("(?i)\\b(src|href|srcset)\\s*=\\s*(\"([^\"]*)\"|'([^']*)')");
 
     public record Result(int filesRenamed, int htmlFilesUpdated) {
     }
@@ -35,9 +37,10 @@ public class ParenthesisFileRenamer {
             return new Result(0, 0);
         }
 
-        // Pass 1: find and rename files with parentheses
+        // Pass 1: find and collect files with parentheses and HTML files
         List<Path> htmlFiles = new ArrayList<>();
         Map<Path, String> renames = new HashMap<>();
+        Map<String, String> renamedFileNames = new HashMap<>();
 
         Files.walkFileTree(directory, new SimpleFileVisitor<>() {
             @Override
@@ -46,13 +49,24 @@ public class ParenthesisFileRenamer {
                 if (name.endsWith(".html")) {
                     htmlFiles.add(file);
                 }
-                if (name.contains("(")) {
+                if (name.contains("(") || name.contains(")")) {
                     String newName = name.replace('(', '-').replace(")", "");
                     renames.put(file, newName);
+                    renamedFileNames.put(name, newName);
                 }
                 return FileVisitResult.CONTINUE;
             }
         });
+
+        // Pre-check for collision risks before performing moves
+        for (Map.Entry<Path, String> entry : renames.entrySet()) {
+            Path source = entry.getKey();
+            Path target = source.resolveSibling(entry.getValue());
+            if (Files.exists(target) && !renames.containsKey(target)) {
+                throw new FileAlreadyExistsException(
+                        "Cannot rename '" + source + "' to '" + target + "' because target file already exists");
+            }
+        }
 
         for (Map.Entry<Path, String> entry : renames.entrySet()) {
             Path source = entry.getKey();
@@ -60,17 +74,39 @@ public class ParenthesisFileRenamer {
             Files.move(source, target);
         }
 
-        // Pass 2: update references in HTML files
+        // Pass 2: update references in HTML files scoped to src, href, and srcset attributes
         int updatedCount = 0;
-        for (Path html : htmlFiles) {
-            String content = Files.readString(html, StandardCharsets.UTF_8);
-            String updated = PAREN_REFERENCE.matcher(content).replaceAll("$1-$2");
-            if (!updated.equals(content)) {
-                Files.writeString(html, updated, StandardCharsets.UTF_8);
-                updatedCount++;
+        if (!renamedFileNames.isEmpty()) {
+            for (Path html : htmlFiles) {
+                String content = Files.readString(html, StandardCharsets.UTF_8);
+                String updated = updateAttributeReferences(content, renamedFileNames);
+                if (!updated.equals(content)) {
+                    Files.writeString(html, updated, StandardCharsets.UTF_8);
+                    updatedCount++;
+                }
             }
         }
 
         return new Result(renames.size(), updatedCount);
+    }
+
+    private String updateAttributeReferences(String content, Map<String, String> renamedFileNames) {
+        Matcher matcher = ATTR_PATTERN.matcher(content);
+        StringBuilder sb = new StringBuilder();
+        while (matcher.find()) {
+            String attrName = matcher.group(1);
+            String quote = matcher.group(3) != null ? "\"" : "'";
+            String attrValue = matcher.group(3) != null ? matcher.group(3) : matcher.group(4);
+
+            String updatedValue = attrValue;
+            for (Map.Entry<String, String> entry : renamedFileNames.entrySet()) {
+                updatedValue = updatedValue.replace(entry.getKey(), entry.getValue());
+            }
+
+            String replacement = attrName + "=" + quote + updatedValue + quote;
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
     }
 }

--- a/migration/src/main/java/io/quarkus/tools/ParenthesisFileRenamer.java
+++ b/migration/src/main/java/io/quarkus/tools/ParenthesisFileRenamer.java
@@ -10,8 +10,10 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -38,40 +40,68 @@ public class ParenthesisFileRenamer {
         }
 
         // Pass 1: find and collect files with parentheses and HTML files
+        // HTML files are tracked by their eventual (post-rename) path so they remain readable
+        // even when the HTML file itself has parentheses in its name.
         List<Path> htmlFiles = new ArrayList<>();
-        Map<Path, String> renames = new HashMap<>();
-        Map<String, String> renamedFileNames = new HashMap<>();
+        Map<Path, Path> renames = new HashMap<>(); // source -> target (absolute paths)
+        Map<String, String> renamedFileNames = new HashMap<>(); // oldName -> newName (for HTML reference updates)
 
         Files.walkFileTree(directory, new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                 String name = file.getFileName().toString();
-                if (name.endsWith(".html")) {
-                    htmlFiles.add(file);
-                }
-                if (name.contains("(") || name.contains(")")) {
+                boolean hasParens = name.contains("(") || name.contains(")");
+                if (hasParens) {
                     String newName = name.replace('(', '-').replace(")", "");
-                    renames.put(file, newName);
+                    Path target = file.resolveSibling(newName);
+                    renames.put(file, target);
                     renamedFileNames.put(name, newName);
+                    // If the HTML file itself is being renamed, track its future path
+                    if (name.endsWith(".html")) {
+                        htmlFiles.add(target);
+                    }
+                } else if (name.endsWith(".html")) {
+                    htmlFiles.add(file);
                 }
                 return FileVisitResult.CONTINUE;
             }
         });
 
-        // Pre-check for collision risks before performing moves
-        for (Map.Entry<Path, String> entry : renames.entrySet()) {
-            Path source = entry.getKey();
-            Path target = source.resolveSibling(entry.getValue());
+        // Pre-check for collision risks before performing any moves:
+        // 1. Two different sources rename to the same target
+        // 2. A target already exists as a non-renamed file
+        Set<Path> targets = new HashSet<>();
+        for (Map.Entry<Path, Path> entry : renames.entrySet()) {
+            Path target = entry.getValue();
+            if (!targets.add(target)) {
+                throw new FileAlreadyExistsException(
+                        "Cannot rename '" + entry.getKey() + "' to '" + target
+                                + "' because another source file renames to the same target");
+            }
             if (Files.exists(target) && !renames.containsKey(target)) {
                 throw new FileAlreadyExistsException(
-                        "Cannot rename '" + source + "' to '" + target + "' because target file already exists");
+                        "Cannot rename '" + entry.getKey() + "' to '" + target
+                                + "' because target file already exists");
             }
         }
 
-        for (Map.Entry<Path, String> entry : renames.entrySet()) {
-            Path source = entry.getKey();
-            Path target = source.resolveSibling(entry.getValue());
-            Files.move(source, target);
+        // Perform renames; on failure, roll back already-completed moves
+        List<Path[]> completed = new ArrayList<>();
+        try {
+            for (Map.Entry<Path, Path> entry : renames.entrySet()) {
+                Files.move(entry.getKey(), entry.getValue());
+                completed.add(new Path[] { entry.getKey(), entry.getValue() });
+            }
+        } catch (IOException e) {
+            // Best-effort rollback of completed renames
+            for (int i = completed.size() - 1; i >= 0; i--) {
+                try {
+                    Files.move(completed.get(i)[1], completed.get(i)[0]);
+                } catch (IOException ignored) {
+                    // Rollback is best-effort; original exception is more important
+                }
+            }
+            throw e;
         }
 
         // Pass 2: update references in HTML files scoped to src, href, and srcset attributes

--- a/migration/src/main/java/io/quarkus/tools/ParenthesisFileRenamerCommand.java
+++ b/migration/src/main/java/io/quarkus/tools/ParenthesisFileRenamerCommand.java
@@ -1,0 +1,37 @@
+package io.quarkus.tools;
+
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "rename-parens", mixinStandardHelpOptions = true, version = "1.0", description = "Renames files with parentheses and updates HTML references")
+public class ParenthesisFileRenamerCommand implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "Directory to scan (e.g. public/)")
+    private java.nio.file.Path directory;
+
+    public static void main(String... args) {
+        int exitCode = new CommandLine(new ParenthesisFileRenamerCommand()).execute(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        if (!java.nio.file.Files.isDirectory(directory)) {
+            System.err.println("Error: '" + directory + "' is not a directory");
+            return 1;
+        }
+
+        ParenthesisFileRenamer renamer = new ParenthesisFileRenamer();
+        ParenthesisFileRenamer.Result result = renamer.rename(directory);
+
+        if (result.filesRenamed() > 0) {
+            System.out.println("Renamed " + result.filesRenamed() + " files with parentheses, updated "
+                    + result.htmlFilesUpdated() + " HTML files");
+        }
+
+        return 0;
+    }
+}

--- a/migration/src/test/java/io/quarkus/tools/ParenthesisFileRenamerTest.java
+++ b/migration/src/test/java/io/quarkus/tools/ParenthesisFileRenamerTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ParenthesisFileRenamerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void renamesFilesAndUpdatesHtml() throws IOException {
+        Path indexFiles = tempDir.resolve("newsletter/38/index_files");
+        Files.createDirectories(indexFiles);
+
+        Files.write(indexFiles.resolve("content"), new byte[] { (byte) 0x89, 'P', 'N', 'G' });
+        Files.write(indexFiles.resolve("content(1)"), new byte[] { (byte) 0x89, 'P', 'N', 'G' });
+        Files.write(indexFiles.resolve("content(14)"), new byte[] { (byte) 0x89, 'P', 'N', 'G' });
+        Files.write(indexFiles.resolve("logo.png"), new byte[] { (byte) 0x89, 'P', 'N', 'G' });
+
+        Path html = tempDir.resolve("newsletter/38/index.html");
+        Files.writeString(html,
+                "<img src=\"./index_files/content\"/>\n"
+                        + "<img src=\"./index_files/content(1)\"/>\n"
+                        + "<img src=\"./index_files/content(14)\"/>\n"
+                        + "<img src=\"./index_files/logo.png\"/>\n",
+                StandardCharsets.UTF_8);
+
+        ParenthesisFileRenamer renamer = new ParenthesisFileRenamer();
+        ParenthesisFileRenamer.Result result = renamer.rename(tempDir);
+
+        assertThat(result.filesRenamed()).isEqualTo(2);
+        assertThat(result.htmlFilesUpdated()).isEqualTo(1);
+
+        assertThat(indexFiles.resolve("content")).exists();
+        assertThat(indexFiles.resolve("content-1")).exists();
+        assertThat(indexFiles.resolve("content-14")).exists();
+        assertThat(indexFiles.resolve("logo.png")).exists();
+        assertThat(indexFiles.resolve("content(1)")).doesNotExist();
+        assertThat(indexFiles.resolve("content(14)")).doesNotExist();
+
+        String updatedHtml = Files.readString(html, StandardCharsets.UTF_8);
+        assertThat(updatedHtml).contains("index_files/content\"");
+        assertThat(updatedHtml).contains("index_files/content-1\"");
+        assertThat(updatedHtml).contains("index_files/content-14\"");
+        assertThat(updatedHtml).contains("index_files/logo.png\"");
+        assertThat(updatedHtml).doesNotContain("content(");
+    }
+
+    @Test
+    void noOpWhenNoParentheses() throws IOException {
+        Path dir = tempDir.resolve("clean");
+        Files.createDirectories(dir);
+        Files.write(dir.resolve("image.png"), new byte[] { 0 });
+        Files.writeString(dir.resolve("page.html"), "<img src=\"image.png\"/>", StandardCharsets.UTF_8);
+
+        ParenthesisFileRenamer renamer = new ParenthesisFileRenamer();
+        ParenthesisFileRenamer.Result result = renamer.rename(tempDir);
+
+        assertThat(result.filesRenamed()).isZero();
+        assertThat(result.htmlFilesUpdated()).isZero();
+    }
+
+    @Test
+    void handlesNonExistentDirectory() throws IOException {
+        ParenthesisFileRenamer renamer = new ParenthesisFileRenamer();
+        ParenthesisFileRenamer.Result result = renamer.rename(tempDir.resolve("does-not-exist"));
+
+        assertThat(result.filesRenamed()).isZero();
+        assertThat(result.htmlFilesUpdated()).isZero();
+    }
+}

--- a/migration/src/test/java/io/quarkus/tools/ParenthesisFileRenamerTest.java
+++ b/migration/src/test/java/io/quarkus/tools/ParenthesisFileRenamerTest.java
@@ -1,9 +1,11 @@
 package io.quarkus.tools;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -23,35 +25,54 @@ class ParenthesisFileRenamerTest {
         Files.write(indexFiles.resolve("content"), new byte[] { (byte) 0x89, 'P', 'N', 'G' });
         Files.write(indexFiles.resolve("content(1)"), new byte[] { (byte) 0x89, 'P', 'N', 'G' });
         Files.write(indexFiles.resolve("content(14)"), new byte[] { (byte) 0x89, 'P', 'N', 'G' });
+        Files.write(indexFiles.resolve("image(preview).png"), new byte[] { (byte) 0x89, 'P', 'N', 'G' });
         Files.write(indexFiles.resolve("logo.png"), new byte[] { (byte) 0x89, 'P', 'N', 'G' });
 
         Path html = tempDir.resolve("newsletter/38/index.html");
         Files.writeString(html,
-                "<img src=\"./index_files/content\"/>\n"
+                "<p>See section(3) and part(foo) for details.</p>\n"
+                        + "<img src=\"./index_files/content\"/>\n"
                         + "<img src=\"./index_files/content(1)\"/>\n"
-                        + "<img src=\"./index_files/content(14)\"/>\n"
+                        + "<a href=\"./index_files/content(14)\">link</a>\n"
+                        + "<img src='./index_files/image(preview).png'/>\n"
                         + "<img src=\"./index_files/logo.png\"/>\n",
                 StandardCharsets.UTF_8);
 
         ParenthesisFileRenamer renamer = new ParenthesisFileRenamer();
         ParenthesisFileRenamer.Result result = renamer.rename(tempDir);
 
-        assertThat(result.filesRenamed()).isEqualTo(2);
+        assertThat(result.filesRenamed()).isEqualTo(3);
         assertThat(result.htmlFilesUpdated()).isEqualTo(1);
 
         assertThat(indexFiles.resolve("content")).exists();
         assertThat(indexFiles.resolve("content-1")).exists();
         assertThat(indexFiles.resolve("content-14")).exists();
+        assertThat(indexFiles.resolve("image-preview.png")).exists();
         assertThat(indexFiles.resolve("logo.png")).exists();
         assertThat(indexFiles.resolve("content(1)")).doesNotExist();
         assertThat(indexFiles.resolve("content(14)")).doesNotExist();
+        assertThat(indexFiles.resolve("image(preview).png")).doesNotExist();
 
         String updatedHtml = Files.readString(html, StandardCharsets.UTF_8);
+        assertThat(updatedHtml).contains("<p>See section(3) and part(foo) for details.</p>");
         assertThat(updatedHtml).contains("index_files/content\"");
         assertThat(updatedHtml).contains("index_files/content-1\"");
         assertThat(updatedHtml).contains("index_files/content-14\"");
+        assertThat(updatedHtml).contains("index_files/image-preview.png'");
         assertThat(updatedHtml).contains("index_files/logo.png\"");
-        assertThat(updatedHtml).doesNotContain("content(");
+    }
+
+    @Test
+    void throwsOnFileCollision() throws IOException {
+        Path dir = tempDir.resolve("collision");
+        Files.createDirectories(dir);
+        Files.write(dir.resolve("content(1)"), new byte[] { 1 });
+        Files.write(dir.resolve("content-1"), new byte[] { 2 });
+
+        ParenthesisFileRenamer renamer = new ParenthesisFileRenamer();
+        assertThatThrownBy(() -> renamer.rename(dir))
+                .isInstanceOf(FileAlreadyExistsException.class)
+                .hasMessageContaining("content-1");
     }
 
     @Test

--- a/migration/src/test/java/io/quarkus/tools/ParenthesisFileRenamerTest.java
+++ b/migration/src/test/java/io/quarkus/tools/ParenthesisFileRenamerTest.java
@@ -30,12 +30,14 @@ class ParenthesisFileRenamerTest {
 
         Path html = tempDir.resolve("newsletter/38/index.html");
         Files.writeString(html,
-                "<p>See section(3) and part(foo) for details.</p>\n"
-                        + "<img src=\"./index_files/content\"/>\n"
-                        + "<img src=\"./index_files/content(1)\"/>\n"
-                        + "<a href=\"./index_files/content(14)\">link</a>\n"
-                        + "<img src='./index_files/image(preview).png'/>\n"
-                        + "<img src=\"./index_files/logo.png\"/>\n",
+                """
+                        <p>See section(3) and part(foo) for details.</p>
+                        <img src="./index_files/content"/>
+                        <img src="./index_files/content(1)"/>
+                        <a href="./index_files/content(14)">link</a>
+                        <img src='./index_files/image(preview).png'/>
+                        <img src="./index_files/logo.png"/>
+                        """,
                 StandardCharsets.UTF_8);
 
         ParenthesisFileRenamer renamer = new ParenthesisFileRenamer();
@@ -73,6 +75,66 @@ class ParenthesisFileRenamerTest {
         assertThatThrownBy(() -> renamer.rename(dir))
                 .isInstanceOf(FileAlreadyExistsException.class)
                 .hasMessageContaining("content-1");
+    }
+
+    /**
+     * Two different source files that both rename to the same target name.
+     * e.g. "foo(bar)" -> "foo-bar" and "foo(-bar)" -> "foo--bar" don't collide,
+     * but "a(b)" -> "a-b" and "a-b(" -> "a-b" both produce "a-b".
+     * The pre-check must catch this before any file is touched.
+     */
+    @Test
+    void throwsWhenTwoSourcesRenameToSameTarget() throws IOException {
+        Path dir = tempDir.resolve("dup-target");
+        Files.createDirectories(dir);
+        // "img(1)" -> "img-1"  (open-paren becomes dash, close-paren dropped)
+        // "img(1"  -> "img-1"  (open-paren becomes dash, no close-paren to drop)
+        // Both slug to the same target "img-1".
+        Files.write(dir.resolve("img(1)"), new byte[] { 1 });
+        Files.write(dir.resolve("img(1"), new byte[] { 2 });
+
+        ParenthesisFileRenamer renamer = new ParenthesisFileRenamer();
+        assertThatThrownBy(() -> renamer.rename(dir))
+                .isInstanceOf(FileAlreadyExistsException.class)
+                .hasMessageContaining("img-1");
+
+        // Neither file should have been moved (pre-check fires before any rename)
+        assertThat(dir.resolve("img(1)")).exists();
+        assertThat(dir.resolve("img(1")).exists();
+        assertThat(dir.resolve("img-1")).doesNotExist();
+    }
+
+    /**
+     * An HTML file whose own name contains parentheses gets renamed.
+     * After the rename the HTML pass must read from the new path, not the stale original.
+     */
+    @Test
+    void renamesHtmlFileWithParenthesesAndUpdatesItsReferences() throws IOException {
+        Path dir = tempDir.resolve("html-parens");
+        Files.createDirectories(dir);
+
+        // The HTML file itself has parens in its name
+        Files.write(dir.resolve("image(1).png"), new byte[] { (byte) 0x89, 'P', 'N', 'G' });
+        Files.writeString(dir.resolve("page(draft).html"),
+                "<img src=\"image(1).png\"/>",
+                StandardCharsets.UTF_8);
+
+        ParenthesisFileRenamer renamer = new ParenthesisFileRenamer();
+        ParenthesisFileRenamer.Result result = renamer.rename(dir);
+
+        assertThat(result.filesRenamed()).isEqualTo(2); // image(1).png and page(draft).html
+        assertThat(result.htmlFilesUpdated()).isEqualTo(1);
+
+        // Old paths gone, new paths exist
+        assertThat(dir.resolve("page(draft).html")).doesNotExist();
+        assertThat(dir.resolve("page-draft.html")).exists();
+        assertThat(dir.resolve("image(1).png")).doesNotExist();
+        assertThat(dir.resolve("image-1.png")).exists();
+
+        // The reference inside the renamed HTML file was updated
+        String updatedHtml = Files.readString(dir.resolve("page-draft.html"), StandardCharsets.UTF_8);
+        assertThat(updatedHtml).contains("src=\"image-1.png\"");
+        assertThat(updatedHtml).doesNotContain("image(1).png");
     }
 
     @Test


### PR DESCRIPTION
Roq's static file handler silently renames files with parentheses (e.g. `{@code content(1)}` becomes `{@code content-1})` during the build, but does not update HTML references, so images 404 at runtime.

This class fixes the source files before the build: it renames files to replace parentheses with dashes and updates all {@code .html} files in the same tree.

I wasn't totally sure if this is something that would be useful outside conversion, since any project could have this issue. But it seems too heavy to add elsewhere.

Btw, I know all these `*Command`s are getting excessive. Once everything is in main I will rewrite `roq-it-jekyll` to use/be a java orchestrator, but I don't want to do that refactoring until I have a working version in main. My branch and file and PR management is getting too complex as it is without adding a refactor on top. 