### PR TITLE
Scan plugins in Jekyll conversion

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/JekyllPluginCommand.java
+++ b/migration/src/main/java/io/quarkus/tools/JekyllPluginCommand.java
@@ -1,0 +1,55 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS info.picocli:picocli:4.7.5
+
+package io.quarkus.tools;
+
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "jekyll-plugins", mixinStandardHelpOptions = true, version = "1.0", description = "Converts Jekyll _plugins/*.rb to Roq/Quarkus equivalents")
+public class JekyllPluginCommand implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "Project directory (must contain _plugins/)")
+    private java.nio.file.Path projectDir;
+
+    public static void main(String... args) {
+        int exitCode = new CommandLine(new JekyllPluginCommand()).execute(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        if (!java.nio.file.Files.isDirectory(projectDir)) {
+            System.err.println("Error: '" + projectDir + "' is not a directory");
+            return 1;
+        }
+
+        System.out.println("Converting Jekyll plugins in " + projectDir.resolve("_plugins"));
+        JekyllPluginConverter converter = new JekyllPluginConverter(projectDir);
+        JekyllPluginConverter.Result result = converter.convert();
+
+        System.out.println("\nPlugin conversion complete:");
+        if (!result.handled().isEmpty()) {
+            System.out.println("  " + result.handled().size() + " handled (already covered by converter)");
+        }
+        if (!result.translated().isEmpty()) {
+            System.out.println("  " + result.translated().size() + " translated to Java");
+        }
+        if (!result.skipped().isEmpty()) {
+            System.out.println("  " + result.skipped().size() + " skipped (equivalent already exists)");
+        }
+
+        if (!result.failed().isEmpty()) {
+            System.err.println("\n  " + result.failed().size() + " plugin(s) need manual migration:");
+            for (String plugin : result.failed()) {
+                System.err.println("\n" + result.failureMessages().get(plugin));
+            }
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/migration/src/main/java/io/quarkus/tools/JekyllPluginConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/JekyllPluginConverter.java
@@ -1,0 +1,159 @@
+package io.quarkus.tools;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Stream;
+
+public class JekyllPluginConverter {
+
+    enum Classification {
+        HANDLED,
+        TRANSLATABLE,
+        MANUAL
+    }
+
+    record PluginInfo(Classification classification, String reason, String equivalentFile) {
+        PluginInfo(Classification classification, String reason) {
+            this(classification, reason, null);
+        }
+    }
+
+    record Result(
+            List<String> handled,
+            List<String> translated,
+            List<String> skipped,
+            List<String> failed,
+            Map<String, String> failureMessages) {
+    }
+
+    // Only truly generic plugins that apply to ALL Jekyll sites.
+    // Site-specific plugins should be classified as MANUAL and fail the build,
+    // guiding users to implement custom equivalents.
+    private static final Map<String, PluginInfo> KNOWN_PLUGINS = Map.of(
+            "cname.rb", new PluginInfo(Classification.HANDLED,
+                    "CNAME value is configured in siteConfig.yml (GitHub Pages convention)"));
+
+    private static final String JAVA_PACKAGE = "io.quarkus.tools.migration";
+    private static final String JAVA_PACKAGE_PATH = "src/main/java/io/quarkus/tools/migration";
+
+    private final Path projectDir;
+
+    public JekyllPluginConverter(Path projectDir) {
+        this.projectDir = projectDir;
+    }
+
+    public Result convert() throws IOException {
+        Path pluginsDir = projectDir.resolve("_plugins");
+        List<String> handled = new ArrayList<>();
+        List<String> translated = new ArrayList<>();
+        List<String> skipped = new ArrayList<>();
+        List<String> failed = new ArrayList<>();
+        Map<String, String> failureMessages = new LinkedHashMap<>();
+
+        if (!Files.isDirectory(pluginsDir)) {
+            return new Result(handled, translated, skipped, failed, failureMessages);
+        }
+
+        List<Path> rubyFiles;
+        try (Stream<Path> paths = Files.list(pluginsDir)) {
+            rubyFiles = paths
+                    .filter(p -> p.getFileName().toString().endsWith(".rb"))
+                    .sorted()
+                    .toList();
+        }
+
+        for (Path rbFile : rubyFiles) {
+            String fileName = rbFile.getFileName().toString();
+            String rbContent = Files.readString(rbFile);
+
+            PluginInfo info = KNOWN_PLUGINS.get(fileName);
+            if (info == null) {
+                info = classifyUnknownPlugin(fileName, rbContent);
+            }
+
+            switch (info.classification()) {
+                case HANDLED -> {
+                    System.out.println("  [HANDLED] " + fileName + " — " + info.reason());
+                    handled.add(fileName);
+                }
+                case TRANSLATABLE -> {
+                    Path equivalentPath = projectDir.resolve(JAVA_PACKAGE_PATH)
+                            .resolve(info.equivalentFile());
+                    if (Files.exists(equivalentPath)) {
+                        System.out.println("  [SKIP] " + fileName
+                                + " — equivalent already exists: " + info.equivalentFile());
+                        skipped.add(fileName);
+                    } else {
+                        translatePlugin(fileName, rbContent, info);
+                        System.out.println("  [TRANSLATED] " + fileName
+                                + " → " + info.equivalentFile());
+                        translated.add(fileName);
+                    }
+                }
+                case MANUAL -> {
+                    Path equivalentPath = projectDir.resolve(JAVA_PACKAGE_PATH)
+                            .resolve(info.equivalentFile());
+                    if (Files.exists(equivalentPath)) {
+                        System.out.println("  [SKIP] " + fileName
+                                + " — equivalent already exists: " + info.equivalentFile());
+                        skipped.add(fileName);
+                    } else {
+                        String msg = buildManualFailureMessage(fileName, rbContent, info);
+                        failureMessages.put(fileName, msg);
+                        failed.add(fileName);
+                        System.err.println("  [MANUAL] " + fileName + " — needs hand-coded equivalent");
+                    }
+                }
+            }
+        }
+
+        return new Result(handled, translated, skipped, failed, failureMessages);
+    }
+
+    private PluginInfo classifyUnknownPlugin(String fileName, String content) {
+        String javaName = rubyFileToJavaClass(fileName) + ".java";
+        return new PluginInfo(Classification.MANUAL,
+                "Unknown Jekyll plugin — needs manual migration", javaName);
+    }
+
+    private String rubyFileToJavaClass(String rbFileName) {
+        String base = rbFileName.replaceAll("\\.rb$", "");
+        StringBuilder sb = new StringBuilder();
+        boolean capitalize = true;
+        for (char c : base.toCharArray()) {
+            if (c == '-' || c == '_') {
+                capitalize = true;
+            } else {
+                sb.append(capitalize ? Character.toUpperCase(c) : c);
+                capitalize = false;
+            }
+        }
+        return sb.toString();
+    }
+
+    private void translatePlugin(String fileName, String rbContent, PluginInfo info) throws IOException {
+        // Currently no plugins support automatic translation.
+        // Site-specific plugins should be added to KNOWN_PLUGINS as TRANSLATABLE
+        // with custom translation logic here.
+        throw new IllegalStateException("No translation logic for: " + fileName);
+    }
+
+    private String buildManualFailureMessage(String fileName, String rbContent, PluginInfo info) {
+        StringBuilder msg = new StringBuilder();
+        msg.append("Jekyll plugin '").append(fileName).append("' requires manual migration.\n");
+        msg.append("Create: ").append(JAVA_PACKAGE_PATH).append("/").append(info.equivalentFile()).append("\n\n");
+        msg.append("Plugin contents:\n");
+
+        String[] lines = rbContent.split("\n");
+        for (int i = 0; i < Math.min(lines.length, 20); i++) {
+            msg.append("  ").append(lines[i]).append("\n");
+        }
+        if (lines.length > 20) {
+            msg.append("  ... (").append(lines.length - 20).append(" more lines)\n");
+        }
+
+        return msg.toString();
+    }
+}

--- a/migration/src/main/java/io/quarkus/tools/JekyllPluginConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/JekyllPluginConverter.java
@@ -77,6 +77,7 @@ public class JekyllPluginConverter {
                 case HANDLED -> {
                     System.out.println("  [HANDLED] " + fileName + " — " + info.reason());
                     handled.add(fileName);
+                    Files.deleteIfExists(rbFile);
                 }
                 case TRANSLATABLE -> {
                     Path equivalentPath = projectDir.resolve(JAVA_PACKAGE_PATH)
@@ -91,6 +92,7 @@ public class JekyllPluginConverter {
                                 + " → " + info.equivalentFile());
                         translated.add(fileName);
                     }
+                    Files.deleteIfExists(rbFile);
                 }
                 case MANUAL -> {
                     Path equivalentPath = projectDir.resolve(JAVA_PACKAGE_PATH)
@@ -99,6 +101,7 @@ public class JekyllPluginConverter {
                         System.out.println("  [SKIP] " + fileName
                                 + " — equivalent already exists: " + info.equivalentFile());
                         skipped.add(fileName);
+                        Files.deleteIfExists(rbFile);
                     } else {
                         String msg = buildManualFailureMessage(fileName, rbContent, info);
                         failureMessages.put(fileName, msg);
@@ -106,6 +109,13 @@ public class JekyllPluginConverter {
                         System.err.println("  [MANUAL] " + fileName + " — needs hand-coded equivalent");
                     }
                 }
+            }
+        }
+
+        // Remove _plugins/ if empty (all plugins handled or translated)
+        try (Stream<Path> remaining = Files.list(pluginsDir)) {
+            if (remaining.findAny().isEmpty()) {
+                Files.delete(pluginsDir);
             }
         }
 

--- a/migration/src/test/java/io/quarkus/tools/JekyllPluginConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/JekyllPluginConverterTest.java
@@ -1,0 +1,208 @@
+package io.quarkus.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JekyllPluginConverterTest {
+
+    @TempDir
+    Path projectDir;
+
+    Path pluginsDir;
+    Path srcDir;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        pluginsDir = projectDir.resolve("_plugins");
+        Files.createDirectories(pluginsDir);
+        srcDir = projectDir.resolve("src/main/java/io/quarkus/tools/migration");
+        Files.createDirectories(srcDir);
+    }
+
+    // --- Generic GitHub Pages plugin (HANDLED) ---
+
+    @Test
+    void testCnamePluginIsHandled() throws IOException {
+        Files.writeString(pluginsDir.resolve("cname.rb"),
+                "module Jekyll\n  class LimitedEnvironmentVariables < Generator\n  end\nend");
+
+        JekyllPluginConverter converter = new JekyllPluginConverter(projectDir);
+        JekyllPluginConverter.Result result = converter.convert();
+
+        assertThat(result.handled()).containsExactly("cname.rb");
+        assertThat(result.translated()).isEmpty();
+        assertThat(result.failed()).isEmpty();
+    }
+
+    // --- Unknown plugins fail by default (MANUAL) ---
+
+    @Test
+    void testUnknownPluginFailsByDefault() throws IOException {
+        Files.writeString(pluginsDir.resolve("custom-plugin.rb"),
+                "module Jekyll\n  module CustomFilter\n  end\nend");
+
+        JekyllPluginConverter converter = new JekyllPluginConverter(projectDir);
+        JekyllPluginConverter.Result result = converter.convert();
+
+        assertThat(result.failed()).containsExactly("custom-plugin.rb");
+        assertThat(result.handled()).isEmpty();
+        assertThat(result.failureMessages().get("custom-plugin.rb"))
+                .contains("custom-plugin.rb")
+                .contains("CustomPlugin.java");
+    }
+
+    @Test
+    void testMultipleUnknownPluginsFail() throws IOException {
+        Files.writeString(pluginsDir.resolve("plugin-a.rb"), "# plugin a");
+        Files.writeString(pluginsDir.resolve("plugin-b.rb"), "# plugin b");
+        Files.writeString(pluginsDir.resolve("plugin-c.rb"), "# plugin c");
+
+        JekyllPluginConverter converter = new JekyllPluginConverter(projectDir);
+        JekyllPluginConverter.Result result = converter.convert();
+
+        assertThat(result.failed()).containsExactlyInAnyOrder(
+                "plugin-a.rb", "plugin-b.rb", "plugin-c.rb");
+        assertThat(result.handled()).isEmpty();
+    }
+
+    // --- Plugins with hand-coded equivalents are skipped ---
+
+    @Test
+    void testPluginSkipsWhenEquivalentExists() throws IOException {
+        Files.writeString(pluginsDir.resolve("my-filter.rb"),
+                "module Jekyll\n  module MyFilter\n  end\nend");
+
+        // Hand-code the equivalent
+        Files.writeString(srcDir.resolve("MyFilter.java"),
+                "package io.quarkus.tools.migration;\npublic class MyFilter {}");
+
+        JekyllPluginConverter converter = new JekyllPluginConverter(projectDir);
+        JekyllPluginConverter.Result result = converter.convert();
+
+        assertThat(result.failed()).isEmpty();
+        assertThat(result.skipped()).containsExactly("my-filter.rb");
+    }
+
+    @Test
+    void testMultiplePluginsWithEquivalents() throws IOException {
+        Files.writeString(pluginsDir.resolve("filter-a.rb"), "# filter a");
+        Files.writeString(pluginsDir.resolve("filter-b.rb"), "# filter b");
+        Files.writeString(pluginsDir.resolve("filter-c.rb"), "# filter c");
+
+        // Provide equivalents for some
+        Files.writeString(srcDir.resolve("FilterA.java"),
+                "package io.quarkus.tools.migration;\npublic class FilterA {}");
+        Files.writeString(srcDir.resolve("FilterC.java"),
+                "package io.quarkus.tools.migration;\npublic class FilterC {}");
+
+        JekyllPluginConverter converter = new JekyllPluginConverter(projectDir);
+        JekyllPluginConverter.Result result = converter.convert();
+
+        assertThat(result.skipped()).containsExactlyInAnyOrder("filter-a.rb", "filter-c.rb");
+        assertThat(result.failed()).containsExactly("filter-b.rb");
+    }
+
+    // --- Ruby filename to Java class name conversion ---
+
+    @Test
+    void testRubyFileNameToJavaClassConversion() throws IOException {
+        Files.writeString(pluginsDir.resolve("my-custom-filter.rb"), "# custom filter");
+
+        JekyllPluginConverter converter = new JekyllPluginConverter(projectDir);
+        JekyllPluginConverter.Result result = converter.convert();
+
+        assertThat(result.failed()).containsExactly("my-custom-filter.rb");
+        assertThat(result.failureMessages().get("my-custom-filter.rb"))
+                .contains("MyCustomFilter.java");
+    }
+
+    @Test
+    void testUnderscoreFileNameConversion() throws IOException {
+        Files.writeString(pluginsDir.resolve("some_long_plugin_name.rb"), "# plugin");
+
+        JekyllPluginConverter converter = new JekyllPluginConverter(projectDir);
+        JekyllPluginConverter.Result result = converter.convert();
+
+        assertThat(result.failed()).containsExactly("some_long_plugin_name.rb");
+        assertThat(result.failureMessages().get("some_long_plugin_name.rb"))
+                .contains("SomeLongPluginName.java");
+    }
+
+    // --- No plugins directory ---
+
+    @Test
+    void testNoPluginsDirSucceeds() throws IOException {
+        Files.delete(pluginsDir);
+
+        JekyllPluginConverter converter = new JekyllPluginConverter(projectDir);
+        JekyllPluginConverter.Result result = converter.convert();
+
+        assertThat(result.handled()).isEmpty();
+        assertThat(result.translated()).isEmpty();
+        assertThat(result.failed()).isEmpty();
+    }
+
+    // --- Empty plugins directory ---
+
+    @Test
+    void testEmptyPluginsDirSucceeds() throws IOException {
+        JekyllPluginConverter converter = new JekyllPluginConverter(projectDir);
+        JekyllPluginConverter.Result result = converter.convert();
+
+        assertThat(result.handled()).isEmpty();
+        assertThat(result.translated()).isEmpty();
+        assertThat(result.failed()).isEmpty();
+    }
+
+    // --- Non-ruby files are ignored ---
+
+    @Test
+    void testNonRubyFilesIgnored() throws IOException {
+        Files.writeString(pluginsDir.resolve("readme.md"), "# Plugins");
+        Files.writeString(pluginsDir.resolve("helper.txt"), "notes");
+        Files.writeString(pluginsDir.resolve(".gitignore"), "*.tmp");
+
+        JekyllPluginConverter converter = new JekyllPluginConverter(projectDir);
+        JekyllPluginConverter.Result result = converter.convert();
+
+        assertThat(result.handled()).isEmpty();
+        assertThat(result.translated()).isEmpty();
+        assertThat(result.failed()).isEmpty();
+    }
+
+    // --- Mixed scenario ---
+
+    @Test
+    void testMixedScenario() throws IOException {
+        // Generic GitHub Pages plugin (handled)
+        Files.writeString(pluginsDir.resolve("cname.rb"), "# cname");
+
+        // Unknown plugins (will fail)
+        Files.writeString(pluginsDir.resolve("custom-filter.rb"), "# custom filter");
+        Files.writeString(pluginsDir.resolve("search-plugin.rb"), "# search");
+
+        // Unknown plugin with hand-coded equivalent (skipped)
+        Files.writeString(pluginsDir.resolve("extensions.rb"), "# extensions");
+        Files.writeString(srcDir.resolve("Extensions.java"),
+                "package io.quarkus.tools.migration;\npublic class Extensions {}");
+
+        // Non-ruby file (ignored)
+        Files.writeString(pluginsDir.resolve("notes.txt"), "notes");
+
+        JekyllPluginConverter converter = new JekyllPluginConverter(projectDir);
+        JekyllPluginConverter.Result result = converter.convert();
+
+        assertThat(result.handled()).containsExactly("cname.rb");
+        assertThat(result.translated()).isEmpty();
+        assertThat(result.skipped()).containsExactly("extensions.rb");
+        assertThat(result.failed()).containsExactlyInAnyOrder(
+                "custom-filter.rb", "search-plugin.rb");
+    }
+}


### PR DESCRIPTION
If people are using Jekyll plugins, there's generally not much we can do. Generic Ruby to Java conversion is way beyond the scope of this converter and hook points are so different in Roq and Jekyll a syntactic conversion would be futile anyway.

However, some Jekyll plugins, like CNAME handling, are automatically handled by Roq. 

We want to scan people's plugins, and identify plugins they don't need (like cname ones), and fail the build if they have any others. In the case where everything is ok, we want to report that.

(For quarkus.io, I've converted the plugins and pre-loaded them in the other repo, see https://github.com/quarkusio/quarkusio.github.io/pull/2849. This will probably have to be the pattern in most cases.)