### PR TITLE
Liquid to Qute conversion: Use _unisolated includes instead of ?? workaround for variable scoping

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/LiquidToQuteCommand.java
+++ b/migration/src/main/java/io/quarkus/tools/LiquidToQuteCommand.java
@@ -201,7 +201,7 @@ public class LiquidToQuteCommand implements Callable<Integer> {
 
                         // Extract types from include lines — match any path ending with the filename
                         java.util.regex.Pattern includeP = java.util.regex.Pattern.compile(
-                                "\\{#include \\S*" + fnQuoted + " type=\"([^\"]+)\" /\\}");
+                                "\\{#include \\S*" + fnQuoted + " type=\"([^\"]+)\"(?: _unisolated)? /\\}");
                         java.util.regex.Matcher includeM = includeP.matcher(content);
                         List<String> types = new ArrayList<>();
                         while (includeM.find()) {
@@ -214,7 +214,7 @@ public class LiquidToQuteCommand implements Callable<Integer> {
                         for (String type : types) {
                             content = content.replaceFirst(
                                     "\\{#include \\S*" + fnQuoted + " type=\""
-                                            + java.util.regex.Pattern.quote(type) + "\" /\\}"
+                                            + java.util.regex.Pattern.quote(type) + "\"(?: _unisolated)? /\\}"
                                             + "\\s*\n(\\s*)\\{#if " + java.util.regex.Pattern.quote(partial.accumVar()) + "\\}",
                                     "$1{#if " + partial.sourceVar() + ".mergeTypes('" + type + "')}");
                         }

--- a/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
@@ -1196,9 +1196,9 @@ public class LiquidToQuteConverter {
 
             String replacement;
             if (!params.isEmpty()) {
-                replacement = "{#include " + path + " " + params + " /}";
+                replacement = "{#include " + path + " " + params + " _unisolated /}";
             } else {
-                replacement = "{#include " + path + " /}";
+                replacement = "{#include " + path + " _unisolated /}";
             }
 
             includeMatcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));

--- a/migration/src/test/java/io/quarkus/tools/LiquidToQuteConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/LiquidToQuteConverterTest.java
@@ -326,7 +326,7 @@ class LiquidToQuteConverterTest {
     @Test
     void testInclude() {
         String input = "{% include \"header.html\" %}";
-        String expected = "{#include partials/header.html /}";
+        String expected = "{#include partials/header.html _unisolated /}";
         assertConverts(input, expected, "Include should convert with partials/ prefix");
     }
 
@@ -1043,7 +1043,7 @@ class LiquidToQuteConverterTest {
     @Test
     void testIncludeWithLeadingSlashStripped() {
         String input = "{% include /templates/secondary-page-title-band.html %}";
-        String expected = "{#include partials/templates/secondary-page-title-band.html /}";
+        String expected = "{#include partials/templates/secondary-page-title-band.html _unisolated /}";
         assertConverts(input, expected,
                 "Leading slash in include path should be stripped to avoid double-slash in partials/ prefix");
     }
@@ -1051,7 +1051,7 @@ class LiquidToQuteConverterTest {
     @Test
     void testIncludePathWithPageNotMangled() {
         String input = "{% include share-page.html title=post.title url=post.url %}";
-        String expected = "{#include partials/share-page.html title=post.title url=post.url /}";
+        String expected = "{#include partials/share-page.html title=post.title url=post.url _unisolated /}";
         assertConverts(input, expected,
                 "Include paths containing '-page.' should not be treated as page field access");
     }


### PR DESCRIPTION
I think I have been missing a Qute feature in some of the conversions. Jekyll's `{% include %}` inherits the parent's variable scope, but Qute's `{#include}` isolates by default (since Quarkus 3.5). Rather than appending `??` to every variable in every partial, we can emit `_unisolated` on include calls so Qute matches Jekyll's scoping behavior.

- LiquidToQuteConverter: add `_unisolated` to all `{#include}` output
- LiquidToQuteCommand: update cross-file merge regexes for `_unisolated`

This avoids a bunch of scripting code in the conversion. 