### PR TITLE
Converter: Add tests for cross-file merging

### DIFF
--- a/migration/src/test/java/io/quarkus/tools/migration/jekyll/CrossFileMergeTest.java
+++ b/migration/src/test/java/io/quarkus/tools/migration/jekyll/CrossFileMergeTest.java
@@ -1,0 +1,100 @@
+package io.quarkus.tools.migration.jekyll;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.TemplateException;
+import io.quarkus.tools.LiquidToQuteCommand;
+
+class CrossFileMergeTest {
+
+    @Test
+    void partialPushInLoopCollapsesToMergeTypes(@TempDir Path tempDir) throws Exception {
+        Path inputDir = copyTestFixtures(tempDir);
+        Path outputDir = tempDir.resolve("output");
+
+        int exitCode = new picocli.CommandLine(new LiquidToQuteCommand())
+                .execute(inputDir.toString(), outputDir.toString());
+        assertEquals(0, exitCode, "Command should exit successfully");
+
+        String partial = Files.readString(outputDir.resolve("_includes/merge-items.html"));
+        assertTrue(partial.contains(".mergeTypes("),
+                "Partial should have push-in-loop collapsed to mergeTypes(): " + partial);
+        assertFalse(partial.contains(".push("),
+                "Partial should not contain push() after collapse: " + partial);
+    }
+
+    @Test
+    void parentIncludeCallerFixedToUseMergeTypes(@TempDir Path tempDir) throws Exception {
+        Path inputDir = copyTestFixtures(tempDir);
+        Path outputDir = tempDir.resolve("output");
+
+        int exitCode = new picocli.CommandLine(new LiquidToQuteCommand())
+                .execute(inputDir.toString(), outputDir.toString());
+        assertEquals(0, exitCode);
+
+        String parent = Files.readString(outputDir.resolve("_includes/parent-docs.html"));
+
+        assertFalse(parent.contains("{#include"),
+                "Parent should not contain {#include} for collapsed partial: " + parent);
+        assertTrue(parent.contains("mergeTypes('tutorial')"),
+                "Parent should call mergeTypes('tutorial'): " + parent);
+        assertTrue(parent.contains("mergeTypes('reference')"),
+                "Parent should call mergeTypes('reference'): " + parent);
+        assertFalse(parent.contains("{#if values}"),
+                "Parent should not reference cross-scope 'values' variable: " + parent);
+        assertFalse(parent.contains("values.orEmpty"),
+                "Parent should not reference cross-scope 'values.orEmpty': " + parent);
+    }
+
+    @Test
+    void parentOutputIsValidQute(@TempDir Path tempDir) throws Exception {
+        Path inputDir = copyTestFixtures(tempDir);
+        Path outputDir = tempDir.resolve("output");
+
+        new picocli.CommandLine(new LiquidToQuteCommand())
+                .execute(inputDir.toString(), outputDir.toString());
+
+        String parent = Files.readString(outputDir.resolve("_includes/parent-docs.html"));
+
+        Engine engine = Engine.builder().addDefaults().build();
+        try {
+            engine.parse(parent);
+        } catch (TemplateException e) {
+            fail("Parent output is not valid Qute:\n" + e.getMessage() + "\n\nOutput:\n" + parent);
+        }
+    }
+
+    private Path copyTestFixtures(Path tempDir) throws Exception {
+        Path fixtureDir = Paths.get(getClass().getClassLoader()
+                .getResource("cross-file-merge/input/_includes/merge-items.html").toURI())
+                .getParent().getParent();
+        Path inputDir = tempDir.resolve("input");
+        copyDirectory(fixtureDir, inputDir);
+        return inputDir;
+    }
+
+    private void copyDirectory(Path source, Path target) throws IOException {
+        Files.walk(source).forEach(s -> {
+            Path t = target.resolve(source.relativize(s));
+            try {
+                if (Files.isDirectory(s)) {
+                    Files.createDirectories(t);
+                } else {
+                    Files.createDirectories(t.getParent());
+                    Files.copy(s, t);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/migration/src/test/resources/cross-file-merge/input/_includes/merge-items.html
+++ b/migration/src/test/resources/cross-file-merge/input/_includes/merge-items.html
@@ -1,0 +1,8 @@
+{% assign v_type = include.type %}
+{% assign values = "" | split: "," %}
+{% for source in index -%}
+    {% for item in source[1].types[v_type] -%}
+        {% assign values = values | push: item %}
+    {% endfor -%}
+{% endfor -%}
+{% assign values = values | sort: 'title' %}

--- a/migration/src/test/resources/cross-file-merge/input/_includes/parent-docs.html
+++ b/migration/src/test/resources/cross-file-merge/input/_includes/parent-docs.html
@@ -1,0 +1,19 @@
+{% assign index = site.data.myindex %}
+<div id="docs">
+  {% include merge-items.html type="tutorial" %}
+  {% if values %}
+  <div class="tutorials">
+    {% for guide in values %}
+    <p>{{ guide.title }}</p>
+    {% endfor %}
+  </div>
+  {% endif %}
+  {% include merge-items.html type="reference" %}
+  {% if values %}
+  <div class="references">
+    {% for guide in values %}
+    <p>{{ guide.title }}</p>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>


### PR DESCRIPTION
This function is already in `main`, but the more complete testing is not. `mergeTypes` solves: parent includes a partial that builds up a list, then the  parent iterates that list after the include returns. Example:

```

  <!-- parent-docs.html (Jekyll) -->
  {% include merge-items.html type="tutorial" %}
  {% if values %}
    {% for guide in values %}
      ...
    {% endfor %}
  {% endif %}
  ```

The partial does `{% assign values = site.pages | where: type %}` (simplified).  In Jekyll, values leaks back to the parent. In Qute, even with `_unisolated`,  this doesn't work — `_unisolated` lets the child read the parent's variables,  but variables assigned inside the child don't flow back up to the parent.

`mergeTypes` is  the fix for bottom-up (child → parent data flow). The cross-file merge  eliminates the include entirely and inlines the logic as `{#let values=source.mergeTypes('tutorial')}` directly in the parent, sidestepping the  scoping problem.
