### PR TITLE
fix: avoid ClassTooLargeException for large data collections

### DIFF
--- a/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep5RecordProcessor.java
+++ b/roq-frontmatter/deployment/src/main/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterStep5RecordProcessor.java
@@ -25,6 +25,7 @@ import io.quarkiverse.roq.frontmatter.deployment.items.record.RoqFrontMatterReco
 import io.quarkiverse.roq.frontmatter.deployment.items.record.RoqFrontMatterRecordedNormalPageBuildItem;
 import io.quarkiverse.roq.frontmatter.deployment.items.record.RoqFrontMatterRecordedPageBuildItem;
 import io.quarkiverse.roq.frontmatter.deployment.items.record.RoqFrontMatterRecordedSiteIndexBuildItem;
+import io.quarkiverse.roq.frontmatter.runtime.EncodedJsonObject;
 import io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterRecorder;
 import io.quarkiverse.roq.frontmatter.runtime.config.ConfiguredCollection;
 import io.quarkiverse.roq.frontmatter.runtime.config.RoqSiteConfig;
@@ -95,7 +96,7 @@ class RoqFrontMatterStep5RecordProcessor {
                 final RoqUrl url = item.url();
                 final Supplier<DocumentPage> document = recorder.createDocument(item.collection().id(),
                         url,
-                        item.source(), item.data(), item.collection().hidden());
+                        item.source(), new EncodedJsonObject(item.data()), item.collection().hidden());
                 documentsById.put(item.source().id(), document);
                 pagesProducer
                         .produce(
@@ -136,7 +137,7 @@ class RoqFrontMatterStep5RecordProcessor {
         List<RoqFrontMatterPublishNormalPageBuildItem> siteIndexPages = new ArrayList<>();
         for (RoqFrontMatterPublishNormalPageBuildItem page : pages) {
             final Supplier<NormalPage> recordedPage = recorder.createPage(page.url(),
-                    page.source(), page.data(), page.paginator());
+                    page.source(), new EncodedJsonObject(page.data()), page.paginator());
             pagesProducer.produce(new RoqFrontMatterRecordedPageBuildItem(page.source().id(), page.url(), false, recordedPage));
             normalPagesProducer
                     .produce(new RoqFrontMatterRecordedNormalPageBuildItem(page.source().id(), page.url(), recordedPage));

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/EncodedJsonObject.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/EncodedJsonObject.java
@@ -1,0 +1,47 @@
+package io.quarkiverse.roq.frontmatter.runtime;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.runtime.annotations.RecordableConstructor;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Wrapper around {@link JsonObject} that controls how data is serialized by the Quarkus bytecode recorder.
+ * <p>
+ * Without this wrapper, the recorder recursively walks the JsonObject's Map structure, creating a constant pool
+ * entry for every nested key and value. For large data (e.g., collections with many articles), this overflows
+ * the JVM's 65,535 constant pool entry limit, causing {@code ClassTooLargeException}.
+ * <p>
+ * This wrapper serializes the data as chunked JSON strings via {@link RecordableConstructor}, collapsing
+ * the entire object tree into a few opaque string constants instead of thousands of individual entries.
+ */
+public class EncodedJsonObject {
+
+    private static final int CHUNK_SIZE = 50_000;
+
+    private final JsonObject data;
+
+    @RecordableConstructor
+    public EncodedJsonObject(List<String> chunks) {
+        this.data = new JsonObject(String.join("", chunks));
+    }
+
+    public EncodedJsonObject(JsonObject data) {
+        this.data = data;
+    }
+
+    public List<String> getChunks() {
+        String encoded = data.encode();
+        int numChunks = (encoded.length() + CHUNK_SIZE - 1) / CHUNK_SIZE;
+        List<String> chunks = new ArrayList<>(numChunks);
+        for (int i = 0; i < encoded.length(); i += CHUNK_SIZE) {
+            chunks.add(encoded.substring(i, Math.min(i + CHUNK_SIZE, encoded.length())));
+        }
+        return chunks;
+    }
+
+    public JsonObject get() {
+        return data;
+    }
+}

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqFrontMatterRecorder.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqFrontMatterRecorder.java
@@ -14,7 +14,6 @@ import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 
@@ -44,13 +43,13 @@ public class RoqFrontMatterRecorder {
         };
     }
 
-    public Supplier<NormalPage> createPage(RoqUrl url, PageSource source, JsonObject data, Paginator paginator) {
-        return () -> new NormalPage(url, source, data, paginator);
+    public Supplier<NormalPage> createPage(RoqUrl url, PageSource source, EncodedJsonObject data, Paginator paginator) {
+        return () -> new NormalPage(url, source, data.get(), paginator);
     }
 
-    public Supplier<DocumentPage> createDocument(String collection, RoqUrl url, PageSource source, JsonObject data,
+    public Supplier<DocumentPage> createDocument(String collection, RoqUrl url, PageSource source, EncodedJsonObject data,
             boolean hidden) {
-        return () -> new DocumentPage(collection, url, source, data, hidden);
+        return () -> new DocumentPage(collection, url, source, data.get(), hidden);
     }
 
     public Supplier<Site> createSite(RootUrl rootUrl, Supplier<NormalPage> indexPage,

--- a/roq-frontmatter/runtime/src/test/java/io/quarkiverse/roq/frontmatter/runtime/EncodedJsonObjectTest.java
+++ b/roq-frontmatter/runtime/src/test/java/io/quarkiverse/roq/frontmatter/runtime/EncodedJsonObjectTest.java
@@ -1,0 +1,78 @@
+package io.quarkiverse.roq.frontmatter.runtime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+class EncodedJsonObjectTest {
+
+    @Test
+    void smallDataRoundtrips() {
+        JsonObject original = new JsonObject()
+                .put("title", "Hello")
+                .put("count", 42);
+        EncodedJsonObject encoded = new EncodedJsonObject(original);
+        List<String> chunks = encoded.getChunks();
+        assertEquals(1, chunks.size());
+        EncodedJsonObject restored = new EncodedJsonObject(chunks);
+        assertEquals(original, restored.get());
+    }
+
+    @Test
+    void nestedDataRoundtrips() {
+        JsonObject original = new JsonObject()
+                .put("title", "Digest")
+                .put("sections", new JsonArray()
+                        .add(new JsonObject()
+                                .put("name", "AI")
+                                .put("articles", new JsonArray()
+                                        .add(new JsonObject()
+                                                .put("id", "ai-1")
+                                                .put("title", "Article One")
+                                                .put("summary", new JsonObject()
+                                                        .put("what", "Something")
+                                                        .put("why", "Because"))))));
+        EncodedJsonObject encoded = new EncodedJsonObject(original);
+        EncodedJsonObject restored = new EncodedJsonObject(encoded.getChunks());
+        assertEquals(original, restored.get());
+        assertEquals("AI", restored.get().getJsonArray("sections").getJsonObject(0).getString("name"));
+    }
+
+    @Test
+    void largeDataChunksCorrectly() {
+        JsonObject original = new JsonObject();
+        JsonArray articles = new JsonArray();
+        for (int i = 0; i < 500; i++) {
+            articles.add(new JsonObject()
+                    .put("id", "article-" + i)
+                    .put("title", "Article number " + i)
+                    .put("description", "A".repeat(200))
+                    .put("deep-summary", "B".repeat(300))
+                    .put("decoder", "C".repeat(200)));
+        }
+        original.put("sections", new JsonArray().add(new JsonObject().put("name", "Test").put("articles", articles)));
+
+        EncodedJsonObject encoded = new EncodedJsonObject(original);
+        List<String> chunks = encoded.getChunks();
+        assertTrue(chunks.size() > 1, "Large data should produce multiple chunks");
+        for (String chunk : chunks) {
+            assertTrue(chunk.length() <= 50_000, "Each chunk must be <= 50000 chars");
+        }
+
+        EncodedJsonObject restored = new EncodedJsonObject(chunks);
+        assertEquals(original, restored.get());
+    }
+
+    @Test
+    void emptyDataRoundtrips() {
+        JsonObject original = new JsonObject();
+        EncodedJsonObject encoded = new EncodedJsonObject(original);
+        EncodedJsonObject restored = new EncodedJsonObject(encoded.getChunks());
+        assertEquals(original, restored.get());
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce `EncodedJsonObject` wrapper with `@RecordableConstructor` to serialize page data as chunked JSON strings instead of letting the bytecode recorder recursively walk the JsonObject Map
- Fixes `ClassTooLargeException` for sites with large data collections (e.g., 60+ data pages with nested article content)

Fixes #477