### PR TITLE
fix: don't HTML-escape RSS titles/descriptions inside CDATA

### DIFF
--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterBasicTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterBasicTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.roq.frontmatter.deployment.apptest;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
@@ -169,6 +170,20 @@ public class RoqFrontMatterBasicTest {
         assertTrue(body.contains("content:encoded"), "Should contain content:encoded element");
         assertTrue(body.contains("..."), "Should contain truncation marker from word limit");
         assertTrue(body.contains("Keep reading"), "Should contain keep reading link");
+    }
+
+    @Test
+    @DisplayName("RSS does not HTML-escape titles/descriptions inside CDATA")
+    public void testRssCdataNotHtmlEscaped() {
+        String body = RestAssured.when().get("/rss.xml").then().statusCode(200).log().ifValidationFails()
+                .extract().body().asString();
+        // Values are wrapped in CDATA, so they must be raw text, not HTML-escaped entities.
+        assertTrue(body.contains("<title><![CDATA[Roq's tips & \"tricks\"]]></title>"),
+                "Title must be raw inside CDATA");
+        assertTrue(body.contains("<description><![CDATA[Roq's astuces & \"conseils\"]]></description>"),
+                "Description must be raw inside CDATA");
+        assertFalse(body.contains("Roq&#39;s"), "Apostrophe must not be HTML-escaped inside CDATA");
+        assertFalse(body.contains("&amp;quot;"), "Quotes must not be HTML-escaped inside CDATA");
     }
 
 }

--- a/roq-frontmatter/deployment/src/test/resources/basic-site/content/posts/2019-01-01-special-chars-post.html
+++ b/roq-frontmatter/deployment/src/test/resources/basic-site/content/posts/2019-01-01-special-chars-post.html
@@ -1,0 +1,9 @@
+---
+layout: post
+title: Roq's tips & "tricks"
+description: Roq's astuces & "conseils"
+---
+
+<h1>Special characters</h1>
+
+<p>Body with an apostrophe: it's fine.</p>

--- a/roq-frontmatter/runtime/src/main/resources/templates/fm/rss.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/fm/rss.html
@@ -5,8 +5,8 @@
 {#let name=(collectionName ?: 'posts') cl=contentLimit.or(-1)}
 <rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
   <channel>
-    <title><![CDATA[ {site.title} ]]></title>
-    <description><![CDATA[ {site.description} ]]></description>
+    <title><![CDATA[ {#if site.title}{site.title.raw}{/if} ]]></title>
+    <description><![CDATA[ {#if site.description}{site.description.raw}{/if} ]]></description>
     <link>{site.url.absolute}</link>
     <atom:link href="{site.url('rss.xml').absolute}" rel="self" type="application/rss+xml"/>
     <generator>Quarkus Roq</generator>
@@ -14,19 +14,19 @@
     <lastBuildDate>{#if site.collections.get(name).size > 0}{site.collections.get(name).get(0).date.rfc822}{/if}</lastBuildDate>
     {#for post in site.collections.get(name)}
       <item>
-        <title><![CDATA[{post.title}]]></title>
+        <title><![CDATA[{post.title.raw}]]></title>
         <link>{post.url.absolute}</link>
         <guid isPermaLink="false">{post.url.absolute}</guid>
         <pubDate>{post.date.rfc822}</pubDate>
-        <description><![CDATA[{post.description}]]></description>
+        <description><![CDATA[{#if post.description}{post.description.raw}{/if}]]></description>
         {#if cl >= 0}
         {#if cl == 0}
-        <content:encoded><![CDATA[{post.content}<div style="margin-top: 50px; font-style: italic;"><strong><a href="{post.url.absolute}">Keep reading</a>.</strong></div><br /> <br />]]></content:encoded>
+        <content:encoded><![CDATA[{post.content.raw}<div style="margin-top: 50px; font-style: italic;"><strong><a href="{post.url.absolute}">Keep reading</a>.</strong></div><br /> <br />]]></content:encoded>
         {#else}
-        <content:encoded><![CDATA[<p>{post.contentAbstract(contentLimit)}</p><div style="margin-top: 50px; font-style: italic;"><strong><a href="{post.url.absolute}">Keep reading</a>.</strong></div><br /> <br />]]></content:encoded>
+        <content:encoded><![CDATA[<p>{post.contentAbstract(contentLimit).raw}</p><div style="margin-top: 50px; font-style: italic;"><strong><a href="{post.url.absolute}">Keep reading</a>.</strong></div><br /> <br />]]></content:encoded>
         {/if}
         {#else}
-        <content:encoded><![CDATA[<p>{post.description}</p><div style="margin-top: 50px; font-style: italic;"><strong><a href="{post.url.absolute}">Keep reading</a>.</strong></div><br /> <br />]]></content:encoded>
+        <content:encoded><![CDATA[<p>{#if post.description}{post.description.raw}{/if}</p><div style="margin-top: 50px; font-style: italic;"><strong><a href="{post.url.absolute}">Keep reading</a>.</strong></div><br /> <br />]]></content:encoded>
         {/if}
       </item>
     {/for}


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                       In the generated `rss.xml`, titles and descriptions containing an apostrophe or                                                                                                                                   ampersand leak to feed readers as literal HTML entities, e.g.                                                                                                                                                                    
  `Ourson&#39;s blog` or `☕ Java à l&#39;ère de l&#39;IA`. 

## Cause                                                                                                                                                                                                                         
  `fm/rss.html` wraps values in `<![CDATA[ ... ]]>`, but because the template file                                                                                                                                                 
  has a `.html` extension, Qute applies HTML escaping to the expressions. Inside                                                                                                                                                   
  CDATA the entities are never decoded, so the escaping both is unnecessary and                                                                                                                                                    
  leaks verbatim to readers.

## Fix                                                                                                                                                                                                                           
  Output the CDATA-wrapped values with `.raw` so they remain unescaped. Nullable                                                                                                                                                   
  description fields are guarded with `{#if}` because `.raw` throws on `null`                                                                                                                                                      
  whereas the previous plain expression rendered an empty string.                                                                                                                                                                  
                                                                                                                                                                                                                                   
  This also fixes `content:encoded` in full mode, whose HTML markup was being                                                                                                                                                      
  escaped inside CDATA too.                                                                                                                                                                                                        
                                                                                                                                                                                                                                   
  ## Test                                                                                                                                                                                                                          
  Adds a post with special characters (`Roq's tips & "tricks"`) to `basic-site`                                                                                                                                                    
  and asserts the RSS keeps titles/descriptions raw inside CDATA. All existing RSS                                                                                                                                                 
  tests still pass (14/14). 