### PR TITLE
Converter: Remove workarounds for qute variable not found issue

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
@@ -2308,44 +2308,11 @@ public class LiquidToQuteConverter {
         // page.data.* and post.data.* access a JsonObject.
         // Do NOT add ?? — Qute passes "property??" as the literal key name to
         // JsonObject.getValue(), which fails because the key is "property".
-        //
-        // BUT: when a .data.* property is used as an argument to str:split/str:splitTrimmed,
-        // a missing key returns Results$NotFound which can't be cast to String → ClassCastException.
-        // Add .or('') to those arguments so the split receives an empty string instead.
-        String result = content.replaceAll(
-                "(str:split(?:Trimmed)?\\()((page|post)\\.data\\.[a-zA-Z_][a-zA-Z0-9_]*)(,)",
-                "$1$2.or('')$4");
-        if (!result.equals(content)) {
-            conversionsApplied.add("Added .or('') to .data.* properties in split arguments");
-            content = result;
-        }
-
-        // Same for .get() arguments — JsonObjectValueResolver.get(param) casts param
-        // to String, so Results$NotFound → ClassCastException.
-        // TODO: Remove .or('') workaround when Quarkus 3.38+ is the minimum version —
-        //       JsonObjectValueResolver will handle NotFound gracefully in 3.38.
-        result = content.replaceAll(
-                "(\\.get\\()((page|post)\\.data\\.[a-zA-Z_][a-zA-Z0-9_]*)(\\))",
-                "$1$2.or('')$4");
-        if (!result.equals(content)) {
-            conversionsApplied.add("Added .or('') to .data.* properties in .get() arguments");
-            content = result;
-        }
-
-        // Also protect plain variable arguments in .get() calls — a variable from a
-        // prior {#let} may hold Results$NotFound if the source expression was missing.
-        // Skip string/number literals and .data.* args (already handled above).
-        // TODO: Remove .or('') workaround when Quarkus 3.38+ is the minimum version.
-        result = addOrEmptyToGetArgs(content);
-        if (!result.equals(content)) {
-            conversionsApplied.add("Added .or('') to variable arguments in .get() calls");
-            content = result;
-        }
 
         // Guard {=page.data.FIELD} output — Liquid outputs empty string for missing
         // keys, but Qute renders NOT_FOUND.  Add .or('') so the output is blank.
         // (.raw is appended later by appendRawToOutputExpressions)
-        result = content.replaceAll(
+        String result = content.replaceAll(
                 "\\{=((page|post)\\.data\\.[a-zA-Z_][a-zA-Z0-9_]*)\\}",
                 "{=$1.or('')}");
         if (!result.equals(content)) {
@@ -2363,33 +2330,6 @@ public class LiquidToQuteConverter {
         }
 
         return result;
-    }
-
-    private String addOrEmptyToGetArgs(String content) {
-        String[] lines = content.split("\n", -1);
-        Pattern pattern = Pattern.compile("\\.get\\(([a-zA-Z_][a-zA-Z0-9_]*)\\)");
-        boolean changed = false;
-        StringBuilder result = new StringBuilder();
-
-        for (int i = 0; i < lines.length; i++) {
-            String line = lines[i];
-            Matcher m = pattern.matcher(line);
-            if (m.find()) {
-                String cleanVersion = line.trim();
-                line = pattern.matcher(line).replaceAll(".get($1.or(''))");
-                String indent = line.substring(0, line.indexOf(line.trim()));
-                result.append(indent)
-                        .append("{! TODO: Quarkus 3.38 fixes NotFound in .get() — remove .or('') to get: ")
-                        .append(cleanVersion).append(" !}\n");
-                changed = true;
-            }
-            result.append(line);
-            if (i < lines.length - 1) {
-                result.append('\n');
-            }
-        }
-
-        return changed ? result.toString() : content;
     }
 
     private String convertUrlConcatenation(String content) {

--- a/migration/src/test/java/io/quarkus/tools/LiquidToQuteConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/LiquidToQuteConverterTest.java
@@ -142,10 +142,9 @@ class LiquidToQuteConverterTest {
     @Test
     void testDefaultBeforeSplitStripsDefault() {
         String input = "{{post.author | default: \"\" | split: \",\"}}";
-        // default is stripped; .or('') added because .data.* on JsonObject returns
-        // Results$NotFound (not null) when key is missing, causing ClassCastException
-        String expected = "{=str:split(post.data.author.or(''), \",\").raw}";
-        assertConverts(input, expected, "default before split should be stripped; .data.* gets .or('')");
+        // default is stripped
+        String expected = "{=str:split(post.data.author, \",\").raw}";
+        assertConverts(input, expected, "default before split should be stripped; .data.* gets ");
     }
 
     @Test
@@ -409,7 +408,7 @@ class LiquidToQuteConverterTest {
         // post.author is custom frontmatter -> post.data.author
         // default is stripped; .or('') guards against Results$NotFound on JsonObject
         String input = "{{post.author | default: \"\" | split: \",\"}}";
-        String expected = "{=str:split(post.data.author.or(''), \",\").raw}";
+        String expected = "{=str:split(post.data.author, \",\").raw}";
         assertConverts(input, expected, "Real-world author pattern should convert correctly");
     }
 
@@ -501,44 +500,48 @@ class LiquidToQuteConverterTest {
 
     @Test
     void testPushInLoopCollapsedToSplitTrimmed() {
-        String input = "{% assign authors_raw = post.author | default: \"\" | split: \",\" %}\n" +
-                "{% assign authors_clean = \"\" | split: \"\" %}\n" +
-                "{% for a in authors_raw %}\n" +
-                "{% assign a_trimmed = a | strip %}\n" +
-                "{% if a_trimmed != \"\" %}\n" +
-                "{% assign authors_clean = authors_clean | push: a_trimmed %}\n" +
-                "{% endif %}\n" +
-                "{% endfor %}\n" +
-                "{% for author_key in authors_clean %}\n" +
-                "{{author_key}}\n" +
-                "{% endfor %}";
-        String expected = "{#for author_key in str:splitTrimmed(post.data.author.or(''), \",\").orEmpty}\n" +
-                "{=author_key.raw}\n" +
-                "{/for}";
+        String input = """
+                {% assign authors_raw = post.author | default: "" | split: "," %}
+                {% assign authors_clean = "" | split: "" %}
+                {% for a in authors_raw %}
+                {% assign a_trimmed = a | strip %}
+                {% if a_trimmed != "" %}
+                {% assign authors_clean = authors_clean | push: a_trimmed %}
+                {% endif %}
+                {% endfor %}
+                {% for author_key in authors_clean %}
+                {{author_key}}
+                {% endfor %}""";
+        String expected = """
+                {#for author_key in str:splitTrimmed(post.data.author, ",").orEmpty}
+                {=author_key.raw}
+                {/for}""";
         assertConverts(input, expected,
                 "Init-empty-list + push-in-loop + iterate should collapse to str:splitTrimmed");
     }
 
     @Test
     void testPushInLoopWithHtmlBetween() {
-        String input = "{% assign authors_raw = post.author | default: \"\" | split: \",\" %}\n" +
-                "{% assign authors_clean = \"\" | split: \"\" %}\n" +
-                "{% for a in authors_raw %}\n" +
-                "{% assign a_trimmed = a | strip %}\n" +
-                "{% if a_trimmed != \"\" %}\n" +
-                "{% assign authors_clean = authors_clean | push: a_trimmed %}\n" +
-                "{% endif %}\n" +
-                "{% endfor %}\n" +
-                "<p class=\"byline\">\n" +
-                "By\n" +
-                "{% for author_key in authors_clean %}\n" +
-                "{{author_key}}\n" +
-                "{% endfor %}";
-        String expected = "<p class=\"byline\">\n" +
-                "By\n" +
-                "{#for author_key in str:splitTrimmed(post.data.author.or(''), \",\").orEmpty}\n" +
-                "{=author_key.raw}\n" +
-                "{/for}";
+        String input = """
+                {% assign authors_raw = post.author | default: "" | split: "," %}
+                {% assign authors_clean = "" | split: "" %}
+                {% for a in authors_raw %}
+                {% assign a_trimmed = a | strip %}
+                {% if a_trimmed != "" %}
+                {% assign authors_clean = authors_clean | push: a_trimmed %}
+                {% endif %}
+                {% endfor %}
+                <p class="byline">
+                By
+                {% for author_key in authors_clean %}
+                {{author_key}}
+                {% endfor %}""";
+        String expected = """
+                <p class="byline">
+                By
+                {#for author_key in str:splitTrimmed(post.data.author, ",").orEmpty}
+                {=author_key.raw}
+                {/for}""";
         assertConverts(input, expected,
                 "Push-in-loop with HTML between should collapse, preserving the HTML");
     }
@@ -559,9 +562,11 @@ class LiquidToQuteConverterTest {
                 "      {% assign authors_raw = post.author | default: \"\" | split: \",\" %}\n" +
                 "      {% assign authors_clean = \"\" | split: \"\" %}";
 
-        String expected = "      {!  Build multi-author list for this post  !}\n" +
-                "      {#let authors_raw=str:split(post.data.author.or(''), \",\")}\n" +
-                "      {#let authors_clean=str:split(\"\", \"\")}{/let}{/let}";
+        String expected = """
+                      {!  Build multi-author list for this post  !}
+                      {#let authors_raw=str:split(post.data.author, ",")}
+                      {#let authors_clean=str:split("", "")}{/let}{/let}\
+                """;
 
         assertConverts(input, expected, "Author file lines 36-38 should convert without {?:} errors");
     }
@@ -628,19 +633,15 @@ class LiquidToQuteConverterTest {
     @Test
     void testDynamicBracketNotation() {
         String input = "{% assign author = site.data.authors[author_key] %}";
-        String expected = "{! TODO: Quarkus 3.38 fixes NotFound in .get() — remove .or('') to get: " +
-                "{#let author=cdi:authors.get(author_key)}{/let} !}\n" +
-                "{#let author=cdi:authors.get(author_key.or(''))}{/let}";
+        String expected = "{#let author=cdi:authors.get(author_key)}{/let}";
         assertConverts(input, expected,
-                "Dynamic bracket notation should be converted to .get() method call with .or('')");
+                "Dynamic bracket notation should be converted to .get() method call");
     }
 
     @Test
     void testDynamicBracketNotationInVariable() {
         String input = "{{ site.data.authors[key].name }}";
-        String expected = "{! TODO: Quarkus 3.38 fixes NotFound in .get() — remove .or('') to get: " +
-                "{=cdi:authors.get(key).name.raw} !}\n" +
-                "{=cdi:authors.get(key.or('')).name.raw}";
+        String expected = "{=cdi:authors.get(key).name.raw}";
         assertConverts(input, expected,
                 "Bracket notation followed by property access should convert correctly");
     }
@@ -648,21 +649,19 @@ class LiquidToQuteConverterTest {
     @Test
     void testGetWithPageDataArgument() {
         String input = "{% assign author = site.data.authors[post.author] %}";
-        String expected = "{#let author=cdi:authors.get(post.data.author.or(''))}{/let}";
+        String expected = "{#let author=cdi:authors.get(post.data.author)}{/let}";
         assertConverts(input, expected,
-                ".data.* property in .get() argument should get .or('') to avoid ClassCastException on NotFound");
+                ".data.* property in .get() argument");
     }
 
     @Test
     void testAssignBracketWithDefaultPreservesOr() {
         String input = "{% assign post_author = site.data.authors[post_author] | default: post_author %}" +
                 "{% if post_author %}x{% endif %}";
-        String expected = "{! TODO: Quarkus 3.38 fixes NotFound in .get() — remove .or('') to get: " +
-                "{#let post_author=cdi:authors.get(post_author).or(post_author)}{#if post_author}x{/if}{/let} !}\n" +
-                "{#let post_author=cdi:authors.get(post_author.or('')).or(post_author)}" +
+        String expected = "{#let post_author=cdi:authors.get(post_author).or(post_author)}" +
                 "{#if post_author}x{/if}{/let}";
         assertConverts(input, expected,
-                "Bracket access with default should preserve fallback as .or()");
+                "Bracket access with default should preserve fallback");
     }
 
     // --- Loop variable tests ---
@@ -1240,9 +1239,7 @@ class LiquidToQuteConverterTest {
     @Test
     void testSiteDataWithBracketAccessConvertsToeCdi() {
         assertConverts("{% if site.data.versioned[docversion_index].index %}yes{% endif %}",
-                "{! TODO: Quarkus 3.38 fixes NotFound in .get() — remove .or('') to get: " +
-                        "{#if cdi:versioned.get(docversion_index).index}yes{/if} !}\n" +
-                        "{#if cdi:versioned.get(docversion_index.or('')).index}yes{/if}",
+                "{#if cdi:versioned.get(docversion_index).index}yes{/if}",
                 "site.data.X[var] should convert to cdi:X.get(var)");
     }
 
@@ -1457,7 +1454,7 @@ class LiquidToQuteConverterTest {
         @Test
         void testTernaryWrapping() {
             assertConverts("{{post.author | default: \"\" | split: \",\"}}",
-                    "{str:split(post.data.author.or(''), \",\").raw}",
+                    "{str:split(post.data.author, \",\").raw}",
                     "Standard syntax should use namespace split with .or('') for .data.*");
         }
 


### PR DESCRIPTION
This is the best kind of PR. So much red. :) 

https://github.com/quarkusio/quarkus/issues/55438 is now available in Quarkus 3.37.4, and that means that all the workarounds the converter did to make sure Roq never hit a not-found variable can now be removed. 