### PR TITLE
Localisation support: Handle processing large data files which use large encodings

### DIFF
--- a/roq-common/runtime/src/main/java/io/quarkiverse/roq/EncodedJson.java
+++ b/roq-common/runtime/src/main/java/io/quarkiverse/roq/EncodedJson.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.roq;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,7 +21,12 @@ import io.vertx.core.json.JsonObject;
  */
 public class EncodedJson {
 
-    private static final int CHUNK_SIZE = 50_000;
+    /**
+     * Maximum chunk size in UTF-8 bytes. The JVM constant pool limit is 65,535 bytes for UTF-8 strings.
+     * We use 30,000 bytes to account for multibyte characters and provide a safety margin.
+     * See https://github.com/quarkiverse/quarkus-roq/issues/1133
+     */
+    private static final int CHUNK_SIZE_BYTES = 30_000;
 
     private final Object data;
 
@@ -44,11 +50,38 @@ public class EncodedJson {
 
     public List<String> getChunks() {
         String encoded = data instanceof JsonObject o ? o.encode() : ((JsonArray) data).encode();
-        int numChunks = (encoded.length() + CHUNK_SIZE - 1) / CHUNK_SIZE;
-        List<String> chunks = new ArrayList<>(numChunks);
-        for (int i = 0; i < encoded.length(); i += CHUNK_SIZE) {
-            chunks.add(encoded.substring(i, Math.min(i + CHUNK_SIZE, encoded.length())));
+
+        // Cheap lower bound: if even every character were 4 bytes it would still fit, skip the file-based chunking and encoding thing
+        if (encoded.length() <= CHUNK_SIZE_BYTES / 4) {
+            return List.of(encoded);
         }
+
+        byte[] utf8Bytes = encoded.getBytes(StandardCharsets.UTF_8);
+
+        // If the entire string fits within the limit, return it as a single chunk
+        if (utf8Bytes.length <= CHUNK_SIZE_BYTES) {
+            return List.of(encoded);
+        }
+
+        // Otherwise, chunk by UTF-8 byte boundaries to avoid splitting multibyte characters
+        List<String> chunks = new ArrayList<>();
+        int offset = 0;
+
+        while (offset < utf8Bytes.length) {
+            int chunkEnd = Math.min(offset + CHUNK_SIZE_BYTES, utf8Bytes.length);
+
+            // Ensure we don't split a multibyte UTF-8 character.
+            // UTF-8 continuation bytes start with 10xxxxxx (0x80-0xBF).
+            // Guard chunkEnd > offset so we always make forward progress on malformed input.
+            while (chunkEnd > offset && chunkEnd < utf8Bytes.length && (utf8Bytes[chunkEnd] & 0xC0) == 0x80) {
+                chunkEnd--;
+            }
+
+            String chunk = new String(utf8Bytes, offset, chunkEnd - offset, StandardCharsets.UTF_8);
+            chunks.add(chunk);
+            offset = chunkEnd;
+        }
+
         return chunks;
     }
 

--- a/roq-data/deployment/src/test/java/io/quarkiverse/roq/data/test/RoqDataLargeMultibyteTest.java
+++ b/roq-data/deployment/src/test/java/io/quarkiverse/roq/data/test/RoqDataLargeMultibyteTest.java
@@ -1,0 +1,68 @@
+package io.quarkiverse.roq.data.test;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Test for issue #1133: "UTF8 string too large" when building a site with multibyte content in YAML data files.
+ *
+ * The JVM constant pool has a 65,535-byte limit for UTF-8 strings. When Japanese or other multibyte characters
+ * are used (3-4 bytes per character in UTF-8), a large string can exceed this limit if chunking is done by
+ * character count instead of byte count.
+ */
+public class RoqDataLargeMultibyteTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> {
+                // Create a large YAML file with multibyte content (Japanese characters)
+                // Each Japanese character is typically 3 bytes in UTF-8
+                // Create a large single string value to trigger the bytecode constant pool limit
+                // The JVM limit is 65,535 bytes; with 3-byte chars, ~21,000 chars would exceed it
+                StringBuilder largeText = new StringBuilder();
+                for (int i = 0; i < 25000; i++) {
+                    largeText.append("日本語"); // 9 bytes (3 chars × 3 bytes each)
+                }
+
+                StringBuilder yaml = new StringBuilder();
+                yaml.append("largeValue: \"").append(largeText).append("\"\nitems:\n");
+                for (int i = 0; i < 100; i++) {
+                    yaml.append("  - text: \"日本語テキスト番号").append(i).append("\"\n");
+                    yaml.append("    description: \"これは説明文です。マルチバイト文字のテストです。\"\n");
+                }
+
+                jar.add(new StringAsset(yaml.toString()),
+                        "data/large-multibyte.yaml")
+                        .add(new StringAsset("quarkus.roq.dir=."),
+                                "application.properties");
+            });
+
+    @Inject
+    @Named("large-multibyte")
+    JsonObject largeMultibyteData;
+
+    @Test
+    public void testLargeMultibyteDataLoads() {
+        Assertions.assertNotNull(largeMultibyteData, "Large multibyte data should be loaded");
+        Assertions.assertTrue(largeMultibyteData.containsKey("items"), "Data should contain 'items' key");
+        Assertions.assertTrue(largeMultibyteData.containsKey("largeValue"), "Data should contain 'largeValue' key");
+
+        // Verify large value is correctly loaded (75,000 characters, 225,000 bytes in UTF-8)
+        String largeValue = largeMultibyteData.getString("largeValue");
+        Assertions.assertNotNull(largeValue, "Large value should not be null");
+        Assertions.assertEquals(75000, largeValue.length(), "Large value should have 75,000 characters");
+
+        // Verify the content is correctly decoded
+        JsonObject firstItem = largeMultibyteData.getJsonArray("items").getJsonObject(0);
+        Assertions.assertEquals("日本語テキスト番号0", firstItem.getString("text"));
+        Assertions.assertEquals("これは説明文です。マルチバイト文字のテストです。", firstItem.getString("description"));
+    }
+}


### PR DESCRIPTION
Resolves #1133. Follow-on to #1121 and #1120. 

Once we start translating Roq content into other languages (or even writing it in another language), character sets expand beyond UTF-8. Some of these character sets can have 3 or 4 bytes per character. When that happens, the current guard against file-largeness isn't strong enough. The JVM has 65,535-byte constant pool limit, but `main` sets a limit of 50k characters per chunk, which with 3-byte characters, can go way over the 65k byte limit. 

  The Fix:
  - Dropped the upper limit to 30,000 bytes per chunk
  - For safety, detects UTF-8 continuation bytes to avoid splitting multibyte sequences
  - Added tests with 75,000 Japanese characters (225,000 bytes)
  
In case it's not obvious, I confess I did not write the Japanese text in the tests myself. :) I worried it might say "ha, someone used Claude without understanding Japanese", but Bob assures me it means:

日本語 — "Japanese language" (lit. Japan + language). Used as the bulk filler for the large string.
日本語テキスト番号 — "Japanese language text number [N]" — the item text values.
これは説明文です。マルチバイト文字のテストです。 — "This is a description. This is a test of multibyte characters." 
  
