### PR TITLE
feat: use GAV + @fatjar for simpler jbang install

### DIFF
--- a/blog/data/roq-cli/install-jbang.yml
+++ b/blog/data/roq-cli/install-jbang.yml
@@ -3,16 +3,10 @@ tabs:
     commands:
       - prompt: "$"
         cmd: "curl"
-        args: "-Ls https://sh.jbang.dev | bash -s - trust add https://repo1.maven.org/maven2/io/quarkiverse/roq/"
-      - prompt: "$"
-        cmd: "curl"
         args: "-Ls https://sh.jbang.dev | bash -s - app install --fresh --force roq@quarkiverse/quarkus-roq"
       - success: "✓ roq installed"
   - title: Windows
     commands:
-      - prompt: ">"
-        cmd: "iex"
-        args: "\"& { $(iwr https://ps.jbang.dev) } trust add https://repo1.maven.org/maven2/io/quarkiverse/roq/\""
       - prompt: ">"
         cmd: "iex"
         args: "\"& { $(iwr https://ps.jbang.dev) } app install --fresh --force roq@quarkiverse/quarkus-roq\""

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,7 +1,7 @@
 {
   "aliases": {
     "roq": {
-      "script-ref": "https://repo1.maven.org/maven2/io/quarkiverse/roq/quarkus-roq-cli/2.1.6/quarkus-roq-cli-2.1.6-runner.jar",
+      "script-ref": "io.quarkiverse.roq:quarkus-roq-cli:2.1.6:runner@fatjar",
       "description": "Roq CLI - static site generator",
       "java": "21+",
       "runtime-options": [


### PR DESCRIPTION
jbang (and maven 4) support @fatjar on GAV's so you dont need to rely on hardcoded maven central file location anymore (since 1-2 years).

also removes need to require trust; and even if it did user will be asked first anyway so no need to make it look harder than it is.