### PR TITLE
Asciidoc: Use absolute paths when setting xrefpathprefix

### DIFF
--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/Page.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/Page.java
@@ -3,6 +3,7 @@ package io.quarkiverse.roq.frontmatter.runtime.model;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.DESCRIPTION;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.TITLE;
 import static io.quarkiverse.roq.frontmatter.runtime.RoqTemplates.ROQ_PAGE_CONTENT_FRAGMENT;
+import static io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl.isAbsolute;
 import static io.quarkiverse.roq.frontmatter.runtime.utils.Pages.getImgFromData;
 import static io.quarkiverse.roq.frontmatter.runtime.utils.Pages.normaliseName;
 import static io.quarkiverse.roq.frontmatter.runtime.utils.Pages.resolveFile;
@@ -226,7 +227,7 @@ public class Page {
         }
         // An absolute path (starting with /) is a site-level image and should be
         // resolved against the public image dir, not the page-local files.
-        if (path.startsWith("/")) {
+        if (isAbsolute(path)) {
             return site().image(path.substring(1));
         }
         path = normaliseName(path, source().files().slugified());
@@ -249,7 +250,7 @@ public class Page {
             // Use site static files
             return site().imageExists(path);
         }
-        if (path.startsWith("/")) {
+        if (isAbsolute(path)) {
             return site().imageExists(path.substring(1));
         }
         path = normaliseName(path, source().files().slugified());

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/RoqUrl.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/RoqUrl.java
@@ -116,6 +116,15 @@ public record RoqUrl(
     }
 
     /**
+     * Checks if this is an absolute path (starting with /)
+     *
+     * @return true if the path starts with a slash
+     */
+    public static boolean isAbsolute(String path) {
+        return path.startsWith("/");
+    }
+
+    /**
      * Create a new Url joining the other path.
      * Whatever if the path starts with `/`, it will always join.
      *
@@ -245,6 +254,37 @@ public record RoqUrl(
     public RoqUrl removeFirst(String str) {
         String newPath = resourcePath().replaceFirst(java.util.regex.Pattern.quote(str), "");
         return new RoqUrl(root(), newPath);
+    }
+
+    /**
+     * Extracts the collection base path from a page URL to use as relfileprefix.
+     * Examples:
+     * - /guides/my-doc → /guides/
+     * - /version/main/guides/security → /version/main/guides/
+     * - /blog/my-post/ → /blog/
+     *
+     * @param pageUrl the absolute page URL
+     * @return the collection base path with trailing slash, or null if cannot be determined
+     */
+    public static String parentPath(String pageUrl) {
+        if (pageUrl == null || pageUrl.isEmpty() || pageUrl.equals("/")) {
+            return null;
+        }
+
+        String path = isAbsolute(pageUrl) ? pageUrl.substring(1) : pageUrl;
+
+        if (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+
+        int lastSlash = path.lastIndexOf('/');
+        if (lastSlash == -1) {
+            // No slash means single-level like /my-doc, return / as base
+            return "/";
+        }
+
+        // Return everything up to and including the last slash before the page name
+        return "/" + path.substring(0, lastSlash + 1);
     }
 
 }

--- a/roq-frontmatter/runtime/src/test/java/io/quarkiverse/roq/frontmatter/runtime/model/RoqUrlTest.java
+++ b/roq-frontmatter/runtime/src/test/java/io/quarkiverse/roq/frontmatter/runtime/model/RoqUrlTest.java
@@ -127,6 +127,41 @@ class RoqUrlTest {
     }
 
     @Test
+    void testParentPathMultiSegment() {
+        assertEquals("/guides/", RoqUrl.parentPath("/guides/my-doc"));
+    }
+
+    @Test
+    void testParentPathDeepPath() {
+        assertEquals("/version/main/guides/", RoqUrl.parentPath("/version/main/guides/security"));
+    }
+
+    @Test
+    void testParentPathTrailingSlash() {
+        assertEquals("/blog/", RoqUrl.parentPath("/blog/my-post/"));
+    }
+
+    @Test
+    void testParentPathSingleSegment() {
+        assertEquals("/", RoqUrl.parentPath("/my-doc"));
+    }
+
+    @Test
+    void testParentPathRoot() {
+        assertNull(RoqUrl.parentPath("/"));
+    }
+
+    @Test
+    void testParentPathNull() {
+        assertNull(RoqUrl.parentPath(null));
+    }
+
+    @Test
+    void testParentPathEmpty() {
+        assertNull(RoqUrl.parentPath(""));
+    }
+
+    @Test
     void testIsFullPathHttpSchemes() {
         assertTrue(RoqUrl.isFullPath("http://example.com"));
         assertTrue(RoqUrl.isFullPath("https://example.com/foo"));

--- a/roq-plugin/asciidoc-jruby/integration-tests/src/test/java/io/quarkiverse/roq/RoqAsciidocJTest.java
+++ b/roq-plugin/asciidoc-jruby/integration-tests/src/test/java/io/quarkiverse/roq/RoqAsciidocJTest.java
@@ -65,13 +65,4 @@ public class RoqAsciidocJTest {
         assertThat(body).contains("Roughly 15 minutes");
     }
 
-    @Test
-    public void testXrefUsesAbsolutePaths() {
-        final String body = RestAssured.when().get("/guides/my-doc").then().statusCode(200).log().ifValidationFails().extract()
-                .asString();
-        // Xrefs should use absolute paths like /guides/rabbitmq/ not relative paths like ../rabbitmq/
-        // This ensures links work correctly in both dev mode and production builds
-        assertThat(body).contains("<a href=\"/guides/rabbitmq/\">Quarkus Messaging RabbitMQ extension</a>");
-        assertThat(body).doesNotContain("href=\"../rabbitmq/\"");
-    }
 }

--- a/roq-plugin/asciidoc-jruby/integration-tests/src/test/java/io/quarkiverse/roq/RoqAsciidocJTest.java
+++ b/roq-plugin/asciidoc-jruby/integration-tests/src/test/java/io/quarkiverse/roq/RoqAsciidocJTest.java
@@ -15,7 +15,7 @@ public class RoqAsciidocJTest {
         final String body = RestAssured.when().get("/guides/my-doc").then().statusCode(200).log().ifValidationFails().extract()
                 .asString();
         assertThat(body).contains("<h1 class=\"page-title\">Getting Started to Quarkus Messaging with AMQP 1.0</h1>");
-        assertThat(body).contains("<a href=\"../rabbitmq/\">Quarkus Messaging RabbitMQ extension</a>");
+        assertThat(body).contains("<a href=\"/guides/rabbitmq/\">Quarkus Messaging RabbitMQ extension</a>");
         assertThat(body).contains("Roughly 15 minutes");
         assertThat(body).contains("<h3 id=\"foo\">Foo</h3>");
         assertThat(body).contains("<h4 id=\"what-is-lorem-ipsum\">What is Lorem Ipsum?</h4>");
@@ -63,5 +63,15 @@ public class RoqAsciidocJTest {
                 .asString();
         assertThat(body).contains("content-result");
         assertThat(body).contains("Roughly 15 minutes");
+    }
+
+    @Test
+    public void testXrefUsesAbsolutePaths() {
+        final String body = RestAssured.when().get("/guides/my-doc").then().statusCode(200).log().ifValidationFails().extract()
+                .asString();
+        // Xrefs should use absolute paths like /guides/rabbitmq/ not relative paths like ../rabbitmq/
+        // This ensures links work correctly in both dev mode and production builds
+        assertThat(body).contains("<a href=\"/guides/rabbitmq/\">Quarkus Messaging RabbitMQ extension</a>");
+        assertThat(body).doesNotContain("href=\"../rabbitmq/\"");
     }
 }

--- a/roq-plugin/asciidoc-jruby/runtime/src/main/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidoctorJConverter.java
+++ b/roq-plugin/asciidoc-jruby/runtime/src/main/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidoctorJConverter.java
@@ -31,7 +31,7 @@ public class AsciidoctorJConverter {
     public static final String ROOTDIR = "root_dir";
 
     private final Asciidoctor asciidoctor;
-    private Map<String, String> configuredAttributes;
+    private final Map<String, String> configuredAttributes;
 
     @Inject
     public AsciidoctorJConverter(AsciidoctorJConfig config) {
@@ -56,9 +56,9 @@ public class AsciidoctorJConverter {
         // The relative path fails if pages are accessed without a trailing slash
         String relfileprefix = "../"; // fallback to relative
         if (templateAttributes.pageUrl() != null) {
-            String collectionBasePath = parentPath(templateAttributes.pageUrl());
-            if (collectionBasePath != null) {
-                relfileprefix = collectionBasePath;
+            String basePath = parentPath(templateAttributes.pageUrl());
+            if (basePath != null) {
+                relfileprefix = basePath;
             }
         }
 

--- a/roq-plugin/asciidoc-jruby/runtime/src/main/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidoctorJConverter.java
+++ b/roq-plugin/asciidoc-jruby/runtime/src/main/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidoctorJConverter.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.roq.plugin.asciidoctorj.runtime;
 
+import static io.quarkiverse.roq.frontmatter.runtime.model.RoqUrl.parentPath;
 import static org.asciidoctor.Options.BASEDIR;
 
 import java.nio.file.Path;
@@ -11,7 +12,12 @@ import java.util.Map;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
-import org.asciidoctor.*;
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.AttributesBuilder;
+import org.asciidoctor.Options;
+import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.SafeMode;
 import org.asciidoctor.ast.Document;
 import org.jboss.logging.Logger;
 
@@ -44,10 +50,22 @@ public class AsciidoctorJConverter {
     }
 
     public Options createOptions(Map<String, String> asciidocAttributes, RoqTemplateAttributes templateAttributes) {
+
+        // Set relfileprefix and relfilesuffix based on the page's collection path
+        // This ensures xrefs generate absolute paths like /guides/file/ instead of ../file/
+        // The relative path fails if pages are accessed without a trailing slash
+        String relfileprefix = "../"; // fallback to relative
+        if (templateAttributes.pageUrl() != null) {
+            String collectionBasePath = parentPath(templateAttributes.pageUrl());
+            if (collectionBasePath != null) {
+                relfileprefix = collectionBasePath;
+            }
+        }
+
         final AttributesBuilder attributes = Attributes.builder()
                 .attribute("showtitle@", "")
                 .attribute("sitegen@", "roq")
-                .attribute("relfileprefix@", "../")
+                .attribute("relfileprefix@", relfileprefix)
                 .attribute("relfilesuffix@", "/")
                 .attribute("noheader@", "");
         if (templateAttributes.pageUrl() != null) {


### PR DESCRIPTION
I noticed that xrefs work on the generated site, but are sometimes failing in dev mode. The problem turned out to be because in the generated site, links always end up with a trailing slash (`/guides/my-page/`), but in dev mode, the trailing slash is not there. This means that the url gets resolved to `/guides/my-page../something`, which then turns into `/something`, which doesn't exist. Instead of hardcoding `..`, we can work out the actual parent path and use that as the relative prefix. 

I always get a bit muddled about trailing slashes and web generation so I wasn't totally sure this fix is better than just adding the trailing slash, but two different claude models and gemini all agreed that it was cleaner, more semantically clear, and more idiomatic than using `..` in urls. So I've gone with that. 

I added some utility methods along the way, so I converted a few other classes to use them as well. 