### PR TITLE
Correct generated files

### DIFF
--- a/blog/includes/configs/quarkus-roq-plugin-tagging.adoc
+++ b/blog/includes/configs/quarkus-roq-plugin-tagging.adoc
@@ -28,26 +28,5 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-roq-plugin-tagging_quarkus-roq-tagging-lowercase]] [.property-path]##link:#quarkus-roq-plugin-tagging_quarkus-roq-tagging-lowercase[`+++quarkus.roq.tagging.lowercase+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.roq.tagging.lowercase+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-When true, all selected tags are transformed to lowercase.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_ROQ_TAGGING_LOWERCASE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_ROQ_TAGGING_LOWERCASE+++`
-endif::add-copy-button-to-env-var[]
---
-|boolean
-|`+++false+++`
-
 |===
 

--- a/blog/includes/configs/quarkus-roq-plugin-tagging_quarkus.roq.adoc
+++ b/blog/includes/configs/quarkus-roq-plugin-tagging_quarkus.roq.adoc
@@ -28,26 +28,5 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-roq-plugin-tagging_quarkus-roq-tagging-lowercase]] [.property-path]##link:#quarkus-roq-plugin-tagging_quarkus-roq-tagging-lowercase[`+++quarkus.roq.tagging.lowercase+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.roq.tagging.lowercase+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-When true, all selected tags are transformed to lowercase.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_ROQ_TAGGING_LOWERCASE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_ROQ_TAGGING_LOWERCASE+++`
-endif::add-copy-button-to-env-var[]
---
-|boolean
-|`+++false+++`
-
 |===
 

--- a/docs/modules/ROOT/pages/_includes/quarkus-roq-plugin-tagging.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-roq-plugin-tagging.adoc
@@ -28,26 +28,5 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-roq-plugin-tagging_quarkus-roq-tagging-lowercase]] [.property-path]##link:#quarkus-roq-plugin-tagging_quarkus-roq-tagging-lowercase[`+++quarkus.roq.tagging.lowercase+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.roq.tagging.lowercase+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-When true, all selected tags are transformed to lowercase.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_ROQ_TAGGING_LOWERCASE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_ROQ_TAGGING_LOWERCASE+++`
-endif::add-copy-button-to-env-var[]
---
-|boolean
-|`+++false+++`
-
 |===
 

--- a/docs/modules/ROOT/pages/_includes/quarkus-roq-plugin-tagging_quarkus.roq.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-roq-plugin-tagging_quarkus.roq.adoc
@@ -28,26 +28,5 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-roq-plugin-tagging_quarkus-roq-tagging-lowercase]] [.property-path]##link:#quarkus-roq-plugin-tagging_quarkus-roq-tagging-lowercase[`+++quarkus.roq.tagging.lowercase+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.roq.tagging.lowercase+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-When true, all selected tags are transformed to lowercase.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_ROQ_TAGGING_LOWERCASE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_ROQ_TAGGING_LOWERCASE+++`
-endif::add-copy-button-to-env-var[]
---
-|boolean
-|`+++false+++`
-
 |===
 


### PR DESCRIPTION
Release CIs fail if the build alters any files. 

https://github.com/quarkiverse/quarkus-roq/pull/1162 did a fix to commit some generated files that were blocking the release, but I must have been working on a state checkout, and so I created duplicated entries. I'm not sure why CI is generating files differently than local builds, because I still can't reproduce the source changes locally, but that's a broader problem for another day. :)