### PR TITLE
fix: update release hook sed to match GAV format

### DIFF
--- a/.github/workflows/hooks/post-prepare-release.sh
+++ b/.github/workflows/hooks/post-prepare-release.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-sed -i "s|quarkus-roq-cli/[^/]*/quarkus-roq-cli-[^-]*-runner|quarkus-roq-cli/${CURRENT_VERSION}/quarkus-roq-cli-${CURRENT_VERSION}-runner|g" jbang-catalog.json
+sed -i "s|quarkus-roq-cli:[^:]*:runner@fatjar|quarkus-roq-cli:${CURRENT_VERSION}:runner@fatjar|g" jbang-catalog.json
 git add jbang-catalog.json
 git commit -m "Update jbang-catalog.json for ${CURRENT_VERSION}"


### PR DESCRIPTION
## Summary
- The `post-prepare-release.sh` hook was using a URL path pattern (`quarkus-roq-cli/[^/]*/quarkus-roq-cli-[^-]*-runner`) to update the version in `jbang-catalog.json`
- The file now uses Maven GAV format (`io.quarkiverse.roq:quarkus-roq-cli:VERSION:runner@fatjar`), so the sed matched nothing, `git commit` found nothing to commit, and the release CI failed
- Updated the sed to match the current GAV format