### PR TITLE
fix(lunr): make search dialog and trigger accessible

### DIFF
--- a/roq-plugin/lunr/deployment/src/test/java/io/quarkiverse/roq/plugin/lunr/test/RoqPluginLunrTagsAccessibilityTest.java
+++ b/roq-plugin/lunr/deployment/src/test/java/io/quarkiverse/roq/plugin/lunr/test/RoqPluginLunrTagsAccessibilityTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.roq.plugin.lunr.test;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+/**
+ * Site: {@code lunr-site} (resource)
+ * <p>
+ * Features tested: accessibility attributes rendered by the search-overlay,
+ * search-button and search-script tags.
+ */
+@DisplayName("Roq Plugin Lunr - search widgets accessibility")
+public class RoqPluginLunrTagsAccessibilityTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application.properties")
+                    .addAsResource("lunr-site"));
+
+    @Test
+    @DisplayName("Search overlay exposes dialog semantics and a live results region")
+    public void testSearchOverlayAccessibility() {
+        RestAssured.when().get("/").then().statusCode(200)
+                .body(containsString(
+                        "id=\"search-overlay\" role=\"dialog\" aria-modal=\"true\" aria-label=\"Search\" aria-hidden=\"true\""))
+                .body(containsString("id=\"search-close\" aria-label=\"Close search\""))
+                .body(containsString(
+                        "id=\"search-results\" role=\"region\" aria-live=\"polite\" aria-label=\"Search results\""));
+    }
+
+    @Test
+    @DisplayName("Search trigger is a keyboard-operable button")
+    public void testSearchButtonAccessibility() {
+        RestAssured.when().get("/").then().statusCode(200)
+                .body(containsString(
+                        "<button type=\"button\" id=\"search-button\" class=\"search-button\" aria-label=\"Search\">"));
+    }
+}

--- a/roq-plugin/lunr/deployment/src/test/resources/application.properties
+++ b/roq-plugin/lunr/deployment/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+quarkus.roq.resource-dir=lunr-site
+
+site.url=https://mywebsite.com
+site.time-zone=UTC

--- a/roq-plugin/lunr/deployment/src/test/resources/lunr-site/content/index.html
+++ b/roq-plugin/lunr/deployment/src/test/resources/lunr-site/content/index.html
@@ -1,0 +1,7 @@
+---
+title: Home
+description: Home page
+layout: default
+---
+
+<p>Hello</p>

--- a/roq-plugin/lunr/deployment/src/test/resources/lunr-site/templates/layouts/default.html
+++ b/roq-plugin/lunr/deployment/src/test/resources/lunr-site/templates/layouts/default.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  {#search-script /}
+</head>
+<body>
+  {#search-button /}
+  {#search-overlay /}
+  {#insert /}
+</body>
+</html>

--- a/roq-plugin/lunr/runtime/src/main/resources/templates/tags/search-button-input.html
+++ b/roq-plugin/lunr/runtime/src/main/resources/templates/tags/search-button-input.html
@@ -1,7 +1,7 @@
-<div class="search-trigger-input">
+<button type="button" class="search-trigger-input" aria-label="{placeholder ?: 'Search...'}">
   <svg class="search-trigger-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
     <path d="M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208zM208 352a144 144 0 1 0 0-288 144 144 0 1 0 0 288z"/>
   </svg>
   <span class="search-trigger-text">{placeholder ?: 'Search...'}</span>
   <kbd class="search-trigger-shortcut">{shortcut ?: '⌘K'}</kbd>
-</div>
+</button>

--- a/roq-plugin/lunr/runtime/src/main/resources/templates/tags/search-button.html
+++ b/roq-plugin/lunr/runtime/src/main/resources/templates/tags/search-button.html
@@ -1,1 +1,1 @@
-<div id="search-button" class="search-button"></div>
+<button type="button" id="search-button" class="search-button" aria-label="Search"></button>

--- a/roq-plugin/lunr/runtime/src/main/resources/templates/tags/search-overlay.html
+++ b/roq-plugin/lunr/runtime/src/main/resources/templates/tags/search-overlay.html
@@ -1,17 +1,18 @@
-<div class="search-overlay" id="search-overlay">
+<div class="search-overlay" id="search-overlay" role="dialog" aria-modal="true" aria-label="Search" aria-hidden="true">
   <div class="search-overlay-content">
-    <button class="search-close" id="search-close">&times;</button>
+    <button class="search-close" id="search-close" aria-label="Close search">&times;</button>
     <div id="search-field">
       <input
         type="search"
         class="search-input"
         id="search-input"
         placeholder="Search..."
+        aria-label="Search"
         autocomplete="off"
         autofocus
       />
     </div>
-    <div class="search-results" id="search-results">
+    <div class="search-results" id="search-results" role="region" aria-live="polite" aria-label="Search results">
       <!-- Search results will be dynamically inserted here -->
     </div>
   </div>

--- a/roq-plugin/lunr/runtime/src/main/web/search.css
+++ b/roq-plugin/lunr/runtime/src/main/web/search.css
@@ -35,8 +35,11 @@
 }
 
 .search-button {
+  appearance: none;
+  -webkit-appearance: none;
   width: 100%;
   height: var(--search-icon-size);
+  padding: 0;
   background: var(--search-icon) no-repeat center;
   background-size: contain;
   border: none;
@@ -45,6 +48,11 @@
 }
 
 .search-trigger-input {
+  appearance: none;
+  -webkit-appearance: none;
+  font: inherit;
+  color: inherit;
+  text-align: left;
   display: flex;
   align-items: center;
   gap: 8px;

--- a/roq-plugin/lunr/runtime/src/main/web/search.js
+++ b/roq-plugin/lunr/runtime/src/main/web/search.js
@@ -26,9 +26,39 @@ const setupSearch = function (options = {}) {
     const searchOverlay = document.getElementById("search-overlay");
     const closeSearch = document.getElementById("search-close");
 
+    let lastFocusedElement = null;
+
+    function getFocusableElements() {
+        return Array.from(
+            searchOverlay.querySelectorAll('a[href], button, input, [tabindex]:not([tabindex="-1"])')
+        ).filter((el) => !el.disabled);
+    }
+
+    function trapFocus(e) {
+        if (e.key !== "Tab") {
+            return;
+        }
+        const focusable = getFocusableElements();
+        if (focusable.length === 0) {
+            return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+        }
+    }
+
     function openSearch(e) {
         e.preventDefault();
+        lastFocusedElement = document.activeElement;
         searchOverlay.classList.add("active");
+        searchOverlay.setAttribute("aria-hidden", "false");
+        searchOverlay.addEventListener("keydown", trapFocus);
         setTimeout(() => {
             searchInputEl.value = '';
             searchInputEl.focus();
@@ -37,8 +67,14 @@ const setupSearch = function (options = {}) {
 
     function closeSearchOverlay(e) {
         searchOverlay.classList.remove("active");
+        searchOverlay.setAttribute("aria-hidden", "true");
+        searchOverlay.removeEventListener("keydown", trapFocus);
         searchInputEl.value = '';
         searchQuery = null;
+        if (lastFocusedElement) {
+            lastFocusedElement.focus();
+            lastFocusedElement = null;
+        }
     }
 
     if (searchButtonEl) {


### PR DESCRIPTION
## Summary

The Lunr search overlay and trigger button had no accessibility semantics:

- The overlay had no `role="dialog"`, `aria-modal`, or accessible name, so screen readers didn't announce it as a dialog.
- The close button (`×`) and the search input had no accessible name (the input relied on `placeholder` only).
- The search results region had no `aria-live`, so results appearing as you type were never announced.
- The default `search-button` and `search-trigger-input` components were plain `<div>`s with no keyboard support (not focusable, not activatable with Enter/Space).
- Closing the overlay dropped focus instead of returning it to the element that opened it, and Tab could escape the dialog into the page behind it.

## Changes

- `search-overlay.html`: `role="dialog"`, `aria-modal="true"`, `aria-label="Search"`, `aria-hidden` on the overlay; `aria-label` on the close button and input; `role="region"` + `aria-live="polite"` on the results container.
- `search-button.html` / `search-button-input.html`: changed from `<div>` to `<button type="button">` with `aria-label`, plus matching CSS resets in `search.css` so native button chrome doesn't regress the existing look.
- `search.js`: toggles `aria-hidden` on open/close, saves `document.activeElement` before opening and restores focus to it on close, and traps `Tab` within the dialog while it's open.

## Test plan

- Added `RoqPluginLunrTagsAccessibilityTest` (deployment module) with a minimal site fixture, asserting the rendered markup carries the new ARIA attributes.
- Ran `mvn verify` for `roq-plugin/lunr/runtime` and `roq-plugin/lunr/deployment` — all tests pass (17 existing + 2 new).
- Manually verified the fix on a real site consuming this plugin: overlay announces as a dialog, results are announced live, and the trigger button is keyboard-operable.