### PR TITLE
Provide BLANK workaround for some asciidoc config, converter updates

### DIFF
--- a/blog/includes/configs/quarkus-roq-plugin-asciidoc-jruby.adoc
+++ b/blog/includes/configs/quarkus-roq-plugin-asciidoc-jruby.adoc
@@ -17,6 +17,8 @@ endif::add-copy-button-to-config-props[]
 --
 Defines the AsciidoctorJ attributes to be applied during rendering.
 
+Use the special value `BLANK` to set an attribute to the empty string, since SmallRye Config does not support empty map values. For example, `quarkus.asciidoc.attributes.idprefix=BLANK` sets `idprefix` to `""`.
+
 Default values:
 
  - `relfileprefix=../`

--- a/blog/includes/configs/quarkus-roq-plugin-asciidoc-jruby_quarkus.asciidoc.adoc
+++ b/blog/includes/configs/quarkus-roq-plugin-asciidoc-jruby_quarkus.asciidoc.adoc
@@ -17,6 +17,8 @@ endif::add-copy-button-to-config-props[]
 --
 Defines the AsciidoctorJ attributes to be applied during rendering.
 
+Use the special value `BLANK` to set an attribute to the empty string, since SmallRye Config does not support empty map values. For example, `quarkus.asciidoc.attributes.idprefix=BLANK` sets `idprefix` to `""`.
+
 Default values:
 
  - `relfileprefix=../`

--- a/docs/modules/ROOT/pages/_includes/quarkus-roq-plugin-asciidoc-jruby.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-roq-plugin-asciidoc-jruby.adoc
@@ -17,6 +17,8 @@ endif::add-copy-button-to-config-props[]
 --
 Defines the AsciidoctorJ attributes to be applied during rendering.
 
+Use the special value `BLANK` to set an attribute to the empty string, since SmallRye Config does not support empty map values. For example, `quarkus.asciidoc.attributes.idprefix=BLANK` sets `idprefix` to `""`.
+
 Default values:
 
  - `relfileprefix=../`

--- a/docs/modules/ROOT/pages/_includes/quarkus-roq-plugin-asciidoc-jruby_quarkus.asciidoc.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-roq-plugin-asciidoc-jruby_quarkus.asciidoc.adoc
@@ -17,6 +17,8 @@ endif::add-copy-button-to-config-props[]
 --
 Defines the AsciidoctorJ attributes to be applied during rendering.
 
+Use the special value `BLANK` to set an attribute to the empty string, since SmallRye Config does not support empty map values. For example, `quarkus.asciidoc.attributes.idprefix=BLANK` sets `idprefix` to `""`.
+
 Default values:
 
  - `relfileprefix=../`

--- a/migration/src/main/java/io/quarkus/tools/JekyllConfigConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/JekyllConfigConverter.java
@@ -30,6 +30,8 @@ public class JekyllConfigConverter {
     public static final String CONFIG_DIR = "config";
     public static final String DATA_DIR = "data";
     public static final String SITE_CONFIG_FILE = "siteConfig.yml";
+    // SmallRye Config rejects empty map values, so use BLANK as a special value
+    public static final String BLANK = "BLANK";
     private final YAMLMapper yamlMapper;
     private final ObjectMapper objectMapper;
     private boolean strictProperties;
@@ -388,6 +390,15 @@ public class JekyllConfigConverter {
         if (config == null || !config.has("asciidoctor")) {
             return;
         }
+
+        // jekyll-asciidoc overrides Asciidoctor's idprefix/idseparator defaults ('_'/'_')
+        // to ''/ '-', producing web-friendly IDs (e.g. 'my-section' instead of '_my_section').
+        // SmallRye Config rejects empty map values, so idprefix uses BLANK (resolved by
+        // the Roq asciidoc plugin to "").
+        // Set before explicit attributes so _config.yml values can override.
+        properties.setProperty("quarkus.asciidoc.attributes.idprefix", BLANK);
+        properties.setProperty("quarkus.asciidoc.attributes.idseparator", "-");
+
         JsonNode asciidoctor = config.get("asciidoctor");
         if (!asciidoctor.has("attributes")) {
             return;
@@ -398,9 +409,10 @@ public class JekyllConfigConverter {
         }
         attributes.fields().forEachRemaining(entry -> {
             String value = entry.getValue().asText();
-            if (!value.isEmpty()) {
-                properties.setProperty("quarkus.asciidoc.attributes." + entry.getKey(), value);
+            if (value.isEmpty()) {
+                value = BLANK;
             }
+            properties.setProperty("quarkus.asciidoc.attributes." + entry.getKey(), value);
         });
     }
 

--- a/migration/src/test/java/io/quarkus/tools/JekyllConfigConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/JekyllConfigConverterTest.java
@@ -750,10 +750,27 @@ class JekyllConfigConverterTest {
                 "Jekyll asciidoctor.attributes.icons should map to quarkus.asciidoc.attributes.icons");
         assertEquals("highlightjs", props.getProperty("quarkus.asciidoc.attributes.source-highlighter"),
                 "Jekyll asciidoctor.attributes.source-highlighter should map to quarkus.asciidoc.attributes.source-highlighter");
-        assertNull(props.getProperty("quarkus.asciidoc.attributes.sectanchors"),
-                "Empty-string attributes should be skipped (SmallRye Config rejects empty map values)");
-        assertNull(props.getProperty("quarkus.asciidoc.attributes.outfilesuffix"),
-                "Empty-string attributes should be skipped");
+        assertEquals("BLANK", props.getProperty("quarkus.asciidoc.attributes.sectanchors"),
+                "Empty-string attributes should be emitted as BLANK (resolved to '' by the Roq plugin)");
+        assertEquals("BLANK", props.getProperty("quarkus.asciidoc.attributes.outfilesuffix"),
+                "Empty-string attributes should be emitted as BLANK");
+        assertEquals("BLANK", props.getProperty("quarkus.asciidoc.attributes.idprefix"),
+                "jekyll-asciidoc defaults idprefix to '' — emitted as BLANK");
+        assertEquals("-", props.getProperty("quarkus.asciidoc.attributes.idseparator"),
+                "jekyll-asciidoc defaults idseparator to '-' instead of Asciidoctor's '_'");
+    }
+
+    @Test
+    void testNoAsciidoctorBlockOmitsIdSeparator() throws IOException {
+        String configYaml = """
+                title: Test Site
+                """;
+        Properties props = converter.createApplicationProperties(
+                new com.fasterxml.jackson.dataformat.yaml.YAMLMapper().readTree(configYaml));
+        assertNull(props.getProperty("quarkus.asciidoc.attributes.idseparator"),
+                "idseparator should only be set when asciidoctor config is present");
+        assertNull(props.getProperty("quarkus.asciidoc.attributes.idprefix"),
+                "idprefix should only be set when asciidoctor config is present");
     }
 
     @Test

--- a/roq-plugin/asciidoc-jruby/deployment/src/test/java/io/quarkiverse/roq/plugin/asciidoctorj/test/AsciidoctorJConverterTest.java
+++ b/roq-plugin/asciidoc-jruby/deployment/src/test/java/io/quarkiverse/roq/plugin/asciidoctorj/test/AsciidoctorJConverterTest.java
@@ -31,6 +31,20 @@ public class AsciidoctorJConverterTest {
     }
 
     @Test
+    void shouldApplyBLANKAttributeAsEmpty() {
+        AsciidoctorJConverter blankConverter = new AsciidoctorJConverter(Map.of("idprefix", "BLANK"));
+        RoqTemplateAttributes attrs = new RoqTemplateAttributes(
+                "/tmp/site",
+                "/tmp/site/content/guides/test.adoc",
+                null, null, null, null);
+
+        Options options = blankConverter.createOptions(Map.of(), attrs);
+        Document doc = asciidoctor.load("= Test\n\n== My Section", options);
+
+        assertThat(doc.getAttribute("idprefix")).isEqualTo("");
+    }
+
+    @Test
     void shouldSetDocnameWithMultipleDots() {
         RoqTemplateAttributes attrs = new RoqTemplateAttributes(
                 "/tmp/site",

--- a/roq-plugin/asciidoc-jruby/runtime/src/main/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidoctorJConfig.java
+++ b/roq-plugin/asciidoc-jruby/runtime/src/main/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidoctorJConfig.java
@@ -13,6 +13,11 @@ public interface AsciidoctorJConfig {
     /**
      * Defines the AsciidoctorJ attributes to be applied during rendering.
      * <p>
+     * Use the special value {@code BLANK} to set an attribute to the empty string,
+     * since SmallRye Config does not support empty map values.
+     * For example, {@code quarkus.asciidoc.attributes.idprefix=BLANK} sets {@code idprefix}
+     * to {@code ""}.
+     * <p>
      * Default values:
      * <ul>
      * <li><code>relfileprefix=../</code></li>

--- a/roq-plugin/asciidoc-jruby/runtime/src/main/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidoctorJConverter.java
+++ b/roq-plugin/asciidoc-jruby/runtime/src/main/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidoctorJConverter.java
@@ -23,6 +23,7 @@ public class AsciidoctorJConverter {
 
     private static final Logger LOG = Logger.getLogger(AsciidoctorJConverter.class);
     public static final String ROOTDIR = "root_dir";
+    public static final String BLANK = "BLANK";
 
     private final Asciidoctor asciidoctor;
     private Map<String, String> configuredAttributes;
@@ -62,7 +63,7 @@ public class AsciidoctorJConverter {
         if (templateAttributes.sitePath() != null) {
             attributes.attribute("site-path", templateAttributes.sitePath());
         }
-        configuredAttributes.forEach(attributes::attribute);
+        configuredAttributes.forEach((key, value) -> attributes.attribute(key, resolveAttributeValue(value)));
         asciidocAttributes.forEach(attributes::attribute);
 
         final OptionsBuilder optionsBuilder = Options.builder();
@@ -89,6 +90,10 @@ public class AsciidoctorJConverter {
         // In Qute context it might often be indented
         final Document doc = asciidoctor.load(trimIndent(asciidoc), options);
         return doc.convert();
+    }
+
+    static String resolveAttributeValue(String value) {
+        return BLANK.equals(value) ? "" : value;
     }
 
     public static String trimIndent(String content) {


### PR DESCRIPTION
I chewed on this a bit, but this fix seems to be the best option, even though it's kind of icky. 

Asciidoctor defaults to idprefix='' and idseparator='', but jekyll-asciidoc overrode these to '' and '-', producing IDs like 'my-section' instead of '_my_section'. This can almost be controlled by application-properties, but SmallRye Config rejects empty map values so idprefix cannot be set to an empty value via application.properties. The recommended solution is to use special values to represent empty values. So I've implemented a BLANK special value and used it in the field where blank is most likely to be needed. 

I also made the converter updates to set this config, since otherwise conversions will have broken fragment anchors.

Note that I've worked around this (https://github.com/quarkusio/quarkusio.github.io/pull/2934), so it's not blocking anything. 