### PR TITLE
fix(frontmatter): omit llms.txt/llms-full.txt heading for collections with no visible docs

### DIFF
--- a/roq-frontmatter/deployment/src/test/collection-site/content/guides/getting-started.html
+++ b/roq-frontmatter/deployment/src/test/collection-site/content/guides/getting-started.html
@@ -2,6 +2,7 @@
 layout: guide
 title: Getting Started (Local Override)
 slug: getting-started
+llmstxt: false
 ---
 <h1>{page.title}</h1>
 <p>This is the local version of the getting started guide, which should override the resource version.</p>

--- a/roq-frontmatter/deployment/src/test/collection-site/content/llms-full.qute.txt
+++ b/roq-frontmatter/deployment/src/test/collection-site/content/llms-full.qute.txt
@@ -1,0 +1,1 @@
+{#include fm/llms-full.html}

--- a/roq-frontmatter/deployment/src/test/collection-site/content/llms.qute.txt
+++ b/roq-frontmatter/deployment/src/test/collection-site/content/llms.qute.txt
@@ -1,0 +1,1 @@
+{#include fm/llms.html}

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterCollectionTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterCollectionTest.java
@@ -18,7 +18,8 @@ import io.restassured.RestAssured;
  * Features tested: multi-collection site (posts + guides), collection counts,
  * next/prev navigation, date-based link patterns, pagination (size, total, pages),
  * author filtering, past() extension, readTime, local file overriding resource file,
- * theme layout override by local layout, layout chain rendering.
+ * theme layout override by local layout, layout chain rendering, llms.txt heading omitted
+ * for a collection with no visible docs.
  */
 @DisplayName("Roq FrontMatter - Collections, navigation, pagination, theme override, and local/resource priority")
 public class RoqFrontMatterCollectionTest {
@@ -303,5 +304,35 @@ public class RoqFrontMatterCollectionTest {
         String body = RestAssured.when().get("/guides/getting-started").then().statusCode(200)
                 .extract().body().asString();
         org.junit.jupiter.api.Assertions.assertTrue(body.contains("<article class=\"guide\">"));
+    }
+
+    // --- llms.txt ---
+
+    @Test
+    @DisplayName("llms.txt omits heading for collection with no visible docs")
+    public void testLlmsTxtOmitsCollectionWithNoVisibleDocs() {
+        RestAssured.when().get("/llms.txt").then().statusCode(200).log().ifValidationFails()
+                .body(not(containsString("## Guides")));
+    }
+
+    @Test
+    @DisplayName("llms.txt keeps heading for collection with visible docs")
+    public void testLlmsTxtKeepsCollectionWithVisibleDocs() {
+        RestAssured.when().get("/llms.txt").then().statusCode(200).log().ifValidationFails()
+                .body(containsString("## Posts"));
+    }
+
+    @Test
+    @DisplayName("llms-full.txt omits heading for collection with no visible docs")
+    public void testLlmsFullTxtOmitsCollectionWithNoVisibleDocs() {
+        RestAssured.when().get("/llms-full.txt").then().statusCode(200).log().ifValidationFails()
+                .body(not(containsString("## Guides")));
+    }
+
+    @Test
+    @DisplayName("llms-full.txt keeps heading for collection with visible docs")
+    public void testLlmsFullTxtKeepsCollectionWithVisibleDocs() {
+        RestAssured.when().get("/llms-full.txt").then().statusCode(200).log().ifValidationFails()
+                .body(containsString("## Posts"));
     }
 }

--- a/roq-frontmatter/deployment/src/test/resources/collection-site-resources/content/guides/advanced-usage.html
+++ b/roq-frontmatter/deployment/src/test/resources/collection-site-resources/content/guides/advanced-usage.html
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Advanced Usage
+llmstxt: false
 ---
 <h1>{page.title}</h1>
 <p>This guide covers advanced configuration patterns for Roq collections and layouts.</p>

--- a/roq-frontmatter/deployment/src/test/resources/collection-site-resources/content/guides/no-layout-guide.html
+++ b/roq-frontmatter/deployment/src/test/resources/collection-site-resources/content/guides/no-layout-guide.html
@@ -1,5 +1,6 @@
 ---
 title: No Layout Guide
+llmstxt: false
 ---
 <h1>{page.title}</h1>
 <p>This guide has no explicit layout in its frontmatter, so it should inherit the collection default.</p>

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqLlmsTxtTemplateExtension.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqLlmsTxtTemplateExtension.java
@@ -1,6 +1,8 @@
 package io.quarkiverse.roq.frontmatter.runtime;
 
+import io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage;
 import io.quarkiverse.roq.frontmatter.runtime.model.Page;
+import io.quarkiverse.roq.frontmatter.runtime.model.RoqCollection;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.qute.TemplateExtension;
 
@@ -10,6 +12,19 @@ public class RoqLlmsTxtTemplateExtension {
 
     public static boolean llmstxt(Page page) {
         return page.data().getBoolean("llmstxt", true);
+    }
+
+    /**
+     * Returns whether the collection has at least one document visible in llms.txt.<br>
+     * Example: "{#if collection.hasLlmstxtEntries}".
+     */
+    public static boolean hasLlmstxtEntries(RoqCollection collection) {
+        for (DocumentPage doc : collection) {
+            if (llmstxt(doc)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static String capitalizeFirst(String s) {

--- a/roq-frontmatter/runtime/src/main/resources/templates/fm/llms-full.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/fm/llms-full.html
@@ -6,7 +6,7 @@
 
 {/if}
 {#for collection in site.collections.list}
-{#if !collection.hidden && !collection.derived}
+{#if !collection.hidden && !collection.derived && collection.hasLlmstxtEntries}
 ## {collection.id.capitalizeFirst}
 
 {#for doc in collection}

--- a/roq-frontmatter/runtime/src/main/resources/templates/fm/llms.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/fm/llms.html
@@ -6,7 +6,7 @@
 
 {/if}
 {#for collection in site.collections.list}
-{#if !collection.hidden && !collection.derived}
+{#if !collection.hidden && !collection.derived && collection.hasLlmstxtEntries}
 ## {collection.id.capitalizeFirst}
 
 {#for doc in collection}


### PR DESCRIPTION
## Summary

A collection whose every document opts out via `llmstxt: false` still printed
an empty `## <Collection>` heading in `/llms.txt` and `/llms-full.txt`. The
heading was gated only on `!collection.hidden && !collection.derived`, never
on whether any document in the collection actually passed the per-doc
`llmstxt` filter used inside the loop. A fully-opted-out collection therefore
rendered a dangling heading with nothing under it.

Example, with a `recipes` collection whose layout sets `llmstxt: false`:

```
## Recipes

## Pages

- [About](/about/): About this site
```

## Fix

- `RoqLlmsTxtTemplateExtension`: add `hasLlmstxtEntries(RoqCollection)`,
  returning whether at least one document in the collection isn't opted out.
- `templates/fm/llms.html` / `llms-full.html`: require
  `collection.hasLlmstxtEntries` alongside the existing
  `!collection.hidden && !collection.derived` condition.

## Test plan

- New `RoqFrontMatterLlmsTxtEmptyCollectionTest` (fixture:
  `llms-empty-collection-site`) covers both directions:
  - a collection whose only doc opts out via `llmstxt: false` → heading omitted
  - a sibling collection with a visible doc → heading and entry still printed
- Verified against unmodified code first to confirm the reproduction, then
  against the fix.