### PR TITLE
Fix adoc tag processing

### DIFF
--- a/roq-plugin/asciidoc-jruby/runtime/pom.xml
+++ b/roq-plugin/asciidoc-jruby/runtime/pom.xml
@@ -31,6 +31,17 @@
             <artifactId>asciidoctorj-diagram</artifactId>
             <version>${asciidoctorj-diagram.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/roq-plugin/asciidoc-jruby/runtime/src/main/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidocJInclude.java
+++ b/roq-plugin/asciidoc-jruby/runtime/src/main/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidocJInclude.java
@@ -24,8 +24,8 @@ import io.quarkiverse.tools.stringpaths.StringPaths;
 public class AsciidocJInclude extends IncludeProcessor {
     private static final Pattern URL_PREFIX_PATTERN = Pattern.compile("^((https?|file|ftp|irc)://|mailto:)");
     private static final Pattern HEADING_PATTERN = Pattern.compile("^(=+)(\\s+.*)$");
-    private static final Pattern TAG_START_PATTERN = Pattern.compile("^(?://|#|--|;;|<!--)\\s*tag::(\\S+?)\\[\\]");
-    private static final Pattern TAG_END_PATTERN = Pattern.compile("^(?://|#|--|;;|<!--)\\s*end::(\\S+?)\\[\\]");
+    private static final Pattern TAG_START_PATTERN = Pattern.compile("^\\s*(?://|#|--|;;|<!--)\\s*tag::(\\S+?)\\[\\]");
+    private static final Pattern TAG_END_PATTERN = Pattern.compile("^\\s*(?://|#|--|;;|<!--)\\s*end::(\\S+?)\\[\\]");
 
     public AsciidocJInclude() {
     }
@@ -83,9 +83,22 @@ public class AsciidocJInclude extends IncludeProcessor {
 
     }
 
-    private static void pushInclude(PreprocessorReader reader, String content, String target, Map<String, Object> attributes)
+    private void pushInclude(PreprocessorReader reader, String content, String target, Map<String, Object> attributes)
             throws IOException {
+        String tagsValue = resolveTagsValue(attributes);
         final String processedContent = String.join("\n", processInclude(content, attributes));
+
+        if (tagsValue != null) {
+            Set<String> availableTags = collectTagNames(content.lines().toList());
+            for (String raw : tagsValue.split("[;,]")) {
+                String tag = raw.trim();
+                if (!tag.isEmpty() && !tag.startsWith("!") && !availableTags.contains(tag)) {
+                    log(new LogRecord(Severity.WARN,
+                            "Include tag '%s' not found in '%s'".formatted(tag, target)));
+                }
+            }
+        }
+
         reader.pushInclude(
                 processedContent,
                 target,
@@ -94,20 +107,36 @@ public class AsciidocJInclude extends IncludeProcessor {
                 attributes);
     }
 
+    private static String resolveTagsValue(Map<String, Object> attrs) {
+        if (attrs.containsKey("tag") && attrs.get("tag") instanceof String) {
+            return (String) attrs.get("tag");
+        }
+        if (attrs.containsKey("tags") && attrs.get("tags") instanceof String) {
+            return (String) attrs.get("tags");
+        }
+        return null;
+    }
+
+    static Set<String> collectTagNames(List<String> lines) {
+        Set<String> tags = new LinkedHashSet<>();
+        for (String line : lines) {
+            Matcher m = TAG_START_PATTERN.matcher(line);
+            if (m.find()) {
+                tags.add(m.group(1));
+            }
+        }
+        return tags;
+    }
+
     // The main entry point, based on the Ruby push_include logic
     static List<String> processInclude(String content, Map<String, Object> attrs) throws IOException {
         // 1. Handle encoding (applies to file reading, not in-memory)
         List<String> lines = content.lines().toList();
 
-        // 2. Handle tag/tag(s) extraction first, as in Ruby
-        if (attrs.containsKey("tag") && attrs.get("tag") instanceof String) {
-            lines = extractTag(lines, (String) attrs.get("tag"));
-        } else if (attrs.containsKey("tags") && attrs.get("tags") instanceof String) {
-            // Ruby supports "tags" as a comma-separated list
-            final String tags = (String) attrs.get("tags");
-            for (String tag : tags.split(",")) {
-                lines = extractTag(lines, tag.trim());
-            }
+        // Handle tag/tag(s) extraction first, as in Ruby
+        String tagsValue = resolveTagsValue(attrs);
+        if (tagsValue != null) {
+            lines = extractTags(lines, tagsValue);
         }
 
         // 3. Handle lines attribute (after tags, as in Ruby)
@@ -125,30 +154,49 @@ public class AsciidocJInclude extends IncludeProcessor {
         return lines;
     }
 
-    // --- Helper methods: direct port of Ruby logic ---
-
-    // Extract lines between tag::...[] and end::...[]
+    // Extract lines matching the given tag expression.
     // Supports standard AsciiDoc comment styles: //, #, --, ;;, <!--
-    private static List<String> extractTag(List<String> lines, String tag) {
-        List<String> result = new ArrayList<>();
-        boolean inTag = false;
-        for (String line : lines) {
-            if (!inTag) {
-                Matcher m = TAG_START_PATTERN.matcher(line);
-                if (m.find() && m.group(1).equals(tag)) {
-                    inTag = true;
-                    continue;
-                }
-            } else {
-                Matcher m = TAG_END_PATTERN.matcher(line);
-                if (m.find() && m.group(1).equals(tag)) {
-                    break;
-                }
+    // Tags are separated by ";" or ",", and "!" negates (excludes) a tag.
+    private static List<String> extractTags(List<String> lines, String tagsValue) {
+        List<String> includeTags = new ArrayList<>();
+        List<String> excludeTags = new ArrayList<>();
+
+        for (String raw : tagsValue.split("[;,]")) {
+            String tag = raw.trim();
+            if (tag.isEmpty()) {
+                continue;
             }
-            if (inTag) {
+            if (tag.startsWith("!")) {
+                excludeTags.add(tag.substring(1));
+            } else {
+                includeTags.add(tag);
+            }
+        }
+
+        Set<String> activeTagStack = new LinkedHashSet<>();
+        List<String> result = new ArrayList<>();
+
+        for (String line : lines) {
+            Matcher startMatcher = TAG_START_PATTERN.matcher(line);
+            if (startMatcher.find()) {
+                activeTagStack.add(startMatcher.group(1));
+                continue;
+            }
+            Matcher endMatcher = TAG_END_PATTERN.matcher(line);
+            if (endMatcher.find()) {
+                activeTagStack.remove(endMatcher.group(1));
+                continue;
+            }
+
+            boolean included = includeTags.isEmpty()
+                    || activeTagStack.stream().anyMatch(includeTags::contains);
+            boolean excluded = activeTagStack.stream().anyMatch(excludeTags::contains);
+
+            if (included && !excluded) {
                 result.add(line);
             }
         }
+
         return result;
     }
 

--- a/roq-plugin/asciidoc-jruby/runtime/src/test/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidocJIncludeProcessIncludeTest.java
+++ b/roq-plugin/asciidoc-jruby/runtime/src/test/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidocJIncludeProcessIncludeTest.java
@@ -1,0 +1,259 @@
+package io.quarkiverse.roq.plugin.asciidoctorj.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class AsciidocJIncludeProcessIncludeTest {
+
+    // Simulates a Java source file with nested AsciiDoc tag regions
+    static final String JAVA_SOURCE = """
+            // tag::example[]
+            package com.example;
+
+            // tag::ignore[]
+            // this line should be excluded
+            // end::ignore[]
+
+            public class Example {
+                // tag::registry[]
+                private final Registry registry;
+
+                // tag::ctor[]
+                Example(Registry registry) {
+                    this.registry = registry;
+                    // tag::gauge[]
+                    registry.gauge("size", list);
+                    // end::gauge[]
+                }
+                // end::ctor[]
+                // end::registry[]
+
+                // tag::primeMethod[]
+                // tag::counted[]
+                int prime() {
+                    // tag::timed[]
+                    return computePrime();
+                    // end::timed[]
+                }
+                // end::counted[]
+                // end::primeMethod[]
+            }
+            // end::example[]
+            """;
+
+    @Nested
+    class SingleTag {
+
+        @Test
+        void extractsSingleTag() throws IOException {
+            List<String> result = AsciidocJInclude.processInclude(JAVA_SOURCE, Map.of("tag", "ctor"));
+
+            assertThat(result)
+                    .anyMatch(l -> l.contains("Example(Registry registry)"))
+                    .anyMatch(l -> l.contains("this.registry = registry;"))
+                    .noneMatch(l -> l.contains("private final Registry registry;"));
+        }
+
+        @Test
+        void extractsIndentedSingleTag() throws IOException {
+            List<String> result = AsciidocJInclude.processInclude(JAVA_SOURCE, Map.of("tag", "gauge"));
+
+            assertThat(result).hasSize(1)
+                    .first().asString().contains("registry.gauge");
+        }
+
+        @Test
+        void returnsEmptyForMissingTag() throws IOException {
+            List<String> result = AsciidocJInclude.processInclude(JAVA_SOURCE, Map.of("tag", "nonexistent"));
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    class MultipleTags {
+
+        @Test
+        void splitsSemicolonSeparatedTags() throws IOException {
+            List<String> result = AsciidocJInclude.processInclude(JAVA_SOURCE, Map.of("tags", "ctor;gauge"));
+
+            assertThat(result)
+                    .anyMatch(l -> l.contains("Example(Registry registry)"))
+                    .anyMatch(l -> l.contains("registry.gauge"));
+        }
+
+        @Test
+        void splitsCommaSeparatedTags() throws IOException {
+            List<String> result = AsciidocJInclude.processInclude(JAVA_SOURCE, Map.of("tags", "ctor,gauge"));
+
+            assertThat(result)
+                    .anyMatch(l -> l.contains("Example(Registry registry)"))
+                    .anyMatch(l -> l.contains("registry.gauge"));
+        }
+
+        @Test
+        void negationWithCommas() throws IOException {
+            List<String> result = AsciidocJInclude.processInclude(JAVA_SOURCE, Map.of("tags", "registry,!gauge"));
+
+            assertThat(result)
+                    .anyMatch(l -> l.contains("private final Registry registry;"))
+                    .noneMatch(l -> l.contains("registry.gauge"));
+        }
+
+        @Test
+        void negationExcludesTag() throws IOException {
+            List<String> result = AsciidocJInclude.processInclude(JAVA_SOURCE, Map.of("tags", "registry;!gauge"));
+
+            assertThat(result)
+                    .anyMatch(l -> l.contains("private final Registry registry;"))
+                    .anyMatch(l -> l.contains("Example(Registry registry)"))
+                    .noneMatch(l -> l.contains("registry.gauge"));
+        }
+
+        @Test
+        void multipleNegations() throws IOException {
+            List<String> result = AsciidocJInclude.processInclude(JAVA_SOURCE,
+                    Map.of("tags", "example;!ignore;!registry;!gauge;!counted;!timed;!primeMethod"));
+
+            assertThat(result)
+                    .anyMatch(l -> l.contains("package com.example;"))
+                    .anyMatch(l -> l.contains("public class Example {"))
+                    .noneMatch(l -> l.contains("should be excluded"))
+                    .noneMatch(l -> l.contains("private final Registry"))
+                    .noneMatch(l -> l.contains("registry.gauge"))
+                    .noneMatch(l -> l.contains("computePrime"));
+        }
+
+        @Test
+        void negationOnlyIncludesLinesOutsideExcludedTags() throws IOException {
+            List<String> result = AsciidocJInclude.processInclude(JAVA_SOURCE,
+                    Map.of("tags", "primeMethod;counted;!timed"));
+
+            assertThat(result)
+                    .anyMatch(l -> l.contains("int prime()"))
+                    .noneMatch(l -> l.contains("computePrime"));
+        }
+    }
+
+    @Nested
+    class IndentedTags {
+
+        static final String INDENTED_SOURCE = """
+                public class Foo {
+                    // tag::inner[]
+                    int x = 1;
+                    // end::inner[]
+                }
+                """;
+
+        @Test
+        void matchesIndentedTagMarkers() throws IOException {
+            List<String> result = AsciidocJInclude.processInclude(INDENTED_SOURCE, Map.of("tag", "inner"));
+
+            assertThat(result).hasSize(1)
+                    .first().asString().contains("int x = 1");
+        }
+
+        @Test
+        void matchesIndentedTagMarkersWithTags() throws IOException {
+            List<String> result = AsciidocJInclude.processInclude(INDENTED_SOURCE, Map.of("tags", "inner"));
+
+            assertThat(result).hasSize(1)
+                    .first().asString().contains("int x = 1");
+        }
+    }
+
+    @Nested
+    class CommentStyles {
+
+        @Test
+        void matchesHashComments() throws IOException {
+            String source = """
+                    # tag::config[]
+                    key=value
+                    # end::config[]
+                    """;
+            List<String> result = AsciidocJInclude.processInclude(source, Map.of("tag", "config"));
+            assertThat(result).containsExactly("key=value");
+        }
+
+        @Test
+        void matchesSemicolonComments() throws IOException {
+            String source = """
+                    ;; tag::init[]
+                    (def x 1)
+                    ;; end::init[]
+                    """;
+            List<String> result = AsciidocJInclude.processInclude(source, Map.of("tag", "init"));
+            assertThat(result).containsExactly("(def x 1)");
+        }
+
+        @Test
+        void matchesHtmlComments() throws IOException {
+            String source = """
+                    <!-- tag::head[] -->
+                    <title>Hello</title>
+                    <!-- end::head[] -->
+                    """;
+            List<String> result = AsciidocJInclude.processInclude(source, Map.of("tag", "head"));
+            assertThat(result).containsExactly("<title>Hello</title>");
+        }
+
+        @Test
+        void matchesDashComments() throws IOException {
+            String source = """
+                    -- tag::query[]
+                    SELECT * FROM t;
+                    -- end::query[]
+                    """;
+            List<String> result = AsciidocJInclude.processInclude(source, Map.of("tag", "query"));
+            assertThat(result).containsExactly("SELECT * FROM t;");
+        }
+    }
+
+    @Nested
+    class NoTagsAttribute {
+
+        @Test
+        void returnsAllLinesWhenNoTagSpecified() throws IOException {
+            String source = "line1\nline2\nline3";
+            List<String> result = AsciidocJInclude.processInclude(source, Map.of());
+            assertThat(result).containsExactly("line1", "line2", "line3");
+        }
+    }
+
+    @Nested
+    class LineRanges {
+
+        @Test
+        void extractsSingleLine() throws IOException {
+            String source = "a\nb\nc\nd";
+            List<String> result = AsciidocJInclude.processInclude(source, Map.of("lines", "2"));
+            assertThat(result).containsExactly("b");
+        }
+
+        @Test
+        void extractsRange() throws IOException {
+            String source = "a\nb\nc\nd";
+            List<String> result = AsciidocJInclude.processInclude(source, Map.of("lines", "2..3"));
+            assertThat(result).containsExactly("b", "c");
+        }
+    }
+
+    @Nested
+    class Indent {
+
+        @Test
+        void appliesIndent() throws IOException {
+            String source = "// tag::x[]\nfoo\n// end::x[]";
+            List<String> result = AsciidocJInclude.processInclude(source, Map.of("tag", "x", "indent", "4"));
+            assertThat(result).containsExactly("    foo");
+        }
+    }
+}


### PR DESCRIPTION
Resolves #1178

AsciiDoc's spec uses ; as the separator, but the Ruby (Asciidoctor) implementation actually accepts both ; and ,. The version in Roq only supported commas. This isn't ideal, since the canonical syntax (and what the Quarkus guides use) is  semicolons.

The fix handles both: tagsValue.split("[;,]"). It also adds tests for both.

With the original ,-split code,` tags=example;!ignore;!registry` was treated as a single tag name `"example;!ignore;!registry"`, which matched nothing, so the result was 0 lines.