### PR TITLE
Use 'true' for boolean asciidoc config

### DIFF
--- a/blog/content/docs/migrating.adoc
+++ b/blog/content/docs/migrating.adoc
@@ -831,6 +831,9 @@ If you are migrating manually, consider adding them to `config/application.prope
 
 | `quarkus.web-bundler.bundling.external=/assets/*`
 | Tells the CSS bundler not to resolve Jekyll-style `/assets/...` URL references
+
+| `quarkus.asciidoc.attributes.sectanchors=true`
+| Enables section anchor links (use `true` for any boolean AsciiDoc attribute since SmallRye Config does not support empty-string map values; Roq converts `true` to an empty string before passing to AsciidoctorJ)
 |===
 
 === LLM prompt for configuration

--- a/blog/content/marketplace/plugins/asciidoc-jruby.md
+++ b/blog/content/marketplace/plugins/asciidoc-jruby.md
@@ -64,6 +64,16 @@ quarkus.asciidoc.attributes.source-highlighter=highlight.js
 quarkus.asciidoc.attributes.icons=font
 ```
 
+For boolean AsciiDoc attributes (flags that are either on or off, such as `sectanchors` or `sectnums`), use `true` as the value:
+
+```properties
+quarkus.asciidoc.attributes.sectanchors=true
+quarkus.asciidoc.attributes.sectnums=true
+quarkus.asciidoc.attributes.experimental=true
+```
+
+> Roq converts `true` to an empty string before passing to AsciidoctorJ, so these behave the same as `:sectanchors:` in an AsciiDoc header. This convention is needed because SmallRye Config does not support empty-string map values.
+
 Or as an include file in the AsciiDoc headers, or as part of the Frontmatter data `asciidoc-attributes` in a page or layout:
 
 ```yaml

--- a/blog/content/marketplace/plugins/asciidoc.md
+++ b/blog/content/marketplace/plugins/asciidoc.md
@@ -88,6 +88,16 @@ quarkus.asciidoc.attributes.source-highlighter=highlight.js
 quarkus.asciidoc.attributes.icons=font
 ```
 
+For boolean AsciiDoc attributes (flags that are either on or off, such as `sectanchors` or `sectnums`), use `true` as the value:
+
+```properties
+quarkus.asciidoc.attributes.sectanchors=true
+quarkus.asciidoc.attributes.sectnums=true
+quarkus.asciidoc.attributes.experimental=true
+```
+
+> Roq converts `true` to an empty string before passing to AsciidoctorJ, so these behave the same as `:sectanchors:` in an AsciiDoc header. This convention is needed because SmallRye Config does not support empty-string map values.
+
 Or as an include file in the AsciiDoc headers, or as part of the Frontmatter data `asciidoc-attributes` in a page or layout:
 
 ```yaml

--- a/migration/src/main/java/io/quarkus/tools/JekyllConfigConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/JekyllConfigConverter.java
@@ -384,6 +384,20 @@ public class JekyllConfigConverter {
         return false;
     }
 
+    // Suffixes that indicate the empty string IS the desired value, not a boolean flag.
+    private static final List<String> VALUE_ATTRIBUTE_SUFFIXES = List.of(
+            "suffix", "prefix", "separator", "dir", "url", "path",
+            "name", "format", "highlighter", "encoding", "file");
+
+    static boolean looksLikeValueAttribute(String name) {
+        for (String suffix : VALUE_ATTRIBUTE_SUFFIXES) {
+            if (name.endsWith(suffix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void addAsciidoctorAttributes(JsonNode config, Properties properties) {
         if (config == null || !config.has("asciidoctor")) {
             return;
@@ -397,9 +411,18 @@ public class JekyllConfigConverter {
             return;
         }
         attributes.fields().forEachRemaining(entry -> {
+            String key = entry.getKey();
             String value = entry.getValue().asText();
             if (!value.isEmpty()) {
-                properties.setProperty("quarkus.asciidoc.attributes." + entry.getKey(), value);
+                properties.setProperty("quarkus.asciidoc.attributes." + key, value);
+            } else if (looksLikeValueAttribute(key)) {
+                // Empty string IS the value (e.g. outfilesuffix, idprefix) — skip,
+                // since SmallRye Config rejects empty map values
+                System.out.println("  [CONFIG] Skipping empty-string attribute '" + key
+                        + "' (looks like a value attribute, not a boolean flag)");
+            } else {
+                // Boolean flag (e.g. sectanchors) — emit as "true"
+                properties.setProperty("quarkus.asciidoc.attributes." + key, "true");
             }
         });
     }

--- a/migration/src/test/java/io/quarkus/tools/JekyllConfigConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/JekyllConfigConverterTest.java
@@ -750,10 +750,28 @@ class JekyllConfigConverterTest {
                 "Jekyll asciidoctor.attributes.icons should map to quarkus.asciidoc.attributes.icons");
         assertEquals("highlightjs", props.getProperty("quarkus.asciidoc.attributes.source-highlighter"),
                 "Jekyll asciidoctor.attributes.source-highlighter should map to quarkus.asciidoc.attributes.source-highlighter");
-        assertNull(props.getProperty("quarkus.asciidoc.attributes.sectanchors"),
-                "Empty-string attributes should be skipped (SmallRye Config rejects empty map values)");
+        assertEquals("true", props.getProperty("quarkus.asciidoc.attributes.sectanchors"),
+                "Boolean AsciiDoc attributes with empty value should be emitted as 'true'");
         assertNull(props.getProperty("quarkus.asciidoc.attributes.outfilesuffix"),
-                "Empty-string attributes should be skipped");
+                "Non-boolean empty-string attributes should be skipped (SmallRye Config rejects empty map values)");
+    }
+
+    @Test
+    void testLooksLikeValueAttribute() {
+        assertTrue(JekyllConfigConverter.looksLikeValueAttribute("outfilesuffix"));
+        assertTrue(JekyllConfigConverter.looksLikeValueAttribute("idprefix"));
+        assertTrue(JekyllConfigConverter.looksLikeValueAttribute("idseparator"));
+        assertTrue(JekyllConfigConverter.looksLikeValueAttribute("imagesdir"));
+        assertTrue(JekyllConfigConverter.looksLikeValueAttribute("source-highlighter"));
+
+        assertFalse(JekyllConfigConverter.looksLikeValueAttribute("sectanchors"));
+        assertFalse(JekyllConfigConverter.looksLikeValueAttribute("sectnums"));
+        assertFalse(JekyllConfigConverter.looksLikeValueAttribute("experimental"));
+        assertFalse(JekyllConfigConverter.looksLikeValueAttribute("toc"));
+        assertFalse(JekyllConfigConverter.looksLikeValueAttribute("hardbreaks"));
+        assertFalse(JekyllConfigConverter.looksLikeValueAttribute("linkcss"));
+        assertFalse(JekyllConfigConverter.looksLikeValueAttribute("data-uri"));
+        assertFalse(JekyllConfigConverter.looksLikeValueAttribute("icons"));
     }
 
     @Test

--- a/roq-plugin/asciidoc-jruby/deployment/src/test/java/io/quarkiverse/roq/plugin/asciidoctorj/test/AsciidoctorJConverterTest.java
+++ b/roq-plugin/asciidoc-jruby/deployment/src/test/java/io/quarkiverse/roq/plugin/asciidoctorj/test/AsciidoctorJConverterTest.java
@@ -14,11 +14,11 @@ import io.quarkiverse.roq.plugin.asciidoctorj.runtime.AsciidoctorJConverter;
 
 public class AsciidoctorJConverterTest {
 
-    private final AsciidoctorJConverter converter = new AsciidoctorJConverter(Map.of());
     private final Asciidoctor asciidoctor = Asciidoctor.Factory.create();
 
     @Test
     void shouldSetDocnameFromSourcePath() {
+        AsciidoctorJConverter converter = new AsciidoctorJConverter(Map.of());
         RoqTemplateAttributes attrs = new RoqTemplateAttributes(
                 "/tmp/site",
                 "/tmp/site/content/guides/my-guide.adoc",
@@ -32,6 +32,7 @@ public class AsciidoctorJConverterTest {
 
     @Test
     void shouldSetDocnameWithMultipleDots() {
+        AsciidoctorJConverter converter = new AsciidoctorJConverter(Map.of());
         RoqTemplateAttributes attrs = new RoqTemplateAttributes(
                 "/tmp/site",
                 "/tmp/site/content/posts/2024-01-01-foo.bar.adoc",
@@ -41,6 +42,22 @@ public class AsciidoctorJConverterTest {
         Document doc = asciidoctor.load("= Test", options);
 
         assertThat(doc.getAttribute("docname")).isEqualTo("2024-01-01-foo.bar");
+    }
+
+    @Test
+    void shouldConvertTrueToEmptyForBooleanAttributes() {
+        AsciidoctorJConverter converter = new AsciidoctorJConverter(
+                Map.of("sectanchors", "true", "icons", "font"));
+        RoqTemplateAttributes attrs = new RoqTemplateAttributes(
+                "/tmp/site",
+                "/tmp/site/content/guides/test.adoc",
+                null, null, null, null);
+
+        Options options = converter.createOptions(Map.of(), attrs);
+        Document doc = asciidoctor.load("= Test\n\n== Section One\n\nContent", options);
+
+        assertThat(doc.getAttribute("sectanchors")).isEqualTo("");
+        assertThat(doc.getAttribute("icons")).isEqualTo("font");
     }
 
 }

--- a/roq-plugin/asciidoc-jruby/runtime/src/main/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidoctorJConfig.java
+++ b/roq-plugin/asciidoc-jruby/runtime/src/main/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidoctorJConfig.java
@@ -20,6 +20,18 @@ public interface AsciidoctorJConfig {
      * <li><code>noheader=true</code></li>
      * <li><code>showtitle=true</code></li>
      * </ul>
+     * <p>
+     * For boolean AsciiDoc attributes (flags that are either set or unset, such as
+     * {@code sectanchors} or {@code sectnums}), use the value {@code "true"}. SmallRye
+     * Config does not support empty-string map values, so {@code "true"} is converted to
+     * an empty string before passing to AsciidoctorJ.
+     * <p>
+     * Examples:
+     * <pre>
+     * quarkus.asciidoc.attributes.sectanchors=true
+     * quarkus.asciidoc.attributes.sectnums=true
+     * quarkus.asciidoc.attributes.icons=font
+     * </pre>
      **/
     Map<String, String> attributes();
 

--- a/roq-plugin/asciidoc-jruby/runtime/src/main/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidoctorJConverter.java
+++ b/roq-plugin/asciidoc-jruby/runtime/src/main/java/io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidoctorJConverter.java
@@ -23,6 +23,7 @@ public class AsciidoctorJConverter {
 
     private static final Logger LOG = Logger.getLogger(AsciidoctorJConverter.class);
     public static final String ROOTDIR = "root_dir";
+    public static final String TRUE = Boolean.TRUE.toString();
 
     private final Asciidoctor asciidoctor;
     private Map<String, String> configuredAttributes;
@@ -62,7 +63,10 @@ public class AsciidoctorJConverter {
         if (templateAttributes.sitePath() != null) {
             attributes.attribute("site-path", templateAttributes.sitePath());
         }
-        configuredAttributes.forEach(attributes::attribute);
+        // SmallRye Config cannot represent empty-string map values, so boolean
+        // AsciiDoc attributes (e.g. sectanchors) are stored as "true" in config.
+        // Convert back to "" so AsciidoctorJ sees them as boolean flags.
+        configuredAttributes.forEach((k, v) -> attributes.attribute(k, TRUE.equals(v) ? "" : v));
         asciidocAttributes.forEach(attributes::attribute);
 
         final OptionsBuilder optionsBuilder = Options.builder();


### PR DESCRIPTION
This is related to https://github.com/quarkiverse/quarkus-roq/pull/1175, but I think the solution here is more natural. For an asciidoc config value that's either present or not, we can't just put it loose into the Roq config. But we can say 'true' in the config, and that seems semantically natural.  

For example, 

#### Jekyll _config.yml:
```
  asciidoctor:
    attributes:
      source-highlighter: highlightjs
      sectanchors: ''
      icons: font
```
becomes

 #### Roq application.properties:
 ```
  quarkus.asciidoc.attributes.source-highlighter=highlightjs
  quarkus.asciidoc.attributes.sectanchors=true
  quarkus.asciidoc.attributes.icons=font
````

I notice even Jekyll was a bit awkward, because it had to do an empty string. Only it also had an option for an array syntax, where presence was enough: https://github.com/asciidoctor/jekyll-asciidoc