### PR TITLE
[Breaking] Allow placeholders to support dots in paths

### DIFF
--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/utils/TemplateLink.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/utils/TemplateLink.java
@@ -122,7 +122,7 @@ public class TemplateLink {
             name = pageSource.baseFileName();
         }
 
-        return StringPaths.slugify(removeDate(name), true, false);
+        return StringPaths.slugify(removeDate(name), true, true);
     }
 
     private static String resolveName(LinkData data) {


### PR DESCRIPTION
At the moment, Page pages can have dots in their paths, but things using placeholder names cannot. I noticed this in the Roq migration, when /blog/vscode-quarkus-1.1.0/ stopped working. 

I've updated the placeholder to also allow dots. I wondered about making it configurable, but I think that's adding user complexity for not much gain. `PageFiles.slugifyFile` uses `allowDots=true` with the explicit rationale about version numbers. Making `:Name/:name` match is consistent with that.

Also, dots in slugs are standard. Jekyll and Hugo both preserve them. 

More generally, there's not really a use case for stripping dots, because if someone wanted dashes, they could use dashes in the file name. 

The one caution is that: if someone has already built their site on Roq with the current behavior, changing the default would move their URLs. So this would want a release note.