### PR TITLE
fix: use Quarkus useConfigDir() for codestart config and add CLI tests

### DIFF
--- a/.github/workflows/create-site-test.yml
+++ b/.github/workflows/create-site-test.yml
@@ -1,0 +1,103 @@
+name: Create Site Test
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Every Monday at 6:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-code-quarkus-download:
+    name: "code.quarkus.io: ${{ matrix.combo.name }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        combo:
+          - name: default theme
+            params: "e=io.quarkiverse.roq%3Aquarkus-roq&e=io.quarkiverse.roq%3Aquarkus-roq-theme-default"
+            expect_files: "content/index.html data/menu.yml web/_custom.css"
+
+          - name: default + markdown
+            params: "e=io.quarkiverse.roq%3Aquarkus-roq&e=io.quarkiverse.roq%3Aquarkus-roq-theme-default&e=io.quarkiverse.roq%3Aquarkus-roq-plugin-markdown"
+            expect_files: "content/index.html data/menu.yml"
+
+          - name: resume theme
+            params: "e=io.quarkiverse.roq%3Aquarkus-roq&e=io.quarkiverse.roq%3Aquarkus-roq-theme-resume"
+            expect_files: "content/index.html data/bio.yml data/profile.yml"
+
+          - name: linktree theme
+            params: "e=io.quarkiverse.roq%3Aquarkus-roq&e=io.quarkiverse.roq%3Aquarkus-roq-theme-linktree"
+            expect_files: "data/profile.yml"
+
+          - name: base theme (no theme extension)
+            params: "e=io.quarkiverse.roq%3Aquarkus-roq&ec=roq-base-theme-codestart"
+            expect_files: "content/index.html web/app.css"
+
+          - name: default + all plugins
+            params: "e=io.quarkiverse.roq%3Aquarkus-roq&e=io.quarkiverse.roq%3Aquarkus-roq-theme-default&e=io.quarkiverse.roq%3Aquarkus-roq-plugin-markdown&e=io.quarkiverse.roq%3Aquarkus-roq-plugin-tagging&e=io.quarkiverse.roq%3Aquarkus-roq-plugin-aliases&e=io.quarkiverse.roq%3Aquarkus-roq-plugin-series&e=io.quarkiverse.roq%3Aquarkus-roq-plugin-sitemap&e=io.quarkiverse.roq%3Aquarkus-roq-plugin-lunr"
+            expect_files: "content/index.html data/menu.yml"
+
+          - name: default + asciidoc
+            params: "e=io.quarkiverse.roq%3Aquarkus-roq&e=io.quarkiverse.roq%3Aquarkus-roq-theme-default&e=io.quarkiverse.roq%3Aquarkus-roq-plugin-asciidoc"
+            expect_files: "content/index.html"
+
+    steps:
+      - name: Download from code.quarkus.io
+        run: |
+          URL="https://code.quarkus.io/d?a=my-roq-site&ndf=true&nw=false&ec=roq-project-codestart&cd=site.title%3DMy+Roq+Site&${{ matrix.combo.params }}&cn=roq"
+          echo "Downloading: $URL"
+          HTTP_CODE=$(curl -sS -w '%{http_code}' -o my-roq-site.zip "$URL")
+          echo "HTTP status: $HTTP_CODE"
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Download failed with HTTP $HTTP_CODE"
+            exit 1
+          fi
+
+      - name: Extract and verify structure
+        run: |
+          unzip -q my-roq-site.zip -d project
+          cd project/my-roq-site
+
+          # Common files from roq-project-codestart
+          for f in pom.xml README.md public/images/favicon.ico public/images/favicon.svg; do
+            if [ ! -f "$f" ]; then
+              echo "::error::Missing expected file: $f"
+              exit 1
+            fi
+          done
+
+          # Combo-specific files
+          for f in ${{ matrix.combo.expect_files }}; do
+            if [ ! -e "$f" ]; then
+              echo "::error::Missing expected file: $f"
+              exit 1
+            fi
+          done
+
+          # Verify pom.xml contains quarkus-roq
+          if ! grep -q 'quarkus-roq' pom.xml; then
+            echo "::error::pom.xml does not contain quarkus-roq dependency"
+            exit 1
+          fi
+
+          echo "All checks passed"
+          echo "--- Project tree ---"
+          find . -not -path './.mvn/*' -not -path './mvnw*' | sort
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: 'maven'
+
+      - name: Verify project compiles
+        working-directory: project/my-roq-site
+        run: mvn -B compile -q

--- a/roq-cli/pom.xml
+++ b/roq-cli/pom.xml
@@ -13,6 +13,7 @@
     <description>Command line interface for Roq static site generator</description>
 
     <properties>
+        <quarkus.version>3.39.1</quarkus.version>
         <vertx.version>5.1.6</vertx.version>
     </properties>
 
@@ -56,6 +57,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-project-core-extension-codestarts</artifactId>
             <version>${quarkus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqProjectCreator.java
+++ b/roq-cli/src/main/java/io/quarkiverse/roq/cli/RoqProjectCreator.java
@@ -118,6 +118,10 @@ public class RoqProjectCreator {
                 .extensions(allExtensions)
                 .extraCodestarts(extraCodestarts);
 
+        if (!noConfig) {
+            createProject.useConfigDir();
+        }
+
         if (allExtensions.stream().noneMatch(e -> e.contains("roq-plugin-hybrid"))) {
             createProject.noDockerfiles();
         }
@@ -129,26 +133,13 @@ public class RoqProjectCreator {
         QuarkusCommandOutcome outcome = createProject.execute();
 
         if (outcome.isSuccess()) {
-            postCreate(allExtensions);
+            postCreate();
             return true;
         }
         return false;
     }
 
-    private void postCreate(Set<String> allExtensions) throws IOException {
-        if (!noConfig) {
-            // Move application.properties to config/
-            Path propsSource = projectDir.resolve("src/main/resources/application.properties");
-            Path configDir = projectDir.resolve("config");
-            Files.createDirectories(configDir);
-            Path propsDest = configDir.resolve("application.properties");
-            if (Files.exists(propsSource)) {
-                Files.move(propsSource, propsDest);
-            } else {
-                Files.createFile(propsDest);
-            }
-        }
-
+    private void postCreate() throws IOException {
         deleteDirIfNoFiles(projectDir.resolve("src"));
     }
 

--- a/roq-cli/src/test/java/io/quarkiverse/roq/cli/RoqProjectCreatorTest.java
+++ b/roq-cli/src/test/java/io/quarkiverse/roq/cli/RoqProjectCreatorTest.java
@@ -1,0 +1,117 @@
+package io.quarkiverse.roq.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RoqProjectCreatorTest {
+
+    private static final String ROQ_VERSION = "999-SNAPSHOT";
+
+    private Path tempDir;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("roq-cli-test");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        FileUtils.deleteDirectory(tempDir.toFile());
+    }
+
+    @Test
+    void createDefaultSite() throws Exception {
+        Path projectDir = createProject("my-site");
+
+        assertProjectStructure(projectDir);
+        assertThat(projectDir.resolve("config/application.properties")).exists();
+        assertPomContains(projectDir, "quarkus-roq-theme-default");
+    }
+
+    @Test
+    void createWithResumeTheme() throws Exception {
+        Path projectDir = createProject("resume-site", "theme:resume");
+
+        assertProjectStructure(projectDir);
+        assertPomContains(projectDir, "quarkus-roq-theme-resume");
+        assertThat(projectDir.resolve("data/bio.yml")).exists();
+    }
+
+    @Test
+    void createWithLinktreeTheme() throws Exception {
+        Path projectDir = createProject("linktree-site", "theme:linktree");
+
+        assertProjectStructure(projectDir);
+        assertPomContains(projectDir, "quarkus-roq-theme-linktree");
+        assertThat(projectDir.resolve("data/profile.yml")).exists();
+    }
+
+    @Test
+    void createWithPlugins() throws Exception {
+        Path projectDir = createProject("plugin-site", "plugin:markdown", "plugin:tagging", "plugin:sitemap");
+
+        assertProjectStructure(projectDir);
+        assertPomContains(projectDir, "quarkus-roq-plugin-markdown");
+        assertPomContains(projectDir, "quarkus-roq-plugin-tagging");
+        assertPomContains(projectDir, "quarkus-roq-plugin-sitemap");
+    }
+
+    @Test
+    void configContainsAltExprSyntax() throws Exception {
+        Path projectDir = createProject("config-site");
+
+        assertThat(projectDir.resolve("config/application.properties"))
+                .content().contains("quarkus.qute.alt-expr-syntax=true");
+    }
+
+    @Test
+    void noSrcDirectoryWhenNoJavaCode() throws Exception {
+        Path projectDir = createProject("nosrc-site");
+
+        assertThat(projectDir.resolve("src")).doesNotExist();
+    }
+
+    @Test
+    void resolveExtensionShorthand() {
+        assertThat(RoqProjectCreator.resolveExtension("theme:default"))
+                .isEqualTo("io.quarkiverse.roq:quarkus-roq-theme-default");
+        assertThat(RoqProjectCreator.resolveExtension("plugin:tagging"))
+                .isEqualTo("io.quarkiverse.roq:quarkus-roq-plugin-tagging");
+        assertThat(RoqProjectCreator.resolveExtension("web:sass"))
+                .isEqualTo("io.quarkiverse.web-bundler:quarkus-web-bundler-sass");
+        assertThat(RoqProjectCreator.resolveExtension("theme:base"))
+                .isNull();
+        assertThat(RoqProjectCreator.resolveExtension("io.quarkus:quarkus-rest"))
+                .isEqualTo("io.quarkus:quarkus-rest");
+    }
+
+    private Path createProject(String name, String... extensions) throws Exception {
+        Path projectDir = tempDir.resolve(name);
+        boolean success = new RoqProjectCreator(projectDir, name)
+                .roqVersion(ROQ_VERSION)
+                .extensions(extensions.length > 0 ? List.of(extensions) : null)
+                .create();
+        assertThat(success).isTrue();
+        return projectDir;
+    }
+
+    private void assertProjectStructure(Path projectDir) {
+        assertThat(projectDir.resolve("pom.xml")).exists();
+        assertThat(projectDir.resolve("README.md")).exists();
+        assertThat(projectDir.resolve("content")).isDirectory();
+        assertThat(projectDir.resolve("public/images/favicon.ico")).exists();
+    }
+
+    private void assertPomContains(Path projectDir, String artifactId) throws Exception {
+        assertThat(projectDir.resolve("pom.xml"))
+                .content().contains(artifactId);
+    }
+}

--- a/roq-frontmatter/runtime/src/main/codestarts/quarkus/roq-project-codestart/base/config/application.properties
+++ b/roq-frontmatter/runtime/src/main/codestarts/quarkus/roq-project-codestart/base/config/application.properties
@@ -1,1 +1,0 @@
-quarkus.qute.alt-expr-syntax=true

--- a/roq-frontmatter/runtime/src/main/codestarts/quarkus/roq-project-codestart/base/src/main/resources/application.yml
+++ b/roq-frontmatter/runtime/src/main/codestarts/quarkus/roq-project-codestart/base/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+quarkus:
+  qute:
+    alt-expr-syntax: true


### PR DESCRIPTION
## Summary
- Fix codestart config path to avoid forbidden output-strategy in Quarkus devtools (moves `config/application.properties` to `src/main/resources/application.yml`)
- Bump CLI Quarkus version to 3.39.1 and use native `useConfigDir()` instead of manual `Files.move` workaround
- Add `RoqProjectCreatorTest` with 7 tests covering project creation (themes, plugins, config content, extension resolution)
- Add weekly CI workflow (`create-site-test.yml`) to verify code.quarkus.io downloads for all theme/plugin combinations

Fixes #1189
Supersedes #1192