### PR TITLE
fix: explicitly set root-path in dev mode test

### DIFF
--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterDevModeTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterDevModeTest.java
@@ -25,6 +25,7 @@ public class RoqFrontMatterDevModeTest {
                     .addAsResource(
                             new org.jboss.shrinkwrap.api.asset.StringAsset(
                                     "quarkus.http.port=" + DEV_MODE_PORT + "\n" +
+                                            "quarkus.http.root-path=/\n" +
                                             "quarkus.roq.resource-dir=basic-site"),
                             "application.properties"));
 


### PR DESCRIPTION
## Summary
- The `RoqFrontMatterDevModeTest` fails when bumping Quarkus because `QuarkusDevModeTest` picks up `quarkus.http.root-path=/foo/` from the test classpath's `application.properties` (used by the routing tests), prefixing all requests with `/foo` and returning 404
- Fix: explicitly set `quarkus.http.root-path=/` in the dev mode test's application.properties to override the classpath default