### PR TITLE
build(deps): bump quarkus-web-bundler from 2.3.3 to 2.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <quarkus-qute-web.version>3.4.5</quarkus-qute-web.version>
         <asciidoctorj.version>3.0.1</asciidoctorj.version>
         <asciidoctorj-diagram.version>3.2.1</asciidoctorj-diagram.version>
-        <quarkus-web-bundler.version>2.3.3</quarkus-web-bundler.version>
+        <quarkus-web-bundler.version>2.3.4</quarkus-web-bundler.version>
         <asciidoc-java.version>1.2.16</asciidoc-java.version>
         <jandex.version>3.6.0</jandex.version>
         <jsoup.version>1.23.2</jsoup.version>


### PR DESCRIPTION
## Summary
- Bumps `quarkus-web-bundler.version` from 2.3.3 to 2.3.4