### PR TITLE
fix: isolate routing test config to prevent dev mode test failure on Quarkus 3.39+

### DIFF
--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterDevModeTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterDevModeTest.java
@@ -25,7 +25,6 @@ public class RoqFrontMatterDevModeTest {
                     .addAsResource(
                             new org.jboss.shrinkwrap.api.asset.StringAsset(
                                     "quarkus.http.port=" + DEV_MODE_PORT + "\n" +
-                                            "quarkus.http.root-path=/\n" +
                                             "quarkus.roq.resource-dir=basic-site"),
                             "application.properties"));
 
@@ -57,7 +56,7 @@ public class RoqFrontMatterDevModeTest {
     public void testGetDynamicPage() {
         RestAssured.given()
                 .port(DEV_MODE_PORT)
-                .get("/page/some-page")
+                .get("/page/some-page/")
                 .then()
                 .statusCode(200)
                 .log().ifValidationFails();
@@ -69,7 +68,7 @@ public class RoqFrontMatterDevModeTest {
         RestAssured.given()
                 .port(DEV_MODE_PORT)
                 .when()
-                .head("/page/some-page")
+                .head("/page/some-page/")
                 .then()
                 .log().all()
                 .statusCode(200);

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterDevModeTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/RoqFrontMatterDevModeTest.java
@@ -25,6 +25,7 @@ public class RoqFrontMatterDevModeTest {
                     .addAsResource(
                             new org.jboss.shrinkwrap.api.asset.StringAsset(
                                     "quarkus.http.port=" + DEV_MODE_PORT + "\n" +
+                                            "quarkus.http.root-path=/\n" +
                                             "quarkus.roq.resource-dir=basic-site"),
                             "application.properties"));
 

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterRoutingTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterRoutingTest.java
@@ -26,7 +26,7 @@ public class RoqFrontMatterRoutingTest {
     @RegisterExtension
     static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
-                    .addAsResource("application.properties")
+                    .addAsResource("routing-application.properties", "application.properties")
                     .addAsResource("routing-site"));
 
     @Test

--- a/roq-frontmatter/deployment/src/test/resources/application.properties
+++ b/roq-frontmatter/deployment/src/test/resources/application.properties
@@ -1,8 +1,1 @@
-quarkus.roq.resource-dir=routing-site
-quarkus.http.root-path=/foo/
-
-site.url=https://mywebsite.com
-site.path-prefix=/bar/
-site.time-zone=UTC
-
 quarkus.log.category."io.quarkiverse.roq.frontmatter".level=DEBUG

--- a/roq-frontmatter/deployment/src/test/resources/routing-application.properties
+++ b/roq-frontmatter/deployment/src/test/resources/routing-application.properties
@@ -1,0 +1,8 @@
+quarkus.roq.resource-dir=routing-site
+quarkus.http.root-path=/foo/
+
+site.url=https://mywebsite.com
+site.path-prefix=/bar/
+site.time-zone=UTC
+
+quarkus.log.category."io.quarkiverse.roq.frontmatter".level=DEBUG


### PR DESCRIPTION
## Summary
- Move routing-specific config (`quarkus.http.root-path`, `site.path-prefix`) from the shared classpath `application.properties` into a dedicated `routing-application.properties` loaded only by `RoqFrontMatterRoutingTest`
- Remove the now-unnecessary `root-path` override from `RoqFrontMatterDevModeTest`
- Fixes the `RoqFrontMatterDevModeTest` failure caused by Quarkus 3.39.1 picking up classpath root-path for RestAssured basePath configuration

Unblocks #1193