### PR TITLE
Correct getParentPath to not mangle urls when they have a host and scheme

### DIFF
--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/RoqUrl.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/model/RoqUrl.java
@@ -273,17 +273,33 @@ public record RoqUrl(
 
     /**
      * Extracts the collection base path from a page URL to use as relfileprefix.
+     * The input may be a root-relative path or a full URL (scheme + host + path); the latter is
+     * what {@code page.url().absolute()} produces, which is what the Asciidoc converter passes in.
      * Examples:
      * - /guides/my-doc → /guides/
      * - /version/main/guides/security → /version/main/guides/
      * - /blog/my-post/ → /blog/
+     * - https://quarkus.io/guides/my-doc → /guides/
+     * - https://example.com/version/main/guides/security → /version/main/guides/
      *
-     * @param pageUrl the absolute page URL
+     * @param pageUrl the page URL, either root-relative or a full URL
      * @return the collection base path with trailing slash, or null if cannot be determined
      */
     public static String parentPath(String pageUrl) {
         if (pageUrl == null || pageUrl.isEmpty() || pageUrl.equals("/")) {
             return null;
+        }
+
+        // When given a full URL (e.g. https://quarkus.io/guides/my-doc), drop the scheme and
+        // authority so we work on the path only; otherwise the host would leak into the prefix.
+        // URI.create() is safe here because pageUrl originates from page.url().absolute(), which
+        // has already been validated; it throws IllegalArgumentException on a malformed URI.
+        if (isFullPath(pageUrl)) {
+            String uriPath = URI.create(pageUrl).getPath();
+            if (uriPath == null || uriPath.isEmpty() || uriPath.equals("/")) {
+                return null;
+            }
+            pageUrl = uriPath;
         }
 
         String path = isAbsolute(pageUrl) ? pageUrl.substring(1) : pageUrl;

--- a/roq-frontmatter/runtime/src/test/java/io/quarkiverse/roq/frontmatter/runtime/model/RoqUrlTest.java
+++ b/roq-frontmatter/runtime/src/test/java/io/quarkiverse/roq/frontmatter/runtime/model/RoqUrlTest.java
@@ -161,6 +161,44 @@ class RoqUrlTest {
         assertNull(RoqUrl.parentPath(""));
     }
 
+    // The Asciidoc converter feeds parentPath() the value of page.url().absolute(), which is a
+    // full URL (scheme + host + path), not a root-relative path. These cases cover that contract.
+
+    @Test
+    void testParentPathFullUrl() {
+        assertEquals("/guides/", RoqUrl.parentPath("https://quarkus.io/guides/init-tasks/"));
+    }
+
+    @Test
+    void testParentPathFullUrlNoTrailingSlash() {
+        assertEquals("/guides/", RoqUrl.parentPath("https://quarkus.io/guides/security"));
+    }
+
+    @Test
+    void testParentPathFullUrlHttpScheme() {
+        assertEquals("/blog/", RoqUrl.parentPath("http://example.com/blog/my-post/"));
+    }
+
+    @Test
+    void testParentPathFullUrlDeepPath() {
+        assertEquals("/version/main/guides/", RoqUrl.parentPath("https://example.com/version/main/guides/security"));
+    }
+
+    @Test
+    void testParentPathFullUrlSingleSegment() {
+        assertEquals("/", RoqUrl.parentPath("https://example.com/my-doc"));
+    }
+
+    @Test
+    void testParentPathFullUrlSiteRoot() {
+        assertNull(RoqUrl.parentPath("https://example.com/"));
+    }
+
+    @Test
+    void testParentPathFullUrlNoPath() {
+        assertNull(RoqUrl.parentPath("https://example.com"));
+    }
+
     @Test
     void testIsFullPathHttpSchemes() {
         assertTrue(RoqUrl.isFullPath("http://example.com"));

--- a/roq-plugin/asciidoc-jruby/deployment/src/test/java/io/quarkiverse/roq/plugin/asciidoctorj/test/QuarkusAsciidoctorJTest.java
+++ b/roq-plugin/asciidoc-jruby/deployment/src/test/java/io/quarkiverse/roq/plugin/asciidoctorj/test/QuarkusAsciidoctorJTest.java
@@ -8,14 +8,16 @@ import java.util.Map;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.roq.frontmatter.runtime.RoqTemplateAttributes;
 import io.quarkiverse.roq.plugin.asciidoctorj.runtime.AsciidoctorJConverter;
 import io.quarkiverse.roq.plugin.asciidoctorj.runtime.AsciidoctorJSectionHelperFactory;
 import io.quarkus.qute.Engine;
 
 public class QuarkusAsciidoctorJTest {
 
-    public static final AsciidoctorJSectionHelperFactory FACTORY = new AsciidoctorJSectionHelperFactory(
-            new AsciidoctorJConverter(Map.of()));
+    public static final AsciidoctorJConverter CONVERTER = new AsciidoctorJConverter(Map.of());
+
+    public static final AsciidoctorJSectionHelperFactory FACTORY = new AsciidoctorJSectionHelperFactory(CONVERTER);
 
     @Test
     public void shouldConvertUsingAsciiTag() {
@@ -50,6 +52,20 @@ public class QuarkusAsciidoctorJTest {
                     <p><a href="../foo/">Bar</a></p>
                  </div>
                 """);
+    }
+
+    @Test
+    void shouldDeriveXrefPrefixFromPathWhenPageUrlIsAbsolute() {
+        // In production the page URL passed to the converter is page.url().absolute(), i.e. a full
+        // URL including scheme and host. The xref prefix must be derived from the path only; if the
+        // whole URL leaks in, inter-document links become /https://host/guides/... and 404.
+        RoqTemplateAttributes attributes = new RoqTemplateAttributes(
+                null, null, "https://quarkus.io", "/", "https://quarkus.io/guides/my-doc/", "/guides/my-doc/");
+
+        String result = CONVERTER.apply("xref:foo.adoc[Bar]", Map.of(), attributes);
+
+        assertThat(result).contains("<a href=\"/guides/foo/\">Bar</a>");
+        assertThat(result).doesNotContain("/https:");
     }
 
     @Test


### PR DESCRIPTION
#158 was the right idea, but it had an unfortunate bug that turned up in production; the `getParentPath()` method fails totally for full urls – ie, when `site.url` is set. Given a full URL it left the scheme and host in place, so the computed `relfileprefix` became /https://host/guides/ and every inter-document xref resolved to a 404.

I've checked this preserves the intended behaviour of #158 with fewer appalling side effects. I've also added some unit tests for the missing scenario, and a slightly higher level test which simulates the `site.url` scenario.