### PR TITLE
feat(config): update logDataBeans default to false and enhance logging description

### DIFF
--- a/blog/content/docs/advanced.adoc
+++ b/blog/content/docs/advanced.adoc
@@ -600,8 +600,8 @@ The layout template accesses data fields via `page.data`:
 | When true, only data files with a matching `@DataMapping` annotation produce beans
 
 | `quarkus.roq.data.log-data-beans`
-| `true`
-| Log registered data beans during build
+| `false`
+| Log the list of registered data beans at INFO level during build (always available at DEBUG level)
 |===
 
 == Debugging

--- a/blog/includes/configs/quarkus-roq-data.adoc
+++ b/blog/includes/configs/quarkus-roq-data.adoc
@@ -58,7 +58,8 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Log data beans as info during build
+Whether to log the list of registered data beans at INFO level during build.  +
+When disabled, the list is still available at DEBUG level for the `io.quarkiverse.roq.data.deployment.RoqDataBeanProcessor` logger.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -69,7 +70,7 @@ Environment variable: `+++QUARKUS_ROQ_DATA_LOG_DATA_BEANS+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|`+++false+++`
 
 |===
 

--- a/blog/includes/configs/quarkus-roq-data_quarkus.roq.adoc
+++ b/blog/includes/configs/quarkus-roq-data_quarkus.roq.adoc
@@ -58,7 +58,8 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Log data beans as info during build
+Whether to log the list of registered data beans at INFO level during build.  +
+When disabled, the list is still available at DEBUG level for the `io.quarkiverse.roq.data.deployment.RoqDataBeanProcessor` logger.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -69,7 +70,7 @@ Environment variable: `+++QUARKUS_ROQ_DATA_LOG_DATA_BEANS+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|`+++false+++`
 
 |===
 

--- a/docs/modules/ROOT/pages/_includes/quarkus-roq-data.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-roq-data.adoc
@@ -58,7 +58,8 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Log data beans as info during build
+Whether to log the list of registered data beans at INFO level during build.  +
+When disabled, the list is still available at DEBUG level for the `io.quarkiverse.roq.data.deployment.RoqDataBeanProcessor` logger.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -69,7 +70,7 @@ Environment variable: `+++QUARKUS_ROQ_DATA_LOG_DATA_BEANS+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|`+++false+++`
 
 |===
 

--- a/docs/modules/ROOT/pages/_includes/quarkus-roq-data_quarkus.roq.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-roq-data_quarkus.roq.adoc
@@ -58,7 +58,8 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Log data beans as info during build
+Whether to log the list of registered data beans at INFO level during build.  +
+When disabled, the list is still available at DEBUG level for the `io.quarkiverse.roq.data.deployment.RoqDataBeanProcessor` logger.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -69,7 +70,7 @@ Environment variable: `+++QUARKUS_ROQ_DATA_LOG_DATA_BEANS+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|`+++false+++`
 
 |===
 

--- a/roq-data/deployment/src/main/java/io/quarkiverse/roq/data/deployment/RoqDataBeanProcessor.java
+++ b/roq-data/deployment/src/main/java/io/quarkiverse/roq/data/deployment/RoqDataBeanProcessor.java
@@ -77,10 +77,15 @@ class RoqDataBeanProcessor {
             beans.add("    - %s[name=%s]".formatted(beanBuildItem.getBeanClass().getName(), beanBuildItem.getName()));
         }
 
-        if (!beans.isEmpty() && config.logDataBeans()) {
-            LOG.infof("Roq data beans%s: %n%s",
+        if (!beans.isEmpty() && (config.logDataBeans() || LOG.isDebugEnabled())) {
+            final String message = "Roq data beans%s: %n%s".formatted(
                     roqDataJsonBuildItems.isEmpty() ? "" : " (* add a @DataMapping to enable type-safety)",
                     String.join(System.lineSeparator(), beans));
+            if (config.logDataBeans()) {
+                LOG.info(message);
+            } else {
+                LOG.debug(message);
+            }
         }
     }
 

--- a/roq-data/deployment/src/main/java/io/quarkiverse/roq/data/deployment/RoqDataConfig.java
+++ b/roq-data/deployment/src/main/java/io/quarkiverse/roq/data/deployment/RoqDataConfig.java
@@ -30,9 +30,12 @@ public interface RoqDataConfig {
     boolean enforceBean();
 
     /**
-     * Log data beans as info during build
+     * Whether to log the list of registered data beans at INFO level during build.
+     * <br>
+     * When disabled, the list is still available at DEBUG level for the
+     * {@code io.quarkiverse.roq.data.deployment.RoqDataBeanProcessor} logger.
      */
-    @WithDefault("true")
+    @WithDefault("false")
     boolean logDataBeans();
 
     static boolean isEqual(RoqDataConfig q1, RoqDataConfig q2) {


### PR DESCRIPTION
Closes: #1176 

- The detailed listing is now set to DEBUG. It only moves to INFO when the `quarkus.roq.data.log-data-beans` option is enabled. The string is constructed only if either of the two levels is used.