### PR TITLE
Handle attributes in asciidoc headers

### DIFF
--- a/roq-plugin/asciidoc-common/deployment/src/main/java/io/quarkiverse/roq/plugin/asciidoc/common/deployment/AsciidocHeaderParser.java
+++ b/roq-plugin/asciidoc-common/deployment/src/main/java/io/quarkiverse/roq/plugin/asciidoc/common/deployment/AsciidocHeaderParser.java
@@ -55,6 +55,20 @@ public class AsciidocHeaderParser {
     // Matches attribute entries: :name: value, :!name: (unset), :name!: (unset)
     private static final Pattern ATTRIBUTE_ENTRY = Pattern.compile("^:(!?\\w[^:]*):(?:[ \\t]+(.*))?$");
 
+    // TODO: if https://github.com/yupiik/tools-maven-plugin/issues/100 is resolved, the
+    //  resolveAttributeReferences method and its three call sites in toPageData() can be
+    //  removed, reverting those lines to plain header.title() / attributes.get(...) calls.
+    //  Yupiik's Parser already has a private earlyAttributeReplacement(String, Map<String,String>)
+    //  method that does this — if it were package-visible we could call it directly instead.
+
+    // Matches an attribute reference such as {my-title}.
+    // Attribute names must start with a word character and may contain word characters and
+    // hyphens, per the AsciiDoc specification. This is intentionally stricter than Yupiik's
+    // own ATTRIBUTE_VALUE pattern (\{(?<name>[^ }]+)}), which accepts any non-space, non-}
+    // character. The tighter pattern avoids false matches on Qute expressions such as
+    // {data.field} or shell-style substitutions that may appear in content.
+    private static final Pattern ATTRIBUTE_REFERENCE = Pattern.compile("\\{(\\w[\\w-]*)}");
+
     public static RoqFrontMatterHeaderParserBuildItem createBuildItem(boolean qute, Predicate<TemplateContext> isApplicable) {
         return new RoqFrontMatterHeaderParserBuildItem(isApplicable, templateContext -> {
             Parser parser = new Parser();
@@ -92,10 +106,7 @@ public class AsciidocHeaderParser {
             }
         }
         if (!header.title().isBlank()) {
-            pageData.put(TITLE, header.title());
-        }
-        if (header.attributes().containsKey(DESCRIPTION) && !header.attributes().get(DESCRIPTION).isBlank()) {
-            pageData.put(DESCRIPTION, header.attributes().get("description"));
+            pageData.put(TITLE, resolveAttributeReferences(header.title(), attributes));
         }
 
         if ((header.author() != null) && !header.author().isEmpty()
@@ -112,12 +123,39 @@ public class AsciidocHeaderParser {
                     .put("remark", header.revision().revmark()));
         }
         if (attributes.containsKey("description")) {
-            pageData.put(DESCRIPTION, attributes.get("description"));
+            pageData.put(DESCRIPTION, resolveAttributeReferences(attributes.get("description"), attributes));
         }
         if (attributes.containsKey("image")) {
-            pageData.put("image", attributes.get("image"));
+            pageData.put("image", resolveAttributeReferences(attributes.get("image"), attributes));
         }
         return pageData;
+    }
+
+    // TODO: this method and its call sites in toPageData() can be deleted once
+    //  https://github.com/yupiik/tools-maven-plugin/issues/100 is resolved and Yupiik
+    //  substitutes attribute references in header fields (title, attribute values) itself.
+    //  (Yupiik's Parser already has a private earlyAttributeReplacement method for this purpose.)
+    //
+    // Resolves attribute references such as {my-attr} against the document header attributes.
+    // The Yupiik parser reads the title line before the header attribute entries (and before any
+    // include::_attributes.adoc[] in the header), so it never substitutes attribute references in
+    // the doctitle. Asciidoctor, by contrast, defers doctitle substitution until the whole header
+    // (includes and all) is parsed. We reproduce that here using the fully resolved header
+    // attributes. Unknown references are left untouched, matching Asciidoctor's default
+    // attribute-missing=skip behaviour.
+    static String resolveAttributeReferences(String value, Map<String, String> attributes) {
+        if (value == null || value.indexOf('{') < 0) {
+            return value;
+        }
+        Matcher matcher = ATTRIBUTE_REFERENCE.matcher(value);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String name = matcher.group(1);
+            String replacement = attributes.containsKey(name) ? attributes.get(name) : matcher.group();
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(result);
+        return result.toString();
     }
 
     public static Map<String, String> processAttributes(Map<String, String> input) {
@@ -139,6 +177,14 @@ public class AsciidocHeaderParser {
     // Pre-process ifdef/ifndef/endif/ifeval directives, evaluating conditions against
     // attributes defined so far in the header. This mirrors (in simplified form) what the
     // reference Asciidoctor preprocessor does before header parsing.
+    //
+    // NOTE: Yupiik 1.2.16 handles block-form ifdef/ifndef/ifeval in readAttributes() natively,
+    // but silently drops the inline form (ifdef::attr[content] on a single line) and stops header
+    // parsing there. This pre-pass is still required to cover that case correctly. Once
+    // https://github.com/yupiik/tools-maven-plugin/issues/102 is resolved the pre-pass and
+    // everything it uses (SIMPLE_CONDITIONAL, CONDITIONAL_DIRECTIVE, COMMA, PLUS, isIncluding,
+    // evaluateCondition, trackAttribute) can be removed entirely.
+    //
     // NOTE: attributes set externally (e.g. via quarkus.asciidoc.attributes in the pom or
     // environment variables) are not yet available here — only attributes defined within the
     // document header itself are tracked. Supporting external attributes would require threading

--- a/roq-plugin/asciidoc-common/deployment/src/test/java/io/quarkiverse/roq/plugin/asciidoc/common/deployment/AsciidocHeaderParserTest.java
+++ b/roq-plugin/asciidoc-common/deployment/src/test/java/io/quarkiverse/roq/plugin/asciidoc/common/deployment/AsciidocHeaderParserTest.java
@@ -648,6 +648,185 @@ class AsciidocHeaderParserTest {
         }
     }
 
+    @Nested
+    class TitleAttributeReferences {
+
+        @Test
+        void shouldResolveTitleFromAttributeDefinedInHeader() {
+            // The Yupiik parser reads the title line before the attribute entries, so it never
+            // substitutes {attr} in the doctitle. We resolve it against the header attributes,
+            // matching Asciidoctor.
+            String content = """
+                    = {my-guide-title}
+                    :my-guide-title: Some parameterized title
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("title")).isEqualTo("Some parameterized title");
+        }
+
+        @Test
+        void shouldResolveTitleFromAttributeDefinedInHeaderInclude() {
+            // Mirrors the real guides: the title references an attribute defined via
+            // include::_attributes.adoc[] on the line immediately after the title.
+            String content = """
+                    = {my-guide-title}
+                    include::_attributes.adoc[]
+
+                    Body.
+                    """;
+
+            TemplateContext ctx = new TemplateContext(
+                    Path.of("src/test/resources/attribute-title/index.adoc").toAbsolutePath(),
+                    "attribute-title/index.adoc", content);
+            JsonObject result = buildItem.parse().apply(ctx);
+            assertThat(result.getString("title")).isEqualTo("Some parameterized title");
+        }
+
+        @Test
+        void shouldResolveTitleWithSurroundingLiteralText() {
+            String content = """
+                    = Using {my-thing} in Quarkus
+                    :my-thing: the TLS registry
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("title")).isEqualTo("Using the TLS registry in Quarkus");
+        }
+
+        @Test
+        void shouldLeaveUnknownAttributeReferenceUntouched() {
+            // Matches Asciidoctor's default attribute-missing=skip behaviour.
+            String content = """
+                    = {not-defined}
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("title")).isEqualTo("{not-defined}");
+        }
+
+        @Test
+        void shouldLeaveLiteralTitleUntouched() {
+            String content = """
+                    = My Title
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("title")).isEqualTo("My Title");
+        }
+    }
+
+    @Nested
+    class DescriptionAttributeReferences {
+
+        @Test
+        void shouldResolveDescriptionFromAttributeDefinedInHeader() {
+            String content = """
+                    = My Title
+                    :product: Quarkus
+                    :description: A guide to {product}.
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("description")).isEqualTo("A guide to Quarkus.");
+        }
+
+        @Test
+        void shouldResolveDescriptionWithMultipleReferences() {
+            String content = """
+                    = My Title
+                    :product: Quarkus
+                    :version: 3.x
+                    :description: Using {product} {version} in production.
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("description")).isEqualTo("Using Quarkus 3.x in production.");
+        }
+
+        @Test
+        void shouldLeaveUnknownReferenceInDescriptionUntouched() {
+            String content = """
+                    = My Title
+                    :description: Covers {not-defined} topics.
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("description")).isEqualTo("Covers {not-defined} topics.");
+        }
+
+        @Test
+        void shouldLeaveLiteralDescriptionUntouched() {
+            String content = """
+                    = My Title
+                    :description: A plain description with no references.
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("description")).isEqualTo("A plain description with no references.");
+        }
+    }
+
+    @Nested
+    class ImageAttributeReferences {
+
+        @Test
+        void shouldResolveImageFromAttributeDefinedInHeader() {
+            String content = """
+                    = My Title
+                    :imagesdir: /assets/images
+                    :image: {imagesdir}/hero.png
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("image")).isEqualTo("/assets/images/hero.png");
+        }
+
+        @Test
+        void shouldLeaveUnknownReferenceInImageUntouched() {
+            String content = """
+                    = My Title
+                    :image: {imagesdir}/hero.png
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("image")).isEqualTo("{imagesdir}/hero.png");
+        }
+
+        @Test
+        void shouldLeaveLiteralImageUntouched() {
+            String content = """
+                    = My Title
+                    :image: /assets/images/hero.png
+
+                    Body.
+                    """;
+
+            JsonObject result = parse(content);
+            assertThat(result.getString("image")).isEqualTo("/assets/images/hero.png");
+        }
+    }
+
     // --- stripConditionalDirectives unit tests ---
 
     @Nested

--- a/roq-plugin/asciidoc-common/deployment/src/test/resources/attribute-title/_attributes.adoc
+++ b/roq-plugin/asciidoc-common/deployment/src/test/resources/attribute-title/_attributes.adoc
@@ -1,0 +1,1 @@
+:my-guide-title: Some parameterized title


### PR DESCRIPTION
Ideally this would be done in the Yupiik layer, so I've also opened https://github.com/yupiik/tools-maven-plugin/issues/100. If that one closes, we'd still want the tests from this PR, just a bit less of the code. 

See https://github.com/quarkusio/quarkus/pull/56389