### PR TITLE
fix: resolve <html lang> from page/site frontmatter instead of hardcoded "en"

### DIFF
--- a/roq-frontmatter/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/roq-frontmatter/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -66,6 +66,7 @@ Key fields:
 - **date** — Page date. For collection documents, can also be parsed from filename (`YYYY-MM-DD-slug.md`)
 - **tags** — String or array of tags
 - **author** — Author identifier
+- **lang** — Language/locale of the page (e.g. `fr`, `en-US`). Drives the rendered `<html lang="...">` attribute and the `og:locale` SEO meta tag. Resolution order: page `lang` → site `lang` (set in the index page frontmatter) → the JVM default locale. This is independent of `site.defaultLocale`, which only controls the fallback locale used for locale-aware date formatting (`page.date.shortDate`, etc.)
 - **robots** — Value rendered as `<meta name="robots">` in the HTML head by the built-in `{#seo page site /}` tag (e.g. `noindex`, `nofollow`, `noindex, nofollow`). Use it to keep drafts, internal docs, or staging pages out of search engine indexes. The meta tag is only emitted when the key is set on the page
 - **draft** — `true` to mark as draft (hidden unless `site.draft=true`)
 - **paginate** — Enable pagination. Shorthand: `paginate: posts`. Full config: `collection`, `size`, `link`
@@ -448,7 +449,7 @@ Content helpers:
 site.url=http://localhost:8080
 site.draft=true                    # Show draft pages
 site.future=true                   # Show future-dated documents
-site.defaultLocale=en              # Default language
+site.defaultLocale=en              # Default locale for date formatting (see also 'lang' frontmatter key)
 site.draftDirectory=drafts         # Folder name for drafts
 site.slugifyFiles=true             # Slugify static file names for SEO
 site.escaped-pages=posts/escaped** # Skip Qute parsing for matched pages

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterBaseThemeTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterBaseThemeTest.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.roq.frontmatter.deployment.apptest;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,10 @@ import io.restassured.RestAssured;
  * Site: {@code base-theme-site} (resource)
  * <p>
  * Verifies that roq-base theme layouts work as fallback when no local layouts are provided.
+ * Also covers the {@code <html lang="...">} attribute: the site sets {@code lang: fr} and the
+ * "about" page overrides it with {@code lang: de}, exercising the page → site fallback chain
+ * (the JVM-default fallback case needs its own lang-free site, see
+ * {@link RoqFrontMatterHtmlLangGlobalFallbackTest}).
  */
 @DisplayName("Roq FrontMatter - Base theme layouts")
 public class RoqFrontMatterBaseThemeTest {
@@ -39,5 +44,19 @@ public class RoqFrontMatterBaseThemeTest {
         RestAssured.when().get("/posts/hello-post").then().statusCode(200).log().ifValidationFails()
                 .body(containsString("<h1 class=\"page-title\">Hello Post</h1>"))
                 .body(containsString("A post using roq-base post layout."));
+    }
+
+    @Test
+    @DisplayName("html lang attribute uses the page's FM lang when set")
+    public void testHtmlLangFromPage() {
+        RestAssured.when().get("/about").then().statusCode(200).log().ifValidationFails()
+                .body("html.@lang", equalTo("de"));
+    }
+
+    @Test
+    @DisplayName("html lang attribute falls back to the site's FM lang when the page has none")
+    public void testHtmlLangFallsBackToSite() {
+        RestAssured.when().get("/posts/hello-post").then().statusCode(200).log().ifValidationFails()
+                .body("html.@lang", equalTo("fr"));
     }
 }

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterHtmlLangGlobalFallbackTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterHtmlLangGlobalFallbackTest.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.roq.frontmatter.deployment.apptest;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+/**
+ * Site: {@code html-lang-global-site} (resource)
+ * <p>
+ * Neither the page nor the site frontmatter sets {@code lang}, so the {@code <html lang="...">}
+ * attribute must fall back to the JVM default locale ({@code global:locale}, i.e.
+ * {@code Locale.getDefault()} — not affected by the {@code quarkus.default-locale} runtime config).
+ * <p>
+ * The page-lang and site-lang-fallback cases are covered by {@link RoqFrontMatterBaseThemeTest}
+ * instead (its {@code base-theme-site} fixture sets a {@code lang} on the site and on one page).
+ * This case needs a dedicated site with no {@code lang} set anywhere, since {@code site.data}
+ * always comes from the index page's own frontmatter.
+ */
+@DisplayName("Roq FrontMatter - html lang attribute falls back to JVM default locale")
+public class RoqFrontMatterHtmlLangGlobalFallbackTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest unitTest = new QuarkusExtensionTest()
+            .overrideConfigKey("quarkus.roq.resource-dir", "html-lang-global-site")
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("html-lang-global-site"));
+
+    @Test
+    @DisplayName("Index page falls back to the JVM default locale")
+    public void testGlobalLangFallback() {
+        RestAssured.when().get("/").then().statusCode(200).log().ifValidationFails()
+                .body("html.@lang", equalTo(Locale.getDefault().toString()));
+    }
+}

--- a/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterHtmlLangGlobalFallbackTest.java
+++ b/roq-frontmatter/deployment/src/test/java/io/quarkiverse/roq/frontmatter/deployment/apptest/RoqFrontMatterHtmlLangGlobalFallbackTest.java
@@ -15,8 +15,10 @@ import io.restassured.RestAssured;
  * Site: {@code html-lang-global-site} (resource)
  * <p>
  * Neither the page nor the site frontmatter sets {@code lang}, so the {@code <html lang="...">}
- * attribute must fall back to the JVM default locale ({@code global:locale}, i.e.
- * {@code Locale.getDefault()} — not affected by the {@code quarkus.default-locale} runtime config).
+ * attribute must fall back to the JVM default locale as a BCP 47 tag ({@code global:htmlLocale},
+ * i.e. {@code Locale.getDefault().toLanguageTag()} — not affected by the {@code quarkus.default-locale}
+ * runtime config). This is distinct from {@code global:locale} ({@code Locale#toString()}), which
+ * uses the underscore-separated form expected by the {@code og:locale} SEO meta tag.
  * <p>
  * The page-lang and site-lang-fallback cases are covered by {@link RoqFrontMatterBaseThemeTest}
  * instead (its {@code base-theme-site} fixture sets a {@code lang} on the site and on one page).
@@ -36,6 +38,6 @@ public class RoqFrontMatterHtmlLangGlobalFallbackTest {
     @DisplayName("Index page falls back to the JVM default locale")
     public void testGlobalLangFallback() {
         RestAssured.when().get("/").then().statusCode(200).log().ifValidationFails()
-                .body("html.@lang", equalTo(Locale.getDefault().toString()));
+                .body("html.@lang", equalTo(Locale.getDefault().toLanguageTag()));
     }
 }

--- a/roq-frontmatter/deployment/src/test/resources/base-theme-site/content/about.html
+++ b/roq-frontmatter/deployment/src/test/resources/base-theme-site/content/about.html
@@ -1,4 +1,5 @@
 ---
 title: About
+lang: de
 ---
 <p>About page using roq-base page layout</p>

--- a/roq-frontmatter/deployment/src/test/resources/base-theme-site/content/index.html
+++ b/roq-frontmatter/deployment/src/test/resources/base-theme-site/content/index.html
@@ -1,4 +1,5 @@
 ---
 title: Base Theme Site
+lang: fr
 ---
 <h1>Welcome</h1>

--- a/roq-frontmatter/deployment/src/test/resources/html-lang-global-site/content/index.html
+++ b/roq-frontmatter/deployment/src/test/resources/html-lang-global-site/content/index.html
@@ -1,0 +1,6 @@
+---
+title: No Lang Anywhere Site
+layout: default
+---
+
+<span class="site-title">{site.title}</span>

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqFrontMatterKeys.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqFrontMatterKeys.java
@@ -76,6 +76,17 @@ public interface RoqFrontMatterKeys {
     String AUTHOR = "author";
 
     /**
+     * Language/locale — e.g. {@code lang: fr}. Drives the rendered {@code <html lang="...">} attribute and the
+     * {@code og:locale} SEO meta tag. Resolution order: page {@code lang} → site {@code lang} (from the index
+     * page frontmatter) → the JVM default locale.
+     * <br>
+     * ▸ Scope: site / page / document
+     * <br>
+     * ▸ Access: {@code page.data.getString("lang")} · {@code site.data.getString("lang")}
+     */
+    String LANG = "lang";
+
+    /**
      * Custom URL slug — e.g. {@code slug: my-custom-slug} (overrides auto-generated slug from title)
      * <br>
      * ▸ Scope: page / document

--- a/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplateGlobal.java
+++ b/roq-frontmatter/runtime/src/main/java/io/quarkiverse/roq/frontmatter/runtime/RoqTemplateGlobal.java
@@ -10,5 +10,8 @@ import io.quarkus.qute.TemplateGlobal;
 public class RoqTemplateGlobal {
     static LocalDateTime now = LocalDateTime.now();
     static String roqVersion = Objects.toString(RoqTemplateGlobal.class.getPackage().getImplementationVersion(), "???");
+    // Locale#toString() (e.g. "en_US") matches the Open Graph og:locale convention, used as-is for that tag.
     static String locale = Locale.getDefault().toString();
+    // HTML's lang attribute requires a BCP 47 tag (e.g. "en-US"), hence the separate toLanguageTag() global.
+    static String htmlLocale = Locale.getDefault().toLanguageTag();
 }

--- a/roq-frontmatter/runtime/src/main/resources/templates/theme-layouts/roq-base/default.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/theme-layouts/roq-base/default.html
@@ -1,5 +1,8 @@
+{@io.quarkiverse.roq.frontmatter.runtime.model.Page page}
+{@io.quarkiverse.roq.frontmatter.runtime.model.Site site}
+{#let pageLang=page.data.lang?? siteLang=site.data.lang??}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{pageLang ?: siteLang ?: global:locale}">
 <head>
   {#insert head-meta}
   <meta charset="UTF-8">
@@ -15,3 +18,4 @@
   {#insert /}
 </body>
 </html>
+{/let}

--- a/roq-frontmatter/runtime/src/main/resources/templates/theme-layouts/roq-base/default.html
+++ b/roq-frontmatter/runtime/src/main/resources/templates/theme-layouts/roq-base/default.html
@@ -1,8 +1,7 @@
 {@io.quarkiverse.roq.frontmatter.runtime.model.Page page}
 {@io.quarkiverse.roq.frontmatter.runtime.model.Site site}
-{#let pageLang=page.data.lang?? siteLang=site.data.lang??}
 <!DOCTYPE html>
-<html lang="{pageLang ?: siteLang ?: global:locale}">
+<html lang="{page.data.getString('lang') ?: site.data.getString('lang') ?: global:htmlLocale}">
 <head>
   {#insert head-meta}
   <meta charset="UTF-8">
@@ -18,4 +17,3 @@
   {#insert /}
 </body>
 </html>
-{/let}

--- a/roq-theme/linktree/integration-tests/src/test/java/io/quarkiverse/roq/RoqThemeLinktreeTest.java
+++ b/roq-theme/linktree/integration-tests/src/test/java/io/quarkiverse/roq/RoqThemeLinktreeTest.java
@@ -40,6 +40,18 @@ public class RoqThemeLinktreeTest {
     }
 
     @Test
+    void testHtmlLangAttribute() {
+        String body = given().config(TIMEOUT_CONFIG)
+                .when().get("/")
+                .then()
+                .statusCode(200)
+                .extract().asString();
+        // No 'lang' frontmatter is set in this sample site, so it falls back to the JVM default
+        // locale; just verify the attribute is rendered with a non-empty value (not hardcoded "en").
+        assertThat(body).containsPattern("<html lang=\"[^\"]+\"");
+    }
+
+    @Test
     void testLinktreesLayout() {
         String body = given().config(TIMEOUT_CONFIG)
                 .when().get("/trees")

--- a/roq-theme/linktree/runtime/src/main/resources/templates/theme-layouts/roq-linktree/default.html
+++ b/roq-theme/linktree/runtime/src/main/resources/templates/theme-layouts/roq-linktree/default.html
@@ -1,7 +1,8 @@
 {@io.quarkiverse.roq.frontmatter.runtime.model.Page page}
 {@io.quarkiverse.roq.frontmatter.runtime.model.Site site}
+{#let pageLang=page.data.lang?? siteLang=site.data.lang??}
 <!DOCTYPE html>
-<html lang="en" class="bg-slate-100 dark:bg-slate-900">
+<html lang="{pageLang ?: siteLang ?: global:locale}" class="bg-slate-100 dark:bg-slate-900">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -13,3 +14,4 @@
   {#insert /}
 </body>
 </html>
+{/let}

--- a/roq-theme/linktree/runtime/src/main/resources/templates/theme-layouts/roq-linktree/default.html
+++ b/roq-theme/linktree/runtime/src/main/resources/templates/theme-layouts/roq-linktree/default.html
@@ -1,8 +1,7 @@
 {@io.quarkiverse.roq.frontmatter.runtime.model.Page page}
 {@io.quarkiverse.roq.frontmatter.runtime.model.Site site}
-{#let pageLang=page.data.lang?? siteLang=site.data.lang??}
 <!DOCTYPE html>
-<html lang="{pageLang ?: siteLang ?: global:locale}" class="bg-slate-100 dark:bg-slate-900">
+<html lang="{page.data.getString('lang') ?: site.data.getString('lang') ?: global:htmlLocale}" class="bg-slate-100 dark:bg-slate-900">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14,4 +13,3 @@
   {#insert /}
 </body>
 </html>
-{/let}

--- a/roq-theme/resume/integration-tests/src/test/java/io/quarkiverse/roq/RoqThemeResumeTest.java
+++ b/roq-theme/resume/integration-tests/src/test/java/io/quarkiverse/roq/RoqThemeResumeTest.java
@@ -39,6 +39,15 @@ public class RoqThemeResumeTest {
     }
 
     @Test
+    public void testHtmlLangAttribute() {
+        final String body = RestAssured.when().get("/").then().statusCode(200).log().ifValidationFails().extract()
+                .asString();
+        // No 'lang' frontmatter is set in this sample site, so it falls back to the JVM default
+        // locale; just verify the attribute is rendered with a non-empty value (not hardcoded "en").
+        assertThat(body).containsPattern("<html lang=\"[^\"]+\"");
+    }
+
+    @Test
     public void testStyle() {
         final String body = RestAssured.when().get(bundle.style("app")).then().statusCode(200).log().ifValidationFails()
                 .extract()

--- a/roq-theme/resume/runtime/src/main/resources/templates/theme-layouts/roq-resume/default.html
+++ b/roq-theme/resume/runtime/src/main/resources/templates/theme-layouts/roq-resume/default.html
@@ -1,5 +1,8 @@
+{@io.quarkiverse.roq.frontmatter.runtime.model.Page page}
+{@io.quarkiverse.roq.frontmatter.runtime.model.Site site}
+{#let pageLang=page.data.lang?? siteLang=site.data.lang??}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{pageLang ?: siteLang ?: global:locale}">
 <head>
   {#include partials/roq-resume/head.html /}
 </head>
@@ -7,3 +10,4 @@
     {#insert /}
 </body>
 </html>
+{/let}

--- a/roq-theme/resume/runtime/src/main/resources/templates/theme-layouts/roq-resume/default.html
+++ b/roq-theme/resume/runtime/src/main/resources/templates/theme-layouts/roq-resume/default.html
@@ -1,8 +1,7 @@
 {@io.quarkiverse.roq.frontmatter.runtime.model.Page page}
 {@io.quarkiverse.roq.frontmatter.runtime.model.Site site}
-{#let pageLang=page.data.lang?? siteLang=site.data.lang??}
 <!DOCTYPE html>
-<html lang="{pageLang ?: siteLang ?: global:locale}">
+<html lang="{page.data.getString('lang') ?: site.data.getString('lang') ?: global:htmlLocale}">
 <head>
   {#include partials/roq-resume/head.html /}
 </head>
@@ -10,4 +9,3 @@
     {#insert /}
 </body>
 </html>
-{/let}


### PR DESCRIPTION
## Summary
- The `roq-base`, `roq-resume`, and `roq-linktree` theme layouts hardcoded `<html lang="en">`.
- Roq already resolves a page/site `lang` frontmatter key for the `og:locale` SEO meta tag (`seo.html` / `seoLocale.html`), so this reuses the same `page lang -> site lang -> JVM default locale` fallback chain for the `<html lang="...">` attribute.
- Documents the `lang` frontmatter key in `RoqFrontMatterKeys` and the `roq-frontmatter` skill doc.

## Test plan
- [x] New `RoqFrontMatterBaseThemeTest` assertions cover page-lang and page->site fallback via the `base-theme-site` fixture.
- [x] New `RoqFrontMatterHtmlLangGlobalFallbackTest` covers the JVM-default fallback (no `lang` set anywhere).
- [x] Added `<html lang>` smoke assertions to the existing `roq-resume` and `roq-linktree` theme integration tests.