### PR TITLE
Add sort virtual method to jekyll templates

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
+++ b/migration/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
@@ -23,7 +23,9 @@ import io.vertx.core.json.JsonObject;
 @TemplateExtension
 public class JekyllFiltersExtension {
 
-    // Null-safe get — prevents NPE when key is null (e.g. from ?? operator)
+    /**
+     * Null-safe get for JsonObject. Prevents NPE when key is null (e.g. from ?? operator).
+     */
     static Object get(JsonObject obj, String key) {
         if (obj == null || key == null || key.isEmpty()) {
             return null;
@@ -31,6 +33,10 @@ public class JekyllFiltersExtension {
         return obj.getValue(key);
     }
 
+    /**
+     * Jekyll's "where" filter: select items from an array where a property matches a value.
+     * Usage in Qute: {myArray.where("key", "value")}
+     */
     static JsonArray where(JsonArray array, String property, String value) {
         JsonArray result = new JsonArray();
         for (int i = 0; i < array.size(); i++) {
@@ -45,18 +51,34 @@ public class JekyllFiltersExtension {
         return result;
     }
 
+    /**
+     * Get the first element of a JsonArray.
+     * Usage in Qute: {myArray.first}
+     */
     static Object first(JsonArray array) {
         return array == null || array.isEmpty() ? null : array.getValue(0);
     }
 
+    /**
+     * Get the last element of a JsonArray.
+     * Usage in Qute: {myArray.last}
+     */
     static Object last(JsonArray array) {
         return array == null || array.isEmpty() ? null : array.getValue(array.size() - 1);
     }
 
+    /**
+     * Get the size of a JsonArray.
+     * Usage in Qute: {myArray.size}
+     */
     static int size(JsonArray array) {
         return array == null ? 0 : array.size();
     }
 
+    /**
+     * Jekyll's "group_by" filter: group items by a property value.
+     * Usage in Qute: {myArray.groupBy("type")}
+     */
     static JsonArray groupBy(JsonArray items, String property) {
         if (items == null) {
             return new JsonArray();
@@ -86,12 +108,21 @@ public class JekyllFiltersExtension {
     private static final DateTimeFormatter RFC_822 = DateTimeFormatter
             .ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
 
-    // Bridges LocalDateTime → RFC 822; Roq's built-in rfc822 only handles ZonedDateTime
+    /**
+     * RFC 822 date-time for LocalDateTime (assumes UTC).
+     * Roq's built-in rfc822 only works on ZonedDateTime; this bridges the gap
+     * for template globals like {now} which are LocalDateTime.
+     * Usage in Qute: {now.rfc822}
+     */
     static String rfc822(LocalDateTime dateTime) {
         return dateTime.atZone(ZoneOffset.UTC).format(RFC_822);
     }
 
-    // Qute auto-escapes in .html but not in .xml/.txt
+    /**
+     * Jekyll's "xml_escape" / "escape" filter: escape HTML/XML special characters.
+     * Qute auto-escapes in .html templates but not in .xml/.txt files.
+     * Usage in Qute: {=myString.escapeHtml}
+     */
     static String escapeHtml(String str) {
         if (str == null) {
             return "";
@@ -103,6 +134,10 @@ public class JekyllFiltersExtension {
                 .replace("'", "&#39;");
     }
 
+    /**
+     * Jekyll/Liquid's "capitalize" filter: uppercase the first character.
+     * Usage in Qute: {myString.capitalize}
+     */
     static String capitalize(String str) {
         if (str == null || str.isEmpty()) {
             return str;
@@ -110,6 +145,10 @@ public class JekyllFiltersExtension {
         return Character.toUpperCase(str.charAt(0)) + str.substring(1);
     }
 
+    /**
+     * Jekyll's "truncate" filter: truncate a string to a given number of characters.
+     * Usage in Qute: {myString.truncate(280)}
+     */
     static String truncate(String str, int length) {
         if (str == null) {
             return "";
@@ -118,6 +157,16 @@ public class JekyllFiltersExtension {
             return str;
         }
         return str.substring(0, length) + "...";
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T extends Comparable<T>> List<T> sort(List<T> list) {
+        if (list == null || list.isEmpty()) {
+            return List.of();
+        }
+        List<T> sorted = new ArrayList<>(list);
+        Collections.sort(sorted);
+        return sorted;
     }
 
     static List<?> sort(List<?> list, String property) {
@@ -129,6 +178,41 @@ public class JekyllFiltersExtension {
         return sorted;
     }
 
+    /**
+     * A simple key/value pair whose properties are named exactly as the templates
+     * expect: {@code data.first} for the key and {@code data.last} for the value.
+     * Mirrors the shape of the entries produced by Roq's built-in JsonObject iteration.
+     */
+    public record JsonEntry(String first, Object last) {
+    }
+
+    /**
+     * Jekyll's "sort" filter for JsonObject (map-of-maps, e.g. data/authors.yaml).
+     * Returns a list of {@link JsonEntry} sorted by the named property on each value,
+     * so templates can use {data.first} (key) and {data.last} (value).
+     * Usage in Qute: {cdi:authors.sort('name')}
+     */
+    static List<JsonEntry> sort(JsonObject obj, String property) {
+        if (obj == null || obj.isEmpty()) {
+            return List.of();
+        }
+        List<JsonEntry> entries = new ArrayList<>();
+        for (String key : obj.fieldNames()) {
+            entries.add(new JsonEntry(key, obj.getValue(key)));
+        }
+        entries.sort((a, b) -> {
+            String va = extractProperty(a.last(), property);
+            String vb = extractProperty(b.last(), property);
+            if (va == null)
+                return vb == null ? 0 : 1;
+            if (vb == null)
+                return -1;
+            return va.compareToIgnoreCase(vb);
+        });
+        return entries;
+    }
+
+    /** Jekyll's "sort" filter for JsonArray. */
     static JsonArray sort(JsonArray array, String property) {
         if (array == null || array.isEmpty()) {
             return new JsonArray();
@@ -138,6 +222,7 @@ public class JekyllFiltersExtension {
         return new JsonArray(sorted);
     }
 
+    /** Jekyll's "reverse" filter for JsonArray. */
     static JsonArray reverse(JsonArray array) {
         if (array == null || array.isEmpty()) {
             return new JsonArray();
@@ -147,7 +232,11 @@ public class JekyllFiltersExtension {
         return new JsonArray(reversed);
     }
 
-    // Selects items where a boolean property is falsy (bridges Liquid's unless pattern)
+    /**
+     * Filter items where the given boolean property is falsy.
+     * Bridges Liquid's unless pattern.
+     * Usage in Qute: {list:whereNot(myList, 'upcoming')}
+     */
     @TemplateExtension(namespace = "list")
     static List<Object> whereNot(Iterable<?> items, String property) {
         List<Object> result = new ArrayList<>();
@@ -315,7 +404,12 @@ public class JekyllFiltersExtension {
         return result;
     }
 
-    // Replaces Liquid's push-accumulation pattern (broken in Qute because {#let} is block-scoped)
+    /**
+     * Merge all items of a given type from all sources in a data index JsonObject.
+     * Replaces the broken Jekyll push-accumulation pattern that doesn't work in Qute
+     * ({#let} is block-scoped so push results are discarded in loops).
+     * Usage in Qute: {index.mergeTypes('tutorial')}
+     */
     @SuppressWarnings("unchecked")
     static JsonArray mergeTypes(JsonObject index, String type) {
         if (index == null || type == null || type.isEmpty()) {
@@ -370,6 +464,11 @@ public class JekyllFiltersExtension {
         return new JsonObject().put("value", obj);
     }
 
+    /**
+     * Jekyll's "markdownify" filter: convert Markdown text to HTML.
+     * Returns a RawString to bypass Qute's auto-escaping.
+     * Usage in Qute: {=myString.markdownify}
+     */
     static RawString markdownify(String str) {
         if (str == null || str.isEmpty()) {
             return new RawString("");
@@ -377,6 +476,11 @@ public class JekyllFiltersExtension {
         return new RawString(str);
     }
 
+    /**
+     * Output a string without HTML escaping.
+     * Qute auto-escapes HTML in .html templates; this bypasses that for trusted content.
+     * Usage in Qute: {=myString.raw}
+     */
     static RawString raw(String str) {
         if (str == null) {
             return new RawString("");
@@ -395,7 +499,10 @@ public class JekyllFiltersExtension {
     public static class MutableMap {
         private final Map<String, Object> data = new HashMap<>();
 
-        // Returns empty RawString so {=_m.assign(...)} produces no visible output
+        /**
+         * Store a value under the given key (mirrors Liquid's assign).
+         * Returns an empty RawString so {=_m.assign(...)} produces no visible output.
+         */
         public RawString assign(String key, Object value) {
             data.put(key, value);
             return new RawString("");
@@ -406,7 +513,12 @@ public class JekyllFiltersExtension {
         }
     }
 
-    // Namespace form handles null base objects (instance extensions can't dispatch on null)
+    /**
+     * Split a string by delimiter, returning an iterable list.
+     * Uses namespace form so it can handle null base objects (instance extensions can't
+     * dispatch on null). Also returns List instead of String[] for Qute iteration.
+     * Usage in Qute: {str:split(myString, ",")}
+     */
     @TemplateExtension(namespace = "str")
     static List<String> split(String str, String delimiter) {
         if (str == null || str.isEmpty()) {
@@ -415,6 +527,10 @@ public class JekyllFiltersExtension {
         return Arrays.asList(str.split(Pattern.quote(delimiter)));
     }
 
+    /**
+     * Like split but returns RawStrings to prevent Qute auto-escaping of HTML content.
+     * Usage in Qute: {str:splitRaw(myString, ",")}
+     */
     @TemplateExtension(namespace = "str")
     static List<RawString> splitRaw(String str, String delimiter) {
         if (str == null || str.isEmpty()) {
@@ -425,7 +541,12 @@ public class JekyllFiltersExtension {
                 .toList();
     }
 
-    // Replaces Liquid split+trim+push loop (broken in Qute due to block-scoped {#let})
+    /**
+     * Split, trim each element, and filter out empty strings.
+     * Replaces the Liquid pattern: assign clean = "" | split: "" / for x in raw / push trimmed / endfor
+     * That pattern doesn't work in Qute because {#let} is block-scoped (push results are discarded).
+     * Usage in Qute: {str:splitTrimmed(myString, ",")}
+     */
     @TemplateExtension(namespace = "str")
     static List<String> splitTrimmed(String str, String delimiter) {
         if (str == null || str.isEmpty()) {

--- a/migration/src/test/java/io/quarkus/tools/migration/JekyllFiltersExtensionTest.java
+++ b/migration/src/test/java/io/quarkus/tools/migration/JekyllFiltersExtensionTest.java
@@ -2,6 +2,7 @@ package io.quarkus.tools.migration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -260,6 +261,124 @@ class JekyllFiltersExtensionTest {
     }
 
     record TagCount(String name, Long count) {
+    }
+
+    // -------------------------------------------------------------------------
+    // sort(JsonObject, String) — the new overload for data/authors.yaml style maps
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sortJsonObjectByProperty_returnsEntriesSortedByNamedField() {
+        JsonObject authors = new JsonObject()
+                .put("gsmet", new JsonObject().put("name", "Guillaume Smet"))
+                .put("ebernard", new JsonObject().put("name", "Emmanuel Bernard"))
+                .put("fnigro", new JsonObject().put("name", "Francesco Nigro"));
+
+        List<JekyllFiltersExtension.JsonEntry> sorted = JekyllFiltersExtension.sort(authors, "name");
+
+        assertEquals(3, sorted.size());
+        assertEquals("ebernard", sorted.get(0).first());
+        assertEquals("fnigro", sorted.get(1).first());
+        assertEquals("gsmet", sorted.get(2).first());
+    }
+
+    @Test
+    void sortJsonObjectByProperty_valuesArePreserved() {
+        JsonObject authors = new JsonObject()
+                .put("gsmet", new JsonObject().put("name", "Guillaume Smet").put("twitter", "gsmet_"))
+                .put("ebernard", new JsonObject().put("name", "Emmanuel Bernard").put("twitter", "Emmanuelbernard"));
+
+        List<JekyllFiltersExtension.JsonEntry> sorted = JekyllFiltersExtension.sort(authors, "name");
+
+        // first entry is Emmanuel Bernard — check the full value object is intact
+        JsonObject firstValue = (JsonObject) sorted.get(0).last();
+        assertEquals("Emmanuel Bernard", firstValue.getString("name"));
+        assertEquals("Emmanuelbernard", firstValue.getString("twitter"));
+    }
+
+    @Test
+    void sortJsonObjectByProperty_isCaseInsensitive() {
+        JsonObject data = new JsonObject()
+                .put("b", new JsonObject().put("name", "charlie"))
+                .put("a", new JsonObject().put("name", "Alice"))
+                .put("c", new JsonObject().put("name", "Bob"));
+
+        List<JekyllFiltersExtension.JsonEntry> sorted = JekyllFiltersExtension.sort(data, "name");
+
+        assertEquals("Alice", ((JsonObject) sorted.get(0).last()).getString("name"));
+        assertEquals("Bob", ((JsonObject) sorted.get(1).last()).getString("name"));
+        assertEquals("charlie", ((JsonObject) sorted.get(2).last()).getString("name"));
+    }
+
+    @Test
+    void sortJsonObjectByProperty_nullsAreSortedLast() {
+        JsonObject data = new JsonObject()
+                .put("b", new JsonObject().put("name", "Zara"))
+                .put("a", new JsonObject()) // no "name" field
+                .put("c", new JsonObject().put("name", "Aaron"));
+
+        List<JekyllFiltersExtension.JsonEntry> sorted = JekyllFiltersExtension.sort(data, "name");
+
+        assertEquals("Aaron", ((JsonObject) sorted.get(0).last()).getString("name"));
+        assertEquals("Zara", ((JsonObject) sorted.get(1).last()).getString("name"));
+        // entry without "name" is sorted last
+        assertNotNull(sorted.get(2));
+        assertTrue(((JsonObject) sorted.get(2).last()).fieldNames().isEmpty()
+                || ((JsonObject) sorted.get(2).last()).getString("name") == null);
+    }
+
+    @Test
+    void sortJsonObjectByProperty_emptyObjectReturnsEmptyList() {
+        List<JekyllFiltersExtension.JsonEntry> sorted = JekyllFiltersExtension.sort(new JsonObject(), "name");
+        assertTrue(sorted.isEmpty());
+    }
+
+    @Test
+    void sortJsonObjectByProperty_nullObjectReturnsEmptyList() {
+        List<JekyllFiltersExtension.JsonEntry> sorted = JekyllFiltersExtension.sort((JsonObject) null, "name");
+        assertTrue(sorted.isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // sort(JsonArray, String) — existing overload, regression coverage
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sortJsonArrayByProperty_returnsArraySortedByNamedField() {
+        JsonArray tags = new JsonArray()
+                .add(new JsonObject().put("name", "quarkus").put("count", 10))
+                .add(new JsonObject().put("name", "java").put("count", 5))
+                .add(new JsonObject().put("name", "graalvm").put("count", 3));
+
+        JsonArray sorted = JekyllFiltersExtension.sort(tags, "name");
+
+        assertEquals("graalvm", sorted.getJsonObject(0).getString("name"));
+        assertEquals("java", sorted.getJsonObject(1).getString("name"));
+        assertEquals("quarkus", sorted.getJsonObject(2).getString("name"));
+    }
+
+    @Test
+    void sortJsonArrayByProperty_emptyArrayReturnsEmptyArray() {
+        JsonArray sorted = JekyllFiltersExtension.sort(new JsonArray(), "name");
+        assertTrue(sorted.isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // sort(List, String) — existing overload, regression coverage
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sortListByProperty_returnsListSortedByNamedField() {
+        var items = List.of(
+                new JsonObject().put("name", "Zoe"),
+                new JsonObject().put("name", "Alice"),
+                new JsonObject().put("name", "Mike"));
+
+        List<?> sorted = JekyllFiltersExtension.sort(items, "name");
+
+        assertEquals("Alice", ((JsonObject) sorted.get(0)).getString("name"));
+        assertEquals("Mike", ((JsonObject) sorted.get(1)).getString("name"));
+        assertEquals("Zoe", ((JsonObject) sorted.get(2)).getString("name"));
     }
 
     @Test


### PR DESCRIPTION
Retroactively fixing a bug I discovered post-conversion. The methods in the jekyll template are missing a sort in some scenarios.