### PR TITLE
Converter: Ensure string literals have quotes when used as arguments

### DIFF
--- a/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
+++ b/migration/src/main/java/io/quarkus/tools/LiquidToQuteConverter.java
@@ -409,7 +409,7 @@ public class LiquidToQuteConverter {
             StringBuilder fwaSb = new StringBuilder();
 
             while (fwaMatcher.find()) {
-                String arg = fwaMatcher.group(1).trim();
+                String arg = normalizeFilterArg(fwaMatcher.group(1).trim());
                 fwaMatcher.appendReplacement(fwaSb, "." + quteMethod + "(" + Matcher.quoteReplacement(arg) + ")");
             }
             fwaMatcher.appendTail(fwaSb);
@@ -460,6 +460,19 @@ public class LiquidToQuteConverter {
         }
 
         return content;
+    }
+
+    /**
+     * Normalizes a Liquid filter argument for use in a Qute method call.
+     * Liquid uses double-quoted string literals (e.g. "name"), but Qute requires
+     * single-quoted string literals (e.g. 'name'). Bare identifiers (variable
+     * references) are passed through unchanged.
+     */
+    private String normalizeFilterArg(String arg) {
+        if (arg.startsWith("\"") && arg.endsWith("\"") && arg.length() >= 2) {
+            return "'" + arg.substring(1, arg.length() - 1) + "'";
+        }
+        return arg;
     }
 
     private String convertWhereExpFilter(String content) {

--- a/migration/src/test/java/io/quarkus/tools/LiquidToQuteConverterTest.java
+++ b/migration/src/test/java/io/quarkus/tools/LiquidToQuteConverterTest.java
@@ -1495,6 +1495,31 @@ class LiquidToQuteConverterTest {
                 "group_by | sort should chain as .groupBy(arg).sort(arg), not nest sort inside groupBy arg: " + result);
         assertFalse(result.contains("group_by.sort("),
                 "sort should not be nested inside the groupBy argument: " + result);
+        assertTrue(result.contains(".sort('name')"),
+                "sort: \"name\" (double-quoted) must convert to .sort('name') with single quotes, not .sort(\"name\"): "
+                        + result);
+    }
+
+    @Test
+    void testSortFilterDoubleQuotedArgProducesSingleQuotedString() {
+        // Liquid: | sort: "name" uses a double-quoted string literal.
+        // Qute requires single-quoted string literals, so the output must be .sort('name').
+        String input = "{% assign sorted = authors | sort: \"name\" %}";
+        String result = converter.convert(input);
+        assertTrue(result.contains(".sort('name')"),
+                "sort: \"name\" should produce .sort('name') with single quotes, got: " + result);
+        assertFalse(result.contains(".sort(\"name\")"),
+                "sort: \"name\" must not produce .sort(\"name\") — Qute requires single-quoted strings: " + result);
+    }
+
+    @Test
+    void testSortFilterSingleQuotedArgPreserved() {
+        // Liquid: | sort: 'title' — already single-quoted; must stay as .sort('title').
+        String input = "{#let values=items.sort('title')}{/let}";
+        // This is already-converted Qute; pass it through to verify it is not double-converted.
+        String result = converter.convert(input);
+        assertTrue(result.contains(".sort('title')"),
+                "Already-single-quoted sort arg must not be double-converted: " + result);
     }
 
     @Test


### PR DESCRIPTION
Another converter bug. We were generating some templates like `authors.sort(name)`. It needs to be `authors.sort('name')`.