### PR TITLE
fix(roq-editor): do not prefix absolute image paths in visual editor

### DIFF
--- a/roq-editor/deployment/src/main/resources/dev-ui/components/visual-editor/extensions/image.js
+++ b/roq-editor/deployment/src/main/resources/dev-ui/components/visual-editor/extensions/image.js
@@ -14,16 +14,25 @@ function isTemplatePlaceholder(src) {
     return src.includes('{') && src.includes('}');
 }
 
+function isAbsoluteSrc(src) {
+    if (typeof src !== 'string') {
+        return false;
+    }
+    return src.startsWith('/') || src.includes('://');
+}
+
 function resolveSrc (options, src) {
     if (isTemplatePlaceholder(src)) {
         return  'assets/placeholder-image.svg';
-    } else {
-        const prefix =
-            typeof options.urlPrefix === 'function'
-                ? options.urlPrefix()
-                : options.urlPrefix;
-        return prefix + src;
     }
+    if (isAbsoluteSrc(src)) {
+        return src;
+    }
+    const prefix =
+        typeof options.urlPrefix === 'function'
+            ? options.urlPrefix()
+            : options.urlPrefix;
+    return prefix + src;
 }
 
 


### PR DESCRIPTION
## Summary
- Skip `urlPrefix` concatenation in the TipTap `RoqImage` extension when an image `src` is already absolute (root path or full URL)
- Prevents broken editor URLs such as `/2022/07/13/post//assets/images/foo.png`

Fixes #1232

## Problem
The visual editor prepends the page preview URL to every image source except Qute template placeholders. Root-absolute markdown paths like `/assets/images/foo.png` therefore become invalid in the WYSIWYG tab, even though they work in the built site and preview iframe.

## Solution
Add `isAbsoluteSrc()` and return those sources unchanged from `resolveSrc()`.

Relative paths (e.g. co-located `design.png`) continue to use `urlPrefix` as before.

## Test plan
- [ ] Open a post in the Roq editor with `![](/assets/images/example.png)` and confirm the image loads in the visual editor
- [ ] Confirm co-located relative images (e.g. `![](design.png)`) still resolve under the page URL
- [ ] Confirm Qute placeholders (e.g. `{=page.image('foo.png')}`) still show the placeholder image
- [ ] Confirm full URLs (`https://...`) are unchanged